### PR TITLE
Fix TitleBlock rendering to use heading tags and unwrap outer <p> ele…

### DIFF
--- a/.changeset/fix-title-block-canvas-heading.md
+++ b/.changeset/fix-title-block-canvas-heading.md
@@ -1,0 +1,5 @@
+---
+"@templatical/editor": patch
+---
+
+Fix Title block rendering as `<p>` inside the editor canvas. The exported MJML/HTML already used the correct `<h${level}>` tag, but the canvas wrapped TipTap's stored content in a plain `<div>` and left the outer `<p>` from the editor's paragraph node in place, so the editor preview diverged from the final email and consumer CSS rules targeting `p` could unintentionally style titles in the canvas. The non-editing branch of `TitleBlock` now renders `h1`–`h4` matching `block.level` and strips the single outer `<p>` wrapper using the same rule the renderer applies. No data migration is needed — existing templates already carry `level` and render correctly on reload. Consumers that previously overrode title styling via `.tpl-text-content p` selectors in the canvas should switch to heading selectors (`h1`–`h4`) to match the exported output.

--- a/packages/editor/src/components/blocks/TitleBlock.vue
+++ b/packages/editor/src/components/blocks/TitleBlock.vue
@@ -6,6 +6,7 @@ import type {
 } from "@templatical/types";
 import { HEADING_LEVEL_FONT_SIZE } from "@templatical/types";
 import { computed, defineAsyncComponent } from "vue";
+import { unwrapParagraph } from "../../utils/unwrapParagraph";
 
 const props = defineProps<{
   block: TitleBlockType;
@@ -35,6 +36,9 @@ const titleStyle = computed(() => {
   }
   return style;
 });
+
+const headingTag = computed(() => `h${props.block.level}`);
+const headingHtml = computed(() => unwrapParagraph(resolvedContent.value));
 </script>
 
 <template>
@@ -50,12 +54,14 @@ const titleStyle = computed(() => {
       :toolbar-position="toolbarPosition"
       @done="handleEditorDone"
     />
-    <!-- eslint-disable vue/no-v-html -->
-    <div
+    <!-- eslint-disable vue/no-v-html, vue/no-v-text-v-html-on-component -->
+    <component
+      :is="headingTag"
       v-else
-      class="tpl-text-content tpl:outline-none [&_a]:tpl:underline [&_p]:tpl:m-0 [&_p]:tpl:mb-2 [&_p:last-child]:tpl:mb-0"
-      v-html="resolvedContent"
+      class="tpl-text-content tpl:m-0 tpl:font-[inherit] tpl:text-[length:inherit] tpl:leading-tight tpl:outline-none [&_a]:tpl:underline [&_p]:tpl:m-0 [&_p]:tpl:mb-2 [&_p:last-child]:tpl:mb-0"
+      :style="{ color: 'inherit' }"
+      v-html="headingHtml"
     />
-    <!-- eslint-enable vue/no-v-html -->
+    <!-- eslint-enable vue/no-v-html, vue/no-v-text-v-html-on-component -->
   </div>
 </template>

--- a/packages/editor/src/utils/unwrapParagraph.ts
+++ b/packages/editor/src/utils/unwrapParagraph.ts
@@ -1,0 +1,14 @@
+/**
+ * Strip a single outer `<p>` wrapper from a TipTap-stored HTML string so the
+ * canvas can render the inner inline content directly inside a heading
+ * element. Mirrors the renderer's `unwrapParagraph` so the editor canvas and
+ * the exported MJML/HTML agree on the title's element structure.
+ */
+export function unwrapParagraph(html: string): string {
+  const match = html.match(/^\s*<p\b[^>]*>([\s\S]*)<\/p>\s*$/);
+  if (!match) return html;
+  // Only unwrap when there is exactly one top-level <p>. If the content has
+  // multiple paragraphs, leave it alone — same rule the renderer applies.
+  if (/<\/p>\s*<p\b/i.test(match[1])) return html;
+  return match[1];
+}

--- a/packages/editor/tests/titleBlock.test.ts
+++ b/packages/editor/tests/titleBlock.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { createTitleBlock } from "@templatical/types";
+import TitleBlock from "../src/components/blocks/TitleBlock.vue";
+import { mountEditor } from "./helpers/mount";
+
+function mount(
+  overrides: Partial<Parameters<typeof createTitleBlock>[0]> = {},
+) {
+  const block = createTitleBlock({
+    content: "<p>Hello title</p>",
+    level: 2,
+    ...overrides,
+  });
+  return mountEditor(TitleBlock, {
+    props: { block, viewport: "desktop" as const },
+  });
+}
+
+describe("TitleBlock canvas rendering", () => {
+  it("renders block.level as an h{level} element, not a <p>", () => {
+    const wrapper = mount({ level: 1 });
+    const heading = wrapper.find("h1");
+    expect(heading.exists()).toBe(true);
+    expect(heading.text()).toBe("Hello title");
+    // Regression for issue #69: the canvas must NOT render the title's
+    // content wrapped in a <p> — that diverges from the exported MJML/HTML
+    // output (which uses h${level}) and lets consumer "p" rules leak in.
+    expect(wrapper.find(".tpl-text-content > p").exists()).toBe(false);
+  });
+
+  it("renders each heading level with the matching tag (h1..h4)", () => {
+    // HeadingLevel is constrained to 1..4 in @templatical/types.
+    for (const level of [1, 2, 3, 4] as const) {
+      const wrapper = mount({ level });
+      expect(wrapper.find(`h${level}`).exists()).toBe(true);
+      // No other heading levels rendered.
+      for (const other of [1, 2, 3, 4] as const) {
+        if (other === level) continue;
+        expect(wrapper.find(`h${other}`).exists()).toBe(false);
+      }
+    }
+  });
+
+  it("strips a single outer <p> wrapper from TipTap-stored content", () => {
+    const wrapper = mount({ content: "<p>Plain title</p>", level: 2 });
+    const heading = wrapper.find("h2");
+    // The text is inside the heading directly, not nested under another <p>.
+    expect(heading.element.querySelector("p")).toBeNull();
+    expect(heading.text()).toBe("Plain title");
+  });
+
+  it("preserves inline formatting inside the heading", () => {
+    const wrapper = mount({
+      content: "<p>Hello <strong>bold</strong> world</p>",
+      level: 3,
+    });
+    const heading = wrapper.find("h3");
+    expect(heading.element.querySelector("strong")?.textContent).toBe("bold");
+  });
+
+  it("does NOT unwrap when content has multiple top-level paragraphs", () => {
+    // Mirrors renderer behavior: only a single outer <p> is unwrapped.
+    const wrapper = mount({
+      content: "<p>First</p><p>Second</p>",
+      level: 2,
+    });
+    const heading = wrapper.find("h2");
+    expect(heading.exists()).toBe(true);
+    expect(heading.element.querySelectorAll("p")).toHaveLength(2);
+  });
+
+  it("applies title style (font-size, color, text-align) on the heading wrapper", () => {
+    const wrapper = mount({
+      level: 2,
+      color: "#ff0000",
+      textAlign: "center",
+    });
+    const styled = wrapper.find('[style*="color"]');
+    const style = styled.attributes("style") ?? "";
+    expect(style).toContain("color: #ff0000");
+    expect(style).toContain("text-align: center");
+  });
+});

--- a/packages/editor/tests/unwrapParagraph.test.ts
+++ b/packages/editor/tests/unwrapParagraph.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { unwrapParagraph } from "../src/utils/unwrapParagraph";
+
+describe("unwrapParagraph", () => {
+  describe("unwraps single outer <p>", () => {
+    it("strips bare <p>", () => {
+      expect(unwrapParagraph("<p>Hello</p>")).toBe("Hello");
+    });
+
+    it("strips <p> with attributes", () => {
+      expect(unwrapParagraph('<p style="text-align: center">Hello</p>')).toBe(
+        "Hello",
+      );
+      expect(unwrapParagraph('<p class="title">Hello</p>')).toBe("Hello");
+      expect(unwrapParagraph('<p data-foo="bar" class="x">Hello</p>')).toBe(
+        "Hello",
+      );
+    });
+
+    it("tolerates whitespace around the wrapper", () => {
+      expect(unwrapParagraph("  <p>Hello</p>  ")).toBe("Hello");
+      expect(unwrapParagraph("\n<p>Hello</p>\n")).toBe("Hello");
+    });
+
+    it("preserves whitespace inside the wrapper", () => {
+      expect(unwrapParagraph("<p>  spaced  </p>")).toBe("  spaced  ");
+    });
+
+    it("returns empty string for empty <p></p>", () => {
+      expect(unwrapParagraph("<p></p>")).toBe("");
+    });
+
+    it("preserves inline children", () => {
+      expect(unwrapParagraph("<p>Hello <strong>bold</strong> world</p>")).toBe(
+        "Hello <strong>bold</strong> world",
+      );
+      expect(
+        unwrapParagraph('<p>foo <a href="#">link</a> <em>italic</em></p>'),
+      ).toBe('foo <a href="#">link</a> <em>italic</em>');
+    });
+
+    it("preserves newlines inside the wrapper", () => {
+      expect(unwrapParagraph("<p>line1\nline2</p>")).toBe("line1\nline2");
+    });
+  });
+
+  describe("does NOT unwrap", () => {
+    it("multiple top-level <p> elements", () => {
+      const html = "<p>First</p><p>Second</p>";
+      expect(unwrapParagraph(html)).toBe(html);
+    });
+
+    it("three top-level <p> elements", () => {
+      const html = "<p>a</p><p>b</p><p>c</p>";
+      expect(unwrapParagraph(html)).toBe(html);
+    });
+
+    it("multiple <p> with whitespace between them", () => {
+      const html = "<p>First</p>\n  <p>Second</p>";
+      expect(unwrapParagraph(html)).toBe(html);
+    });
+
+    it("content with no <p> wrapper", () => {
+      expect(unwrapParagraph("Hello world")).toBe("Hello world");
+      expect(unwrapParagraph("<h1>Direct heading</h1>")).toBe(
+        "<h1>Direct heading</h1>",
+      );
+      expect(unwrapParagraph("<span>inline</span>")).toBe(
+        "<span>inline</span>",
+      );
+    });
+
+    it("empty string", () => {
+      expect(unwrapParagraph("")).toBe("");
+    });
+
+    it("uppercase <P> (regex is case-sensitive — TipTap emits lowercase)", () => {
+      const html = "<P>Hello</P>";
+      expect(unwrapParagraph(html)).toBe(html);
+    });
+
+    it("<p> followed by trailing non-whitespace content", () => {
+      const html = "<p>Hello</p>trailing";
+      expect(unwrapParagraph(html)).toBe(html);
+    });
+
+    it("content preceded by non-whitespace before <p>", () => {
+      const html = "leading<p>Hello</p>";
+      expect(unwrapParagraph(html)).toBe(html);
+    });
+  });
+
+  it("matches the renderer's unwrap rule for shared inputs", () => {
+    // Sanity: same inputs that the renderer's unwrapParagraph handles must
+    // produce the same output here. If these diverge, canvas and exported
+    // HTML will disagree about title structure (the bug from issue #69).
+    const cases: Array<[string, string]> = [
+      ["<p>x</p>", "x"],
+      ["<p>a</p><p>b</p>", "<p>a</p><p>b</p>"],
+      ["<p>Hello <em>world</em></p>", "Hello <em>world</em>"],
+      ["", ""],
+    ];
+    for (const [input, expected] of cases) {
+      expect(unwrapParagraph(input)).toBe(expected);
+    }
+  });
+});


### PR DESCRIPTION
Closes #69.

Fix Title block rendering as `<p>` inside the editor canvas. The exported MJML/HTML already used the correct `<h${level}>` tag, but the canvas wrapped TipTap's stored content in a plain `<div>` and left the outer `<p>` from the editor's paragraph node in place, so the editor preview diverged from the final email and consumer CSS rules targeting `p` could unintentionally style titles in the canvas. The non-editing branch of `TitleBlock` now renders `h1`–`h4` matching `block.level` and strips the single outer `<p>` wrapper using the same rule the renderer applies.

Unlikely to happen, but consumers that previously overrode title styling via `.tpl-text-content p` selectors in the canvas should switch to heading selectors (`h1`–`h4`) to match the exported output.