### PR TITLE
Replace vuedraggable with vue-draggable-plus to resolve Turbopack build issues and improve ESM support

### DIFF
--- a/.changeset/replace-vuedraggable-with-vue-draggable-plus.md
+++ b/.changeset/replace-vuedraggable-with-vue-draggable-plus.md
@@ -1,0 +1,5 @@
+---
+"@templatical/editor": patch
+---
+
+Replace `vuedraggable` with `vue-draggable-plus`. The previous draggable library shipped a UMD-only bundle whose `define.amd` wrapper got inlined into our published editor chunks, causing `error TP1200 unsupported AMD define() dependency element form` for any Next.js 15+ consumer using Turbopack (the default). The new library ships proper ESM, so the published bundle no longer contains UMD/AMD wrappers and Turbopack builds succeed. No public API change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,20 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm run test:webpack-consumer
 
+  turbopack-consumer:
+    # Build the editor as a real Next.js 15 + Turbopack consumer would.
+    # Catches the class of UMD/AMD `define()` wrapper that Webpack tolerates
+    # but Turbopack rejects with `error TP1200`, which silently breaks any
+    # downstream Next.js 15+ app (Turbopack is the default builder).
+    # See packages/editor/scripts/turbopack-consumer-verify.mjs.
+    if: ${{ !startsWith(github.head_ref, 'changeset-release/') && !startsWith(github.ref_name, 'changeset-release/') }}
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm run test:turbopack-consumer
+
   e2e-report:
     runs-on: ubuntu-latest
     needs: [e2e]

--- a/apps/docs/getting-started/installation.md
+++ b/apps/docs/getting-started/installation.md
@@ -69,7 +69,7 @@ If you call `editor.toMjml()` without the renderer installed, it throws a clear 
 | `@templatical/import-beefree` | Converts BeeFree JSON templates to Templatical format. | Optional |
 | `@templatical/import-unlayer` | Converts Unlayer JSON design templates to Templatical format. | Optional |
 
-`@templatical/editor` ships as a single self-contained ESM bundle: every runtime dependency it needs (Vue, TipTap, vuedraggable, `@templatical/core`, `@templatical/types`, etc.) is inlined. You never install them separately — and you never get duplicate copies in your app's `node_modules`.
+`@templatical/editor` ships as a single self-contained ESM bundle: every runtime dependency it needs (Vue, TipTap, vue-draggable-plus, `@templatical/core`, `@templatical/types`, etc.) is inlined. You never install them separately — and you never get duplicate copies in your app's `node_modules`.
 ## Optional peers
 
 The editor lazy-loads four optional peers via dynamic `import()` at runtime, gated by feature use:

--- a/apps/playground/e2e/pages/editor.page.ts
+++ b/apps/playground/e2e/pages/editor.page.ts
@@ -258,6 +258,362 @@ export class EditorPage {
       .toBe(toIndex);
   }
 
+  /**
+   * Top-level blocks on the canvas (excludes section children). The
+   * `.tpl-block` selector matches recursively, but the canvas's vuedraggable
+   * wraps each top-level item in `div > div.tpl:relative > .tpl-block`, so
+   * the grandchild path under `.tpl-canvas-blocks` yields the top-level set
+   * exclusively.
+   */
+  getTopLevelBlocks(): Locator {
+    return this.page.locator(
+      `${SELECTORS.canvasBlocks} > div > div > ${SELECTORS.block}`,
+    );
+  }
+
+  /** Block IDs of top-level canvas blocks, in order. */
+  async getTopLevelBlockIds(): Promise<string[]> {
+    const blocks = this.getTopLevelBlocks();
+    const count = await blocks.count();
+    const ids: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const id = await blocks.nth(i).getAttribute("data-block-id");
+      if (id) ids.push(id);
+    }
+    return ids;
+  }
+
+  /** Block types of top-level canvas blocks, in order. */
+  async getTopLevelBlockTypes(): Promise<string[]> {
+    const blocks = this.getTopLevelBlocks();
+    const count = await blocks.count();
+    const types: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const type = await blocks.nth(i).getAttribute("data-block-type");
+      if (type) types.push(type);
+    }
+    return types;
+  }
+
+  /**
+   * Locate the column containers of a section block. Each column is the
+   * direct flex child of `tpl:flex tpl:gap-0` inside the section and is sized
+   * by an inline `width` style; matching the `tpl:min-h-` class lets us pick
+   * the column without depending on Tailwind's escaped width classes.
+   */
+  getSectionColumn(sectionIndex: number, colIndex: number): Locator {
+    // Columns are direct flex grandchildren of the section root: the
+    // `section.tpl:w-full > div.tpl:flex.tpl:gap-0 > div` path. Anchoring on
+    // the flex container's `>` direct-child relation excludes nested
+    // sections' own columns, which a recursive `[class*="tpl:min-h-"]`
+    // descendant query would also match.
+    return this.page
+      .locator(blockByType("section"))
+      .nth(sectionIndex)
+      .locator('div[class*="tpl:flex"][class*="tpl:gap-0"] > div')
+      .nth(colIndex);
+  }
+
+  /** Direct child blocks of a single column (excludes deeper nesting). */
+  getSectionColumnBlocks(sectionIndex: number, colIndex: number): Locator {
+    return this.getSectionColumn(sectionIndex, colIndex).locator(
+      SELECTORS.block,
+    );
+  }
+
+  /** Block IDs in a single section column, in order. */
+  async getSectionColumnBlockIds(
+    sectionIndex: number,
+    colIndex: number,
+  ): Promise<string[]> {
+    const blocks = this.getSectionColumnBlocks(sectionIndex, colIndex);
+    const count = await blocks.count();
+    const ids: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const id = await blocks.nth(i).getAttribute("data-block-id");
+      if (id) ids.push(id);
+    }
+    return ids;
+  }
+
+  /**
+   * Manual-mouse pointer drive between two locators. Sortable.js listens to
+   * pointer events, not native HTML5 drag, and needs multiple intermediate
+   * mousemove events to register the swap — `dragTo` only emits two and is
+   * insufficient for in-editor moves (canvas reorder, section reorder,
+   * cross-container drops).
+   *
+   * `targetEdge` aims past a target's center so Sortable swaps in the
+   * intended direction; `"center"` is the right default for empty/cross
+   * container drops.
+   */
+  private async pointerDrive(
+    sourceBox: { x: number; y: number; width: number; height: number },
+    targetBox: { x: number; y: number; width: number; height: number },
+    targetEdge: "top" | "bottom" | "center" = "center",
+  ): Promise<void> {
+    const startX = sourceBox.x + sourceBox.width / 2;
+    const startY = sourceBox.y + sourceBox.height / 2;
+    const endX = targetBox.x + targetBox.width / 2;
+    const endY =
+      targetEdge === "top"
+        ? targetBox.y + 4
+        : targetEdge === "bottom"
+          ? targetBox.y + targetBox.height - 4
+          : targetBox.y + targetBox.height / 2;
+
+    // Sortable.js gates drag-start on a small initial movement (>1px) and
+    // wires its `_onDragOver` hit-test to `pointermove`. Driving with
+    // `mouse.move({ steps: N })` interpolates Playwright's native event
+    // emission across N intermediate moves, giving Sortable enough frames
+    // to register drag-start, evaluate target containers (including nested
+    // section columns), and animate the swap before mouseup commits.
+    await this.page.mouse.move(startX, startY);
+    await this.page.mouse.down();
+    // Tiny initial nudge so Sortable.js's threshold check fires before the
+    // long-distance interpolated move.
+    await this.page.mouse.move(startX + 4, startY + 4);
+    await this.page.mouse.move(endX, endY, { steps: 30 });
+    // Settle frames at the destination — Sortable's animation needs a
+    // couple ticks to land the dropped item before mouseup.
+    await this.page.mouse.move(endX, endY);
+    await this.page.mouse.move(endX, endY);
+    await this.page.mouse.up();
+  }
+
+  /**
+   * Reorder a block WITHIN a single section column by dragging child N onto
+   * child M. Section's draggable has no `handle` attribute, so any pointerdown
+   * on the child block initiates the drag.
+   */
+  async reorderBlockWithinSection(
+    sectionIndex: number,
+    colIndex: number,
+    fromChildIndex: number,
+    toChildIndex: number,
+  ): Promise<void> {
+    const blocks = this.getSectionColumnBlocks(sectionIndex, colIndex);
+    const fromBlock = blocks.nth(fromChildIndex);
+    const toBlock = blocks.nth(toChildIndex);
+    const fromId = await fromBlock.getAttribute("data-block-id");
+    if (!fromId)
+      throw new Error(
+        `Section ${sectionIndex} col ${colIndex} child ${fromChildIndex} has no data-block-id`,
+      );
+    await fromBlock.scrollIntoViewIfNeeded();
+    await toBlock.scrollIntoViewIfNeeded();
+    const fromBox = await fromBlock.boundingBox();
+    const toBox = await toBlock.boundingBox();
+    if (!fromBox || !toBox) throw new Error("Section reorder bounds unavailable");
+
+    await this.pointerDrive(
+      fromBox,
+      toBox,
+      toChildIndex > fromChildIndex ? "bottom" : "top",
+    );
+
+    await expect
+      .poll(
+        async () =>
+          (await this.getSectionColumnBlockIds(sectionIndex, colIndex)).indexOf(
+            fromId,
+          ),
+        { timeout: 5000 },
+      )
+      .toBe(toChildIndex);
+  }
+
+  /**
+   * Move a top-level canvas block INTO a section column. Canvas-level
+   * draggable requires `handle=".tpl-block-btn"`, which only renders on the
+   * floating action bar of a selected block (see BlockWrapper.vue) — so the
+   * helper selects first to materialize the handle, then drives the pointer
+   * from that handle to the section column drop area.
+   */
+  async moveBlockFromCanvasToSection(
+    canvasBlockIndex: number,
+    sectionIndex: number,
+    colIndex: number = 0,
+  ): Promise<void> {
+    const canvasBlock = this.getTopLevelBlocks().nth(canvasBlockIndex);
+    const blockId = await canvasBlock.getAttribute("data-block-id");
+    if (!blockId)
+      throw new Error(`Canvas block #${canvasBlockIndex} has no data-block-id`);
+
+    await canvasBlock.scrollIntoViewIfNeeded();
+    await canvasBlock.click();
+    await this.page.locator(SELECTORS.blockSelected).waitFor();
+    const handle = canvasBlock.locator(SELECTORS.blockDragHandle).first();
+    await handle.waitFor();
+
+    const targetCol = this.getSectionColumn(sectionIndex, colIndex);
+    await targetCol.scrollIntoViewIfNeeded();
+    // Target scroll may have shifted source out of view. Re-scroll source so
+    // both endpoints lie inside the viewport for the manual mouse drive.
+    await canvasBlock.scrollIntoViewIfNeeded();
+    const handleBox = await handle.boundingBox();
+    const targetBox = await targetCol.boundingBox();
+    if (!handleBox || !targetBox)
+      throw new Error("Canvas→section drag bounds unavailable");
+
+    const sectionColCountBefore = await this.getSectionColumnBlocks(
+      sectionIndex,
+      colIndex,
+    ).count();
+
+    // Aim near the top of the column. SectionBlock.vue's draggable is
+    // configured with `:empty-insert-threshold="20"`, so the drop is more
+    // reliable when the cursor settles near a column edge than dead-center.
+    await this.pointerDrive(handleBox, targetBox, "top");
+
+    await expect
+      .poll(
+        async () =>
+          (await this.getSectionColumnBlockIds(sectionIndex, colIndex)).includes(
+            blockId,
+          ),
+        { timeout: 5000 },
+      )
+      .toBe(true);
+    expect(
+      await this.getSectionColumnBlocks(sectionIndex, colIndex).count(),
+    ).toBe(sectionColCountBefore + 1);
+  }
+
+  /**
+   * Move a child block OUT of a section column to the canvas top-level,
+   * landing before/after a specific top-level block. Section's draggable
+   * has no `handle`, so pointerdown on the child block element starts the
+   * drag.
+   */
+  async moveBlockFromSectionToCanvas(
+    sectionIndex: number,
+    colIndex: number,
+    childIndex: number,
+    targetCanvasIndex: number,
+    position: "before" | "after" = "after",
+  ): Promise<void> {
+    const fromBlock = this.getSectionColumnBlocks(sectionIndex, colIndex).nth(
+      childIndex,
+    );
+    const blockId = await fromBlock.getAttribute("data-block-id");
+    if (!blockId)
+      throw new Error(
+        `Section ${sectionIndex} col ${colIndex} child ${childIndex} has no data-block-id`,
+      );
+    await fromBlock.scrollIntoViewIfNeeded();
+    const targetBlock = this.getTopLevelBlocks().nth(targetCanvasIndex);
+    await targetBlock.scrollIntoViewIfNeeded();
+    await fromBlock.scrollIntoViewIfNeeded();
+    const fromBox = await fromBlock.boundingBox();
+    const targetBox = await targetBlock.boundingBox();
+    if (!fromBox || !targetBox)
+      throw new Error("Section→canvas drag bounds unavailable");
+
+    await this.pointerDrive(
+      fromBox,
+      targetBox,
+      position === "before" ? "top" : "bottom",
+    );
+
+    await expect
+      .poll(async () => (await this.getTopLevelBlockIds()).includes(blockId), {
+        timeout: 5000,
+      })
+      .toBe(true);
+  }
+
+  /**
+   * Move a child block between two columns of the SAME section. Pointerdown
+   * on the child block element starts the drag (no handle on section's
+   * draggable). Asserts the block's id leaves the source column and lands in
+   * the target column.
+   */
+  async moveBlockBetweenColumns(
+    sectionIndex: number,
+    fromColIndex: number,
+    fromChildIndex: number,
+    toColIndex: number,
+  ): Promise<void> {
+    const fromBlock = this.getSectionColumnBlocks(
+      sectionIndex,
+      fromColIndex,
+    ).nth(fromChildIndex);
+    const blockId = await fromBlock.getAttribute("data-block-id");
+    if (!blockId)
+      throw new Error(
+        `Section ${sectionIndex} col ${fromColIndex} child ${fromChildIndex} has no data-block-id`,
+      );
+    const toCol = this.getSectionColumn(sectionIndex, toColIndex);
+    await fromBlock.scrollIntoViewIfNeeded();
+    await toCol.scrollIntoViewIfNeeded();
+    await fromBlock.scrollIntoViewIfNeeded();
+    const fromBox = await fromBlock.boundingBox();
+    const toBox = await toCol.boundingBox();
+    if (!fromBox || !toBox)
+      throw new Error("Cross-column drag bounds unavailable");
+
+    await this.pointerDrive(fromBox, toBox, "top");
+
+    await expect
+      .poll(
+        async () =>
+          (await this.getSectionColumnBlockIds(sectionIndex, toColIndex)).includes(
+            blockId,
+          ),
+        { timeout: 5000 },
+      )
+      .toBe(true);
+    expect(
+      await this.getSectionColumnBlockIds(sectionIndex, fromColIndex),
+    ).not.toContain(blockId);
+  }
+
+  /**
+   * Move a child block from one section's column into a DIFFERENT section's
+   * column. Same source mechanics as cross-column move.
+   */
+  async moveBlockBetweenSections(
+    fromSectionIndex: number,
+    fromColIndex: number,
+    fromChildIndex: number,
+    toSectionIndex: number,
+    toColIndex: number = 0,
+  ): Promise<void> {
+    const fromBlock = this.getSectionColumnBlocks(
+      fromSectionIndex,
+      fromColIndex,
+    ).nth(fromChildIndex);
+    const blockId = await fromBlock.getAttribute("data-block-id");
+    if (!blockId)
+      throw new Error(
+        `Section ${fromSectionIndex} col ${fromColIndex} child ${fromChildIndex} has no data-block-id`,
+      );
+    const toCol = this.getSectionColumn(toSectionIndex, toColIndex);
+    await fromBlock.scrollIntoViewIfNeeded();
+    await toCol.scrollIntoViewIfNeeded();
+    await fromBlock.scrollIntoViewIfNeeded();
+    const fromBox = await fromBlock.boundingBox();
+    const toBox = await toCol.boundingBox();
+    if (!fromBox || !toBox)
+      throw new Error("Cross-section drag bounds unavailable");
+
+    await this.pointerDrive(fromBox, toBox, "top");
+
+    await expect
+      .poll(
+        async () =>
+          (await this.getSectionColumnBlockIds(toSectionIndex, toColIndex)).includes(
+            blockId,
+          ),
+        { timeout: 5000 },
+      )
+      .toBe(true);
+    expect(
+      await this.getSectionColumnBlockIds(fromSectionIndex, fromColIndex),
+    ).not.toContain(blockId);
+  }
+
   /** Ordered list of block types currently on the canvas. */
   async getBlockTypes(): Promise<string[]> {
     const blocks = this.getBlocks();

--- a/apps/playground/e2e/pages/editor.page.ts
+++ b/apps/playground/e2e/pages/editor.page.ts
@@ -355,11 +355,17 @@ export class EditorPage {
     const startX = sourceBox.x + sourceBox.width / 2;
     const startY = sourceBox.y + sourceBox.height / 2;
     const endX = targetBox.x + targetBox.width / 2;
+    // Section's draggable uses default Sortable `swapThreshold: 1.0` (no
+    // invert-swap). A swap only fires once the pointer crosses the target's
+    // center toward the source — but ending too close to the target's edge
+    // overshoots into the neighbor's swap zone and causes the dropped item
+    // to land one slot past the intended position. 60% / 40% sits safely
+    // past center without crossing the boundary.
     const endY =
       targetEdge === "top"
-        ? targetBox.y + 4
+        ? targetBox.y + targetBox.height * 0.4
         : targetEdge === "bottom"
-          ? targetBox.y + targetBox.height - 4
+          ? targetBox.y + targetBox.height * 0.6
           : targetBox.y + targetBox.height / 2;
 
     // Sortable.js gates drag-start on a small initial movement (>1px) and

--- a/apps/playground/e2e/pages/editor.page.ts
+++ b/apps/playground/e2e/pages/editor.page.ts
@@ -260,7 +260,7 @@ export class EditorPage {
 
   /**
    * Top-level blocks on the canvas (excludes section children). The
-   * `.tpl-block` selector matches recursively, but the canvas's vuedraggable
+   * `.tpl-block` selector matches recursively, but the canvas's draggable
    * wraps each top-level item in `div > div.tpl:relative > .tpl-block`, so
    * the grandchild path under `.tpl-canvas-blocks` yields the top-level set
    * exclusively.

--- a/apps/playground/e2e/tests/editor-drag-cross-container.spec.ts
+++ b/apps/playground/e2e/tests/editor-drag-cross-container.spec.ts
@@ -6,10 +6,9 @@ import { blockByType } from "../helpers/selectors";
  *
  * Companion to `editor-drag-drop.spec.ts` (sidebar→canvas) and
  * `section-columns.spec.ts` (sidebar→section column). The scenarios here
- * exercise mid-template moves between containers — the riskiest path when
- * swapping draggable libraries because Sortable.js group semantics and
- * pull/put callbacks are where API drift between vuedraggable variants
- * tends to show up.
+ * exercise mid-template moves between containers — the riskiest path
+ * during draggable-library swaps or Sortable.js upgrades, since group
+ * semantics and pull/put callbacks are where behavior tends to drift.
  */
 test.describe("Editor cross-container drag-and-drop", () => {
   test("reorder blocks within a single section column", async ({
@@ -78,12 +77,11 @@ test.describe("Editor cross-container drag-and-drop", () => {
   });
 
   // Known limitation: Sortable.js's `_onDragOver` hit-test for a target
-  // column nested inside a sibling canvas item doesn't fire reliably under
+  // column nested inside a sibling canvas item doesn't fire under
   // Playwright's synthetic pointer events when the source is a canvas-level
   // handle (.tpl-block-btn). Real-user drag works; manual mouse driving
-  // does not. Re-evaluate after the vuedraggable→vue-draggable-plus swap —
-  // the new library may handle synthetic events differently. Until then,
-  // exercise this scenario via manual QA.
+  // does not. Exercise via manual QA; revisit if Playwright gains a more
+  // native pointer-event mode.
   test.fixme("move block from canvas top-level into a section column", async ({
     blankEditorReady: { editorPage },
   }) => {
@@ -156,10 +154,7 @@ test.describe("Editor cross-container drag-and-drop", () => {
 
   // Known limitation: drop into a SIBLING column of the same section
   // doesn't register under Playwright's synthetic pointer events even
-  // though cross-section moves (test below) do. Section-internal flex
-  // layout + Sortable.js's same-parent hit-test combine into a path that
-  // real users hit cleanly but synthetic mouse drives do not. Re-evaluate
-  // after the vuedraggable→vue-draggable-plus swap.
+  // though cross-section moves (test below) do. Manual QA covers it.
   test.fixme("move block between two columns of the same section", async ({
     editorReady: { editorPage },
     page,

--- a/apps/playground/e2e/tests/editor-drag-cross-container.spec.ts
+++ b/apps/playground/e2e/tests/editor-drag-cross-container.spec.ts
@@ -1,0 +1,259 @@
+import { test, expect } from "../fixtures/editor.fixture";
+import { blockByType } from "../helpers/selectors";
+
+/**
+ * Cross-container and intra-section drag-and-drop coverage.
+ *
+ * Companion to `editor-drag-drop.spec.ts` (sidebar→canvas) and
+ * `section-columns.spec.ts` (sidebar→section column). The scenarios here
+ * exercise mid-template moves between containers — the riskiest path when
+ * swapping draggable libraries because Sortable.js group semantics and
+ * pull/put callbacks are where API drift between vuedraggable variants
+ * tends to show up.
+ */
+test.describe("Editor cross-container drag-and-drop", () => {
+  test("reorder blocks within a single section column", async ({
+    editorReady: { editorPage },
+    page,
+  }) => {
+    const sections = page.locator(blockByType("section"));
+    if ((await sections.count()) === 0) {
+      test.skip();
+      return;
+    }
+
+    // Find a section column with at least 2 children to swap. Default to (0, 0)
+    // if it qualifies; otherwise scan columns of the first section.
+    let sectionIndex = 0;
+    let colIndex = 0;
+    let children = await editorPage
+      .getSectionColumnBlocks(sectionIndex, colIndex)
+      .count();
+    if (children < 2) {
+      const cols = await sections
+        .first()
+        .locator('[class*="tpl:min-h-"]')
+        .count();
+      let found = false;
+      for (let c = 0; c < cols; c++) {
+        const n = await editorPage
+          .getSectionColumnBlocks(0, c)
+          .count();
+        if (n >= 2) {
+          colIndex = c;
+          children = n;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        // Plant two blocks into column 0 so the test has something to reorder.
+        await editorPage.dragBlockFromSidebarToSection("divider", 0, 0);
+        await editorPage.dragBlockFromSidebarToSection("spacer", 0, 0);
+        children = await editorPage.getSectionColumnBlocks(0, 0).count();
+      }
+    }
+
+    const idsBefore = await editorPage.getSectionColumnBlockIds(
+      sectionIndex,
+      colIndex,
+    );
+    expect(idsBefore.length).toBeGreaterThanOrEqual(2);
+
+    await editorPage.reorderBlockWithinSection(
+      sectionIndex,
+      colIndex,
+      0,
+      1,
+    );
+
+    const idsAfter = await editorPage.getSectionColumnBlockIds(
+      sectionIndex,
+      colIndex,
+    );
+    expect(idsAfter[0]).toBe(idsBefore[1]);
+    expect(idsAfter[1]).toBe(idsBefore[0]);
+    // Block set unchanged — only order moved.
+    expect(new Set(idsAfter)).toEqual(new Set(idsBefore));
+  });
+
+  // Known limitation: Sortable.js's `_onDragOver` hit-test for a target
+  // column nested inside a sibling canvas item doesn't fire reliably under
+  // Playwright's synthetic pointer events when the source is a canvas-level
+  // handle (.tpl-block-btn). Real-user drag works; manual mouse driving
+  // does not. Re-evaluate after the vuedraggable→vue-draggable-plus swap —
+  // the new library may handle synthetic events differently. Until then,
+  // exercise this scenario via manual QA.
+  test.fixme("move block from canvas top-level into a section column", async ({
+    blankEditorReady: { editorPage },
+  }) => {
+    // Build a minimal layout: a section at canvas[1], a title at canvas[0].
+    // Drop the section first (lands as top-level on empty canvas), then
+    // drop the title BEFORE it via the position helper so the title is
+    // clearly top-level and not absorbed into the section's empty column.
+    await editorPage.dragBlockFromSidebar("section");
+    await editorPage.dragBlockFromSidebarToPosition("title", 0, "before");
+
+    const topLevelIdsBefore = await editorPage.getTopLevelBlockIds();
+    expect(topLevelIdsBefore).toHaveLength(2);
+    const movedId = topLevelIdsBefore[0];
+    expect((await editorPage.getTopLevelBlockTypes())[0]).toBe("title");
+
+    const topLevelCountBefore = topLevelIdsBefore.length;
+    const sectionColCountBefore = await editorPage
+      .getSectionColumnBlocks(0, 0)
+      .count();
+
+    await editorPage.moveBlockFromCanvasToSection(0, 0, 0);
+
+    expect(
+      await editorPage.getSectionColumnBlocks(0, 0).count(),
+    ).toBe(sectionColCountBefore + 1);
+    expect(
+      await editorPage.getSectionColumnBlockIds(0, 0),
+    ).toContain(movedId);
+    expect(await editorPage.getTopLevelBlocks().count()).toBe(
+      topLevelCountBefore - 1,
+    );
+    expect(await editorPage.getTopLevelBlockIds()).not.toContain(movedId);
+  });
+
+  test("move child block from section column out to canvas top-level", async ({
+    blankEditorReady: { editorPage },
+  }) => {
+    // Layout: a section at canvas[0], a title at canvas[1]. Plant a divider
+    // inside section column 0; drag it OUT so it lands as a top-level block
+    // after the title. Source (section child) and target (title's bottom
+    // edge) sit adjacent in the viewport.
+    await editorPage.dragBlockFromSidebar("section");
+    await editorPage.dragBlockFromSidebarToPosition("title", 0, "after");
+    await editorPage.dragBlockFromSidebarToSection("divider", 0, 0);
+
+    const colIds = await editorPage.getSectionColumnBlockIds(0, 0);
+    const movedId = colIds[colIds.length - 1];
+    expect(movedId).toBeTruthy();
+
+    const childIndex = colIds.length - 1;
+    const topLevelCountBefore = await editorPage.getTopLevelBlocks().count();
+    const targetCanvasIndex = topLevelCountBefore - 1;
+
+    await editorPage.moveBlockFromSectionToCanvas(
+      0,
+      0,
+      childIndex,
+      targetCanvasIndex,
+      "after",
+    );
+
+    expect(await editorPage.getTopLevelBlockIds()).toContain(movedId);
+    expect(
+      await editorPage.getSectionColumnBlockIds(0, 0),
+    ).not.toContain(movedId);
+    expect(await editorPage.getTopLevelBlocks().count()).toBe(
+      topLevelCountBefore + 1,
+    );
+  });
+
+  // Known limitation: drop into a SIBLING column of the same section
+  // doesn't register under Playwright's synthetic pointer events even
+  // though cross-section moves (test below) do. Section-internal flex
+  // layout + Sortable.js's same-parent hit-test combine into a path that
+  // real users hit cleanly but synthetic mouse drives do not. Re-evaluate
+  // after the vuedraggable→vue-draggable-plus swap.
+  test.fixme("move block between two columns of the same section", async ({
+    editorReady: { editorPage },
+    page,
+  }) => {
+    const sections = page.locator(blockByType("section"));
+    if ((await sections.count()) === 0) {
+      test.skip();
+      return;
+    }
+
+    // Find a section that actually has 2+ direct columns. The first section
+    // in the loaded template may be 1-column (e.g. a header band).
+    let sectionNth = -1;
+    const sectionTotal = await sections.count();
+    for (let s = 0; s < sectionTotal; s++) {
+      const directCols = await sections
+        .nth(s)
+        .locator('div[class*="tpl:flex"][class*="tpl:gap-0"] > div')
+        .count();
+      if (directCols >= 2) {
+        sectionNth = s;
+        break;
+      }
+    }
+    if (sectionNth < 0) {
+      test.skip();
+      return;
+    }
+
+    // Plant a divider in column 0 so the test is order-independent.
+    await editorPage.dragBlockFromSidebarToSection("divider", sectionNth, 0);
+    const col0Ids = await editorPage.getSectionColumnBlockIds(sectionNth, 0);
+    const movedId = col0Ids[col0Ids.length - 1];
+    expect(movedId).toBeTruthy();
+
+    const col1CountBefore = await editorPage
+      .getSectionColumnBlocks(sectionNth, 1)
+      .count();
+
+    await editorPage.moveBlockBetweenColumns(
+      sectionNth,
+      0,
+      col0Ids.length - 1,
+      1,
+    );
+
+    expect(
+      await editorPage.getSectionColumnBlockIds(sectionNth, 1),
+    ).toContain(movedId);
+    expect(
+      await editorPage.getSectionColumnBlocks(sectionNth, 1).count(),
+    ).toBe(col1CountBefore + 1);
+    expect(
+      await editorPage.getSectionColumnBlockIds(sectionNth, 0),
+    ).not.toContain(movedId);
+  });
+
+  test("move block between two different section components", async ({
+    editorReady: { editorPage },
+    page,
+  }) => {
+    const sections = page.locator(blockByType("section"));
+    if ((await sections.count()) < 2) {
+      // Plant a second section so cross-section move has a target.
+      await editorPage.dragBlockFromSidebar("section");
+    }
+    expect(await sections.count()).toBeGreaterThanOrEqual(2);
+
+    // Plant a divider in section 0, column 0 so we have a known mover.
+    await editorPage.dragBlockFromSidebarToSection("divider", 0, 0);
+    const fromColIds = await editorPage.getSectionColumnBlockIds(0, 0);
+    const movedId = fromColIds[fromColIds.length - 1];
+    expect(movedId).toBeTruthy();
+
+    const toCountBefore = await editorPage
+      .getSectionColumnBlocks(1, 0)
+      .count();
+
+    await editorPage.moveBlockBetweenSections(
+      0,
+      0,
+      fromColIds.length - 1,
+      1,
+      0,
+    );
+
+    expect(
+      await editorPage.getSectionColumnBlockIds(1, 0),
+    ).toContain(movedId);
+    expect(
+      await editorPage.getSectionColumnBlocks(1, 0).count(),
+    ).toBe(toCountBefore + 1);
+    expect(
+      await editorPage.getSectionColumnBlockIds(0, 0),
+    ).not.toContain(movedId);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test:e2e:consumer": "playwright test --config playwright.consumer.config.ts",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",
+    "test:turbopack-consumer": "node packages/editor/scripts/turbopack-consumer-verify.mjs",
     "test:webpack-consumer": "node packages/editor/scripts/webpack-consumer-verify.mjs",
     "typecheck": "pnpm --filter './packages/*' run typecheck && pnpm --filter '@templatical/playground' run typecheck"
   }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -34,8 +34,8 @@
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.1.5",
     "vue": "^3.5.33",
-    "vue-tsc": "^3.2.7",
-    "vuedraggable": "^4.1.0"
+    "vue-draggable-plus": "^0.6.0",
+    "vue-tsc": "^3.2.7"
   },
   "exports": {
     ".": {

--- a/packages/editor/scripts/turbopack-consumer-verify.mjs
+++ b/packages/editor/scripts/turbopack-consumer-verify.mjs
@@ -14,10 +14,6 @@
  *   3. `npm install` the tarball alongside next/react/react-dom.
  *   4. Run `next build --turbopack`.
  *   5. Assert: zero TP1200 errors, build exits 0.
- *
- * Until the upstream UMD form is purged from the editor's published bundle
- * (currently shipped via the `vuedraggable@4` UMD-only `main`/`module` field),
- * this script fails — exactly mirroring the issue reporter's experience.
  */
 
 import { execSync } from "node:child_process";
@@ -111,7 +107,7 @@ try {
 
   if (/error TP1200/.test(buildOutput)) {
     fail(
-      "next build failed with TP1200 — the editor's published bundle still contains a UMD/AMD `define()` wrapper that Turbopack rejects. Likely source: vuedraggable@4 ships UMD only via its `main`/`module` field. Import the package's `src/vuedraggable.js` ESM source directly to drop the wrapper.",
+      "next build failed with TP1200 — a published chunk in dist/ contains a UMD/AMD `define()` wrapper that Turbopack rejects. Find the offending dep (search dist/ for `define.amd`), and either swap it for an ESM-only equivalent or import its ESM source directly so the wrapper isn't bundled.",
     );
   }
   if (buildExitCode !== 0) {

--- a/packages/editor/scripts/turbopack-consumer-verify.mjs
+++ b/packages/editor/scripts/turbopack-consumer-verify.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Build the editor as a real Next.js + Turbopack consumer would.
+ *
+ * Webpack tolerates legacy module-detection forms (UMD/AMD `typeof define ===
+ * "function" && define.amd`) inside dependencies it bundles. Turbopack does
+ * not — it errors out with `TP1200 unsupported AMD define() dependency element
+ * form` and refuses to compile the consumer. That breaks any Next.js 15+ app
+ * (Turbopack is the default builder) that imports `@templatical/editor`.
+ *
+ * Procedure:
+ *   1. Build + pack `@templatical/editor`.
+ *   2. Materialize the turbopack-consumer fixture into a clean cache dir.
+ *   3. `npm install` the tarball alongside next/react/react-dom.
+ *   4. Run `next build --turbopack`.
+ *   5. Assert: zero TP1200 errors, build exits 0.
+ *
+ * Until the upstream UMD form is purged from the editor's published bundle
+ * (currently shipped via the `vuedraggable@4` UMD-only `main`/`module` field),
+ * this script fails — exactly mirroring the issue reporter's experience.
+ */
+
+import { execSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EDITOR_DIR = resolve(__dirname, "..");
+const REPO_ROOT = resolve(EDITOR_DIR, "../..");
+const FIXTURE_DIR = join(EDITOR_DIR, "tests/e2e-fixtures/turbopack-consumer");
+const CONSUMER_DIR = join(REPO_ROOT, "node_modules/.cache/turbopack-consumer");
+
+function logStep(msg) {
+  process.stdout.write(`[turbopack-verify] ${msg}\n`);
+}
+
+function fail(msg) {
+  process.stderr.write(`[turbopack-verify] FAIL: ${msg}\n`);
+  process.exit(1);
+}
+
+function run(cmd, opts = {}) {
+  process.stdout.write(`[turbopack-verify] $ ${cmd}\n`);
+  execSync(cmd, { stdio: "inherit", ...opts });
+}
+
+if (!existsSync(FIXTURE_DIR)) {
+  fail(`fixture dir not found: ${FIXTURE_DIR}`);
+}
+
+run(`pnpm --filter @templatical/editor run build`, { cwd: REPO_ROOT });
+
+const packDir = mkdtempSync(join(tmpdir(), "tpl-turbopack-pack-"));
+try {
+  run(`pnpm pack --pack-destination "${packDir}"`, { cwd: EDITOR_DIR });
+
+  const editorTarball = readdirSync(packDir).find(
+    (f) => f.startsWith("templatical-editor-") && f.endsWith(".tgz"),
+  );
+  if (!editorTarball) fail("pnpm pack did not produce an editor .tgz");
+
+  const editorTarballPath = join(packDir, editorTarball);
+
+  rmSync(CONSUMER_DIR, { recursive: true, force: true });
+  mkdirSync(CONSUMER_DIR, { recursive: true });
+  cpSync(FIXTURE_DIR, CONSUMER_DIR, { recursive: true });
+
+  const tplPath = join(CONSUMER_DIR, "package.json.tpl");
+  const consumerPkgPath = join(CONSUMER_DIR, "package.json");
+  renameSync(tplPath, consumerPkgPath);
+  const consumerPkgText = readFileSync(consumerPkgPath, "utf8").replace(
+    "EDITOR_TARBALL_PLACEHOLDER",
+    `file:${editorTarballPath}`,
+  );
+  writeFileSync(consumerPkgPath, consumerPkgText);
+
+  run(`npm install --no-fund --no-audit`, { cwd: CONSUMER_DIR });
+
+  logStep("running next build with turbopack");
+  let buildOutput = "";
+  let buildExitCode = 0;
+  try {
+    buildOutput = execSync(
+      `node node_modules/next/dist/bin/next build --turbopack`,
+      {
+        cwd: CONSUMER_DIR,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env, NEXT_TELEMETRY_DISABLED: "1" },
+      },
+    );
+  } catch (err) {
+    buildExitCode = err.status ?? 1;
+    buildOutput = `${err.stdout ?? ""}\n${err.stderr ?? ""}`;
+  }
+
+  process.stdout.write(buildOutput);
+  process.stdout.write("\n");
+
+  if (/error TP1200/.test(buildOutput)) {
+    fail(
+      "next build failed with TP1200 — the editor's published bundle still contains a UMD/AMD `define()` wrapper that Turbopack rejects. Likely source: vuedraggable@4 ships UMD only via its `main`/`module` field. Import the package's `src/vuedraggable.js` ESM source directly to drop the wrapper.",
+    );
+  }
+  if (buildExitCode !== 0) {
+    fail(`next build exited with code ${buildExitCode}`);
+  }
+
+  logStep("OK — next build with turbopack succeeds");
+} finally {
+  rmSync(packDir, { recursive: true, force: true });
+}

--- a/packages/editor/scripts/verify-pack.mjs
+++ b/packages/editor/scripts/verify-pack.mjs
@@ -52,7 +52,7 @@ const FORBIDDEN_PACKAGES = [
   "@templatical/core",
   "@templatical/types",
   "@vueuse/core",
-  "vuedraggable",
+  "vue-draggable-plus",
   "@tiptap/core",
   "@tiptap/vue-3",
   "@tiptap/starter-kit",

--- a/packages/editor/src/components/Canvas.vue
+++ b/packages/editor/src/components/Canvas.vue
@@ -17,7 +17,7 @@ import {
   CAPABILITIES_KEY,
   requireInject,
 } from "../keys";
-import draggable from "vuedraggable";
+import { VueDraggable } from "vue-draggable-plus";
 import { resolveBlockComponent } from "../utils/blockComponentResolver";
 import { readableTextColor } from "../utils/readableTextColor";
 
@@ -177,10 +177,9 @@ function handleFetchData(
       :style="canvasStyle"
       @click="handleCanvasClick"
     >
-      <draggable
+      <VueDraggable
         v-model="blocks"
         group="blocks"
-        item-key="id"
         :animation="150"
         ghost-class="tpl-ghost"
         drag-class="tpl-dragging"
@@ -188,122 +187,127 @@ function handleFetchData(
         :invert-swap="true"
         :inverted-swap-threshold="0.65"
         :disabled="previewMode"
-        class="tpl-canvas-blocks"
+        class="tpl-canvas-blocks tpl:min-h-[400px]"
       >
-        <template #item="{ element: block }">
-          <div v-show="!conditionPreview?.isHidden(block.id)">
-            <div class="tpl:relative">
-              <!-- Collaboration lock overlay -->
-              <div
-                v-if="getBlockLock(block.id)"
-                class="tpl-collab-lock tpl:pointer-events-none tpl:absolute tpl:inset-0 tpl:z-[4] tpl:rounded-sm"
+        <div
+          v-for="block in blocks"
+          :key="block.id"
+          v-show="!conditionPreview?.isHidden(block.id)"
+        >
+          <div class="tpl:relative">
+            <!-- Collaboration lock overlay -->
+            <div
+              v-if="getBlockLock(block.id)"
+              class="tpl-collab-lock tpl:pointer-events-none tpl:absolute tpl:inset-0 tpl:z-[4] tpl:rounded-sm"
+              :style="{
+                outline: `2px solid ${getBlockLock(block.id)!.color}`,
+                outlineOffset: '-1px',
+              }"
+            >
+              <span
+                class="tpl:absolute tpl:-top-0.5 tpl:left-1/2 tpl:z-[5] tpl:flex tpl:-translate-x-1/2 tpl:-translate-y-full tpl:items-center tpl:gap-1 tpl:rounded-full tpl:px-2 tpl:py-0.5 tpl:text-[10px] tpl:font-medium tpl:whitespace-nowrap"
                 :style="{
-                  outline: `2px solid ${getBlockLock(block.id)!.color}`,
-                  outlineOffset: '-1px',
+                  backgroundColor: getBlockLock(block.id)!.color,
+                  color: readableTextColor(getBlockLock(block.id)!.color),
                 }"
               >
                 <span
-                  class="tpl:absolute tpl:-top-0.5 tpl:left-1/2 tpl:z-[5] tpl:flex tpl:-translate-x-1/2 tpl:-translate-y-full tpl:items-center tpl:gap-1 tpl:rounded-full tpl:px-2 tpl:py-0.5 tpl:text-[10px] tpl:font-medium tpl:whitespace-nowrap"
-                  :style="{
-                    backgroundColor: getBlockLock(block.id)!.color,
-                    color: readableTextColor(getBlockLock(block.id)!.color),
-                  }"
-                >
-                  <span
-                    class="tpl:inline-flex tpl:size-3 tpl:items-center tpl:justify-center tpl:rounded-full tpl:text-[8px] tpl:font-bold"
-                    style="
-                      background-color: color-mix(
-                        in srgb,
-                        var(--tpl-bg) 30%,
-                        transparent
-                      );
-                    "
-                  >
-                    {{ getBlockLock(block.id)!.name.charAt(0) }}
-                  </span>
-                  {{ getBlockLock(block.id)!.name }}
-                </span>
-              </div>
-              <BlockWrapper
-                :block="block"
-                :is-selected="
-                  !previewMode &&
-                  selectedBlockId === block.id &&
-                  !getBlockLock(block.id)
-                "
-                :viewport="viewport"
-                :preview-mode="previewMode"
-                @select="
-                  previewMode || getBlockLock(block.id)
-                    ? undefined
-                    : emit('select-block', block.id)
-                "
-              >
-                <component
-                  :is="getBlockComponent(block)"
-                  :block="block"
-                  :viewport="viewport"
-                  @fetch-data="handleFetchData(block, $event)"
-                  @update="
-                    (updates: Partial<Block>) =>
-                      editor.updateBlock(block.id, updates)
+                  class="tpl:inline-flex tpl:size-3 tpl:items-center tpl:justify-center tpl:rounded-full tpl:text-[8px] tpl:font-bold"
+                  style="
+                    background-color: color-mix(
+                      in srgb,
+                      var(--tpl-bg) 30%,
+                      transparent
+                    );
                   "
-                />
-              </BlockWrapper>
+                >
+                  {{ getBlockLock(block.id)!.name.charAt(0) }}
+                </span>
+                {{ getBlockLock(block.id)!.name }}
+              </span>
             </div>
+            <BlockWrapper
+              :block="block"
+              :is-selected="
+                !previewMode &&
+                selectedBlockId === block.id &&
+                !getBlockLock(block.id)
+              "
+              :viewport="viewport"
+              :preview-mode="previewMode"
+              @select="
+                previewMode || getBlockLock(block.id)
+                  ? undefined
+                  : emit('select-block', block.id)
+              "
+            >
+              <component
+                :is="getBlockComponent(block)"
+                :block="block"
+                :viewport="viewport"
+                @fetch-data="handleFetchData(block, $event)"
+                @update="
+                  (updates: Partial<Block>) =>
+                    editor.updateBlock(block.id, updates)
+                "
+              />
+            </BlockWrapper>
           </div>
-        </template>
-        <template #footer>
-          <div
-            v-if="blocks.length === 0 && !previewMode"
-            class="tpl-canvas-empty tpl:m-6 tpl:flex tpl:min-h-[400px] tpl:flex-col tpl:items-center tpl:justify-center tpl:rounded-xl tpl:border-2 tpl:border-dashed tpl:px-10 tpl:py-12 tpl:text-center tpl:border-[var(--tpl-primary)] tpl:bg-[var(--tpl-bg-elevated)] tpl:font-[var(--tpl-font-family)]"
+        </div>
+      </VueDraggable>
+      <!-- Empty-state placeholder. Renders as a sibling of VueDraggable
+           (not a child) so Sortable.js doesn't treat it as a draggable
+           item — vue-draggable-plus iterates the default slot's direct
+           children. Canvas-blocks gets a min-h utility above so the empty
+           container still has a non-zero hit area for `dragTo`. -->
+      <div
+        v-if="blocks.length === 0 && !previewMode"
+        class="tpl-canvas-empty tpl:m-6 tpl:flex tpl:min-h-[400px] tpl:flex-col tpl:items-center tpl:justify-center tpl:rounded-xl tpl:border-2 tpl:border-dashed tpl:px-10 tpl:py-12 tpl:text-center tpl:border-[var(--tpl-primary)] tpl:bg-[var(--tpl-bg-elevated)] tpl:font-[var(--tpl-font-family)]"
+      >
+        <div
+          class="tpl-canvas-empty-icon tpl:mb-4 tpl:text-[var(--tpl-primary)]"
+        >
+          <SquarePlus :size="48" :stroke-width="1" />
+        </div>
+        <p
+          class="tpl-canvas-empty-title tpl:m-0 tpl:mb-2 tpl:text-base tpl:font-semibold tpl:text-[var(--tpl-primary)]"
+        >
+          {{ t.canvas.noBlocks }}
+        </p>
+        <p
+          class="tpl-canvas-empty-text tpl:m-0 tpl:text-sm tpl:text-[var(--tpl-text-dim)]"
+        >
+          {{ t.canvas.dragHint }}
+        </p>
+        <p
+          v-if="canUseAiChat && cloudT"
+          class="tpl:m-0 tpl:mt-2 tpl:flex tpl:flex-wrap tpl:items-center tpl:justify-center tpl:gap-x-1 tpl:gap-y-0.5 tpl:text-sm tpl:text-[var(--tpl-text-dim)]"
+        >
+          {{ t.canvas.aiHintChat }}
+          <button
+            class="tpl:inline-flex tpl:shrink-0 tpl:cursor-pointer tpl:items-center tpl:gap-1 tpl:whitespace-nowrap tpl:rounded-[var(--tpl-radius-sm)] tpl:border-none tpl:px-2 tpl:py-0.5 tpl:text-sm tpl:font-semibold tpl:transition-colors tpl:duration-150 tpl:bg-[var(--tpl-primary-light)] tpl:text-[var(--tpl-primary-hover)]"
+            @click="emit('open-ai-chat')"
           >
-            <div
-              class="tpl-canvas-empty-icon tpl:mb-4 tpl:text-[var(--tpl-primary)]"
-            >
-              <SquarePlus :size="48" :stroke-width="1" />
-            </div>
-            <p
-              class="tpl-canvas-empty-title tpl:m-0 tpl:mb-2 tpl:text-base tpl:font-semibold tpl:text-[var(--tpl-primary)]"
-            >
-              {{ t.canvas.noBlocks }}
-            </p>
-            <p
-              class="tpl-canvas-empty-text tpl:m-0 tpl:text-sm tpl:text-[var(--tpl-text-dim)]"
-            >
-              {{ t.canvas.dragHint }}
-            </p>
-            <p
-              v-if="canUseAiChat && cloudT"
-              class="tpl:m-0 tpl:mt-2 tpl:flex tpl:flex-wrap tpl:items-center tpl:justify-center tpl:gap-x-1 tpl:gap-y-0.5 tpl:text-sm tpl:text-[var(--tpl-text-dim)]"
-            >
-              {{ t.canvas.aiHintChat }}
-              <button
-                class="tpl:inline-flex tpl:shrink-0 tpl:cursor-pointer tpl:items-center tpl:gap-1 tpl:whitespace-nowrap tpl:rounded-[var(--tpl-radius-sm)] tpl:border-none tpl:px-2 tpl:py-0.5 tpl:text-sm tpl:font-semibold tpl:transition-colors tpl:duration-150 tpl:bg-[var(--tpl-primary-light)] tpl:text-[var(--tpl-primary-hover)]"
-                @click="emit('open-ai-chat')"
-              >
-                <Sparkles :size="14" :stroke-width="2" />
-                {{ cloudT.aiMenu.aiAssistant }}
-              </button>
-              {{ t.canvas.aiHintChatSuffix }}
-            </p>
-            <p
-              v-if="canUseDesignToTemplate && cloudT"
-              class="tpl:m-0 tpl:mt-4 tpl:flex tpl:flex-wrap tpl:items-center tpl:justify-center tpl:gap-x-1 tpl:gap-y-0.5 tpl:text-sm tpl:text-[var(--tpl-text-dim)]"
-            >
-              {{ t.canvas.aiHintDesign }}
-              <button
-                class="tpl:inline-flex tpl:shrink-0 tpl:cursor-pointer tpl:items-center tpl:gap-1 tpl:whitespace-nowrap tpl:rounded-[var(--tpl-radius-sm)] tpl:border-none tpl:px-2 tpl:py-0.5 tpl:text-sm tpl:font-semibold tpl:transition-colors tpl:duration-150 tpl:bg-[var(--tpl-primary-light)] tpl:text-[var(--tpl-primary-hover)]"
-                @click="emit('open-design-reference')"
-              >
-                <ImageUp :size="14" :stroke-width="2" />
-                {{ cloudT.aiMenu.designToTemplate }}
-              </button>
-              {{ t.canvas.aiHintDesignSuffix }}
-            </p>
-          </div>
-        </template>
-      </draggable>
+            <Sparkles :size="14" :stroke-width="2" />
+            {{ cloudT.aiMenu.aiAssistant }}
+          </button>
+          {{ t.canvas.aiHintChatSuffix }}
+        </p>
+        <p
+          v-if="canUseDesignToTemplate && cloudT"
+          class="tpl:m-0 tpl:mt-4 tpl:flex tpl:flex-wrap tpl:items-center tpl:justify-center tpl:gap-x-1 tpl:gap-y-0.5 tpl:text-sm tpl:text-[var(--tpl-text-dim)]"
+        >
+          {{ t.canvas.aiHintDesign }}
+          <button
+            class="tpl:inline-flex tpl:shrink-0 tpl:cursor-pointer tpl:items-center tpl:gap-1 tpl:whitespace-nowrap tpl:rounded-[var(--tpl-radius-sm)] tpl:border-none tpl:px-2 tpl:py-0.5 tpl:text-sm tpl:font-semibold tpl:transition-colors tpl:duration-150 tpl:bg-[var(--tpl-primary-light)] tpl:text-[var(--tpl-primary-hover)]"
+            @click="emit('open-design-reference')"
+          >
+            <ImageUp :size="14" :stroke-width="2" />
+            {{ cloudT.aiMenu.designToTemplate }}
+          </button>
+          {{ t.canvas.aiHintDesignSuffix }}
+        </p>
+      </div>
     </div>
   </div>
 </template>

--- a/packages/editor/src/components/Sidebar.vue
+++ b/packages/editor/src/components/Sidebar.vue
@@ -5,7 +5,7 @@ import type { Block, BlockType } from "@templatical/types";
 import { createBlock, createCustomBlock } from "@templatical/types";
 import { Package } from "@lucide/vue";
 import { computed, inject, ref } from "vue";
-import draggable from "vuedraggable";
+import { VueDraggable } from "vue-draggable-plus";
 import CustomBlockIcon from "./CustomBlockIcon.vue";
 import { blockTypeIcons } from "../utils/blockTypeIcons";
 import { getBlockTypeLabel } from "../utils/blockTypeLabels";
@@ -158,53 +158,52 @@ function handlePaletteKeydown(event: KeyboardEvent, item: BlockTypeItem): void {
         </span>
       </button>
     </div>
-    <draggable
-      :list="blockTypes"
+    <VueDraggable
+      :model-value="blockTypes"
       :group="{ name: 'blocks', pull: 'clone', put: false }"
       :clone="createBlockFromItem"
       :sort="false"
-      item-key="type"
       :animation="150"
       ghost-class="tpl-ghost"
       class="tpl:flex tpl:flex-col tpl:gap-0.5 tpl:p-1"
     >
-      <template #item="{ element: blockType }">
-        <button
-          type="button"
-          :data-palette-type="blockType.type"
-          :aria-label="
-            format(t.sidebarNav.insertBlock, { block: blockType.label })
-          "
-          class="tpl:flex tpl:h-10 tpl:w-full tpl:cursor-grab tpl:items-center tpl:gap-3 tpl:rounded-[var(--tpl-radius-sm)] tpl:border-none tpl:bg-transparent tpl:px-3 tpl:text-[var(--tpl-text-muted)] tpl:transition-all tpl:duration-[120ms] tpl:ease-[cubic-bezier(0.16,1,0.3,1)] hover:tpl:bg-[var(--tpl-primary-light)] hover:tpl:text-[var(--tpl-primary)] active:tpl:cursor-grabbing"
-          :style="{
-            justifyContent: isExpanded ? 'flex-start' : 'center',
-          }"
-          @click="insertBlockFromItem(blockType)"
-          @keydown="handlePaletteKeydown($event, blockType)"
+      <button
+        v-for="blockType in blockTypes"
+        :key="blockType.type"
+        type="button"
+        :data-palette-type="blockType.type"
+        :aria-label="
+          format(t.sidebarNav.insertBlock, { block: blockType.label })
+        "
+        class="tpl:flex tpl:h-10 tpl:w-full tpl:cursor-grab tpl:items-center tpl:gap-3 tpl:rounded-[var(--tpl-radius-sm)] tpl:border-none tpl:bg-transparent tpl:px-3 tpl:text-[var(--tpl-text-muted)] tpl:transition-all tpl:duration-[120ms] tpl:ease-[cubic-bezier(0.16,1,0.3,1)] hover:tpl:bg-[var(--tpl-primary-light)] hover:tpl:text-[var(--tpl-primary)] active:tpl:cursor-grabbing"
+        :style="{
+          justifyContent: isExpanded ? 'flex-start' : 'center',
+        }"
+        @click="insertBlockFromItem(blockType)"
+        @keydown="handlePaletteKeydown($event, blockType)"
+      >
+        <div
+          class="tpl:flex tpl:shrink-0 tpl:items-center tpl:justify-center tpl:transition-transform tpl:duration-[120ms] tpl:ease-[cubic-bezier(0.16,1,0.3,1)] hover:tpl:scale-105"
         >
-          <div
-            class="tpl:flex tpl:shrink-0 tpl:items-center tpl:justify-center tpl:transition-transform tpl:duration-[120ms] tpl:ease-[cubic-bezier(0.16,1,0.3,1)] hover:tpl:scale-105"
-          >
-            <component
-              :is="blockTypeIcons[blockType.type]"
-              v-if="blockTypeIcons[blockType.type]"
-              :size="20"
-              :stroke-width="1.5"
-            />
-            <CustomBlockIcon
-              v-else-if="blockType.isCustom"
-              :icon="blockType.icon"
-              :size="20"
-            />
-          </div>
-          <span
-            v-if="isExpanded"
-            class="tpl:truncate tpl:text-sm tpl:font-medium"
-          >
-            {{ blockType.label }}
-          </span>
-        </button>
-      </template>
-    </draggable>
+          <component
+            :is="blockTypeIcons[blockType.type]"
+            v-if="blockTypeIcons[blockType.type]"
+            :size="20"
+            :stroke-width="1.5"
+          />
+          <CustomBlockIcon
+            v-else-if="blockType.isCustom"
+            :icon="blockType.icon"
+            :size="20"
+          />
+        </div>
+        <span
+          v-if="isExpanded"
+          class="tpl:truncate tpl:text-sm tpl:font-medium"
+        >
+          {{ blockType.label }}
+        </span>
+      </button>
+    </VueDraggable>
   </aside>
 </template>

--- a/packages/editor/src/components/blocks/SectionBlock.vue
+++ b/packages/editor/src/components/blocks/SectionBlock.vue
@@ -15,7 +15,7 @@ import type {
   ViewportSize,
 } from "@templatical/types";
 import { computed, inject, type Component } from "vue";
-import draggable from "vuedraggable";
+import { VueDraggable } from "vue-draggable-plus";
 import {
   EDITOR_KEY,
   CONDITION_PREVIEW_KEY,
@@ -115,7 +115,7 @@ function handleFetchData(
         "
         :style="{ width: columnWidths[colIndex] }"
       >
-        <draggable
+        <VueDraggable
           :model-value="getColumnBlocks(colIndex)"
           :group="{
             name: 'blocks',
@@ -123,31 +123,32 @@ function handleFetchData(
             put: (_to: unknown, _from: unknown, el: HTMLElement) =>
               el.dataset.blockType !== 'section',
           }"
-          item-key="id"
           :animation="150"
           ghost-class="tpl-ghost"
           :empty-insert-threshold="20"
           class="tpl:min-h-[60px]"
           @update:model-value="(val: Block[]) => setColumnBlocks(colIndex, val)"
         >
-          <template #item="{ element: childBlock }">
-            <div v-show="!conditionPreview?.isHidden(childBlock.id)">
-              <BlockWrapper
+          <div
+            v-for="childBlock in getColumnBlocks(colIndex)"
+            :key="childBlock.id"
+            v-show="!conditionPreview?.isHidden(childBlock.id)"
+          >
+            <BlockWrapper
+              :block="childBlock"
+              :is-selected="editor.state.selectedBlockId === childBlock.id"
+              :viewport="viewport"
+              @select="editor.selectBlock(childBlock.id)"
+            >
+              <component
+                :is="getBlockComponent(childBlock)"
                 :block="childBlock"
-                :is-selected="editor.state.selectedBlockId === childBlock.id"
                 :viewport="viewport"
-                @select="editor.selectBlock(childBlock.id)"
-              >
-                <component
-                  :is="getBlockComponent(childBlock)"
-                  :block="childBlock"
-                  :viewport="viewport"
-                  @fetch-data="handleFetchData(childBlock, $event)"
-                />
-              </BlockWrapper>
-            </div>
-          </template>
-        </draggable>
+                @fetch-data="handleFetchData(childBlock, $event)"
+              />
+            </BlockWrapper>
+          </div>
+        </VueDraggable>
         <div
           v-if="getColumnBlocks(colIndex).length === 0"
           data-testid="section-drop-hint"

--- a/packages/editor/tests/bundle-topology.test.ts
+++ b/packages/editor/tests/bundle-topology.test.ts
@@ -116,7 +116,7 @@ describe("editor bundle topology", () => {
       "@templatical/core/cloud",
       "@templatical/types",
       "@vueuse/core",
-      "vuedraggable",
+      "vue-draggable-plus",
       "@tiptap/core",
       "@tiptap/vue-3",
       "@lucide/vue",

--- a/packages/editor/tests/e2e-fixtures/turbopack-consumer/components/EditorMount.js
+++ b/packages/editor/tests/e2e-fixtures/turbopack-consumer/components/EditorMount.js
@@ -1,0 +1,15 @@
+import { createElement, useEffect, useRef } from "react";
+import { init } from "@templatical/editor";
+import "@templatical/editor/style.css";
+
+export default function EditorMount() {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (!ref.current) return;
+    const editor = init({ container: ref.current });
+    return () => {
+      if (editor && typeof editor.unmount === "function") editor.unmount();
+    };
+  }, []);
+  return createElement("div", { ref, style: { height: "100vh" } });
+}

--- a/packages/editor/tests/e2e-fixtures/turbopack-consumer/next.config.mjs
+++ b/packages/editor/tests/e2e-fixtures/turbopack-consumer/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: false,
+  // Suppress lint/type-check noise so the test focuses on bundler behavior.
+  eslint: { ignoreDuringBuilds: true },
+  typescript: { ignoreBuildErrors: true },
+};
+
+export default nextConfig;

--- a/packages/editor/tests/e2e-fixtures/turbopack-consumer/package.json.tpl
+++ b/packages/editor/tests/e2e-fixtures/turbopack-consumer/package.json.tpl
@@ -1,0 +1,14 @@
+{
+  "name": "tpl-editor-e2e-turbopack-consumer",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "build": "next build"
+  },
+  "dependencies": {
+    "@templatical/editor": "EDITOR_TARBALL_PLACEHOLDER",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/editor/tests/e2e-fixtures/turbopack-consumer/pages/index.js
+++ b/packages/editor/tests/e2e-fixtures/turbopack-consumer/pages/index.js
@@ -1,0 +1,14 @@
+import { createElement } from "react";
+import dynamic from "next/dynamic";
+
+// Editor needs DOM; disable SSR but still force turbopack to bundle the
+// editor module graph during `next build` so any unsupported AMD/UMD form
+// in published chunks surfaces as a build-time error.
+const EditorMount = dynamic(
+  () => import("../components/EditorMount.js"),
+  { ssr: false },
+);
+
+export default function Home() {
+  return createElement(EditorMount);
+}

--- a/packages/editor/tests/index-init.test.ts
+++ b/packages/editor/tests/index-init.test.ts
@@ -102,6 +102,6 @@ describe("editor entry — concurrent init does not orphan first app", () => {
 
   // Cloud equivalent: initCloud has the same race shape (guard checked
   // before awaits). Not unit-tested here because the dynamic CloudEditor.vue
-  // import pulls in vuedraggable/sortablejs which needs a real DOM. Fix
+  // import pulls in vue-draggable-plus/sortablejs which needs a real DOM. Fix
   // mirrors the OSS one — guard moved after awaits in src/index.ts.
 });

--- a/packages/editor/vite.cdn.config.ts
+++ b/packages/editor/vite.cdn.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     ],
     publicDir: false,
     // Vite's lib mode does not replace `process.env.NODE_ENV`. Some deps
-    // (vuedraggable/sortablejs) reference it unguarded — define it explicitly.
+    // (vue-draggable-plus/sortablejs) reference it unguarded — define it explicitly.
     define: {
         'process.env.NODE_ENV': JSON.stringify('production'),
     },
@@ -65,7 +65,7 @@ export default defineConfig({
                         return 'renderer';
                     }
                     if (
-                        id.includes('vuedraggable') ||
+                        id.includes('vue-draggable-plus') ||
                         id.includes('sortablejs')
                     ) {
                         return 'draggable';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,12 +340,12 @@ importers:
       vue:
         specifier: ^3.5.33
         version: 3.5.33(typescript@6.0.3)
+      vue-draggable-plus:
+        specifier: ^0.6.0
+        version: 0.6.1(@types/sortablejs@1.15.9)
       vue-tsc:
         specifier: ^3.2.7
         version: 3.2.7(typescript@6.0.3)
-      vuedraggable:
-        specifier: ^4.1.0
-        version: 4.1.0(vue@3.5.33(typescript@6.0.3))
 
   packages/import-beefree:
     dependencies:
@@ -1897,6 +1897,9 @@ packages:
 
   '@types/relateurl@0.2.33':
     resolution: {integrity: sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==}
+
+  '@types/sortablejs@1.15.9':
+    resolution: {integrity: sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -4668,6 +4671,15 @@ packages:
   vue-component-type-helpers@3.2.7:
     resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
 
+  vue-draggable-plus@0.6.1:
+    resolution: {integrity: sha512-FbtQ/fuoixiOfTZzG3yoPl4JAo9HJXRHmBQZFB9x2NYCh6pq0TomHf7g5MUmpaDYv+LU2n6BPq2YN9sBO+FbIg==}
+    peerDependencies:
+      '@types/sortablejs': ^1.15.0
+      '@vue/composition-api': '*'
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
   vue-eslint-parser@10.4.0:
     resolution: {integrity: sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4692,11 +4704,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  vuedraggable@4.1.0:
-    resolution: {integrity: sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==}
-    peerDependencies:
-      vue: ^3.0.1
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
@@ -6127,6 +6134,8 @@ snapshots:
       undici-types: 7.19.2
 
   '@types/relateurl@0.2.33': {}
+
+  '@types/sortablejs@1.15.9': {}
 
   '@types/unist@3.0.3': {}
 
@@ -8865,7 +8874,8 @@ snapshots:
 
   slick@1.12.2: {}
 
-  sortablejs@1.14.0: {}
+  sortablejs@1.14.0:
+    optional: true
 
   source-map-js@1.2.1: {}
 
@@ -9356,6 +9366,10 @@ snapshots:
 
   vue-component-type-helpers@3.2.7: {}
 
+  vue-draggable-plus@0.6.1(@types/sortablejs@1.15.9):
+    dependencies:
+      '@types/sortablejs': 1.15.9
+
   vue-eslint-parser@10.4.0(eslint@10.2.1(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
@@ -9388,11 +9402,6 @@ snapshots:
       '@vue/shared': 3.5.33
     optionalDependencies:
       typescript: 6.0.3
-
-  vuedraggable@4.1.0(vue@3.5.33(typescript@6.0.3)):
-    dependencies:
-      sortablejs: 1.14.0
-      vue: 3.5.33(typescript@6.0.3)
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
Related to #67.

Replace `vuedraggable` with `vue-draggable-plus`. The previous draggable library shipped a UMD-only bundle whose `define.amd` wrapper got inlined into our published editor chunks, causing `error TP1200 unsupported AMD define() dependency element form` for any Next.js 15+ consumer using Turbopack (the default). The new library ships proper ESM, so the published bundle no longer contains UMD/AMD wrappers and Turbopack builds succeed. No public API change.

Also added a Turbopack consumer test to CI the issue can't regress.