### PR TITLE
Batch of bug fixes hardening editor correctness and security

### DIFF
--- a/.changeset/editor-bug-hunt-batch.md
+++ b/.changeset/editor-bug-hunt-batch.md
@@ -1,0 +1,17 @@
+---
+"@templatical/core": patch
+"@templatical/editor": patch
+---
+
+Batch of bug fixes hardening editor correctness and security:
+
+- **Link dialog rejects dangerous URL schemes.** `javascript:`, `data:`, `vbscript:`, `file:` (plus case-bypasses like `JaVaScRiPt:` and whitespace-padded variants) are now dropped at link-insert time. Safe schemes (`http`, `https`, `mailto`, `tel`, `ftp`, `ftps`, `sms`, `xmpp`, `cid`) and `#` anchors still pass through.
+- **`v-html` content sanitized before render.** `ParagraphBlock` and `TitleBlock` now scrub `<script>`/`<style>`/`<iframe>`/`on*` event handlers and unsafe `href` / `src` schemes from `block.content` before binding it to `v-html`. Closes the XSS path where a malicious or compromised template JSON could execute code on canvas load. TipTap-authored content (the common case) is unaffected.
+- **Block duplication regenerates nested IDs.** Cloning a `table`, `social`, or `menu` block previously reused identical `rows[].id` / `cells[].id` / `icons[].id` / `items[].id` from the source, violating the unique-id invariant.
+- **Removing a section clears descendant selection.** Previously, deleting an ancestor with a child selected left `selectedBlockId` dangling on the now-orphan id. The full subtree is walked on remove and selection is cleared if any descendant id matches.
+- **`addBlock` / `moveBlock` validate `columnIndex` against the section layout.** Passing `columnIndex: 5` on a `"2"`-layout section no longer creates phantom columns persisted into JSON; out-of-range indices are rejected and `moveBlock` leaves the source intact.
+- **Media-picker callers guard against post-unmount writes.** `ImageBlock`, `ImageToolbar`, `VideoToolbar`, and the custom-block `ImageField` now check an alive flag after `await onRequestMedia()`. Closing the editor mid-pick no longer triggers zombie `emit("update")` / pulse-ref writes on a torn-down component.
+- **Keyboard shortcuts scoped to the active editor when two are mounted.** Each `useEditorCore` instance previously installed its own `document` keydown listener, so a single `Cmd+Z` fired both editors' undo handlers. The new `activeEditorTracker` routes shortcuts to the editor the user most recently interacted with (single-editor pages keep the original always-active behavior).
+- **`MergeTagSuggestion` cancels its pending `requestAnimationFrame` on exit.** The reposition-after-paint frame previously ran after the popup tore down, pinning the Vue app and DOM nodes for one frame.
+- **`useMergeTagField.insertMergeTag` no longer emits after the host component unmounts.** A scope-dispose flag now gates the post-`await requestMergeTag()` writes (emit + `isEditing` + `nextTick`).
+- **`useFonts.loadCustomFonts` no longer flips `isLoaded` after dispose.** The post-`Promise.allSettled` write is gated by the same scope-dispose flag.

--- a/packages/core/src/block-actions.ts
+++ b/packages/core/src/block-actions.ts
@@ -1,6 +1,20 @@
 import type { Block, BlockDefaults, BlockType } from "@templatical/types";
 import { createBlock, generateId } from "@templatical/types";
 
+function regenerateNestedIds(block: Block): void {
+  if (block.type === "table") {
+    block.rows = block.rows.map((row) => ({
+      ...row,
+      id: generateId(),
+      cells: row.cells.map((cell) => ({ ...cell, id: generateId() })),
+    }));
+  } else if (block.type === "social") {
+    block.icons = block.icons.map((icon) => ({ ...icon, id: generateId() }));
+  } else if (block.type === "menu") {
+    block.items = block.items.map((item) => ({ ...item, id: generateId() }));
+  }
+}
+
 export interface UseBlockActionsOptions {
   addBlock: (
     block: Block,
@@ -64,12 +78,14 @@ export function useBlockActions(
   ): Block {
     const cloned = JSON.parse(JSON.stringify(block)) as Block;
     cloned.id = generateId();
+    regenerateNestedIds(cloned);
 
     if (cloned.type === "section") {
       cloned.children = cloned.children.map((column) =>
         column.map((child) => {
           const clonedChild = JSON.parse(JSON.stringify(child)) as Block;
           clonedChild.id = generateId();
+          regenerateNestedIds(clonedChild);
           return clonedChild;
         }),
       );

--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -1,5 +1,6 @@
 import type {
   Block,
+  ColumnLayout,
   TemplateContent,
   TemplateDefaults,
   TemplateSettings,
@@ -7,6 +8,12 @@ import type {
   ViewportSize,
 } from "@templatical/types";
 import { createDefaultTemplateContent } from "@templatical/types";
+
+function getColumnCount(layout: ColumnLayout): number {
+  if (layout === "1") return 1;
+  if (layout === "3") return 3;
+  return 2;
+}
 import {
   computed,
   reactive,
@@ -106,6 +113,17 @@ export function useEditor(options: UseEditorOptions): UseEditorReturn {
       }
     }
     return null;
+  }
+
+  function collectBlockIds(block: Block, ids: Set<string>): void {
+    ids.add(block.id);
+    if (block.type === "section") {
+      for (const column of block.children) {
+        for (const child of column) {
+          collectBlockIds(child, ids);
+        }
+      }
+    }
   }
 
   function findBlockParent(
@@ -223,6 +241,9 @@ export function useEditor(options: UseEditorOptions): UseEditorReturn {
       }
       const section = findBlockById(state.content.blocks, targetSectionId);
       if (section && section.type === "section") {
+        if (columnIndex < 0 || columnIndex >= getColumnCount(section.columns)) {
+          return;
+        }
         section.children[columnIndex] = section.children[columnIndex] || [];
         const targetArray = section.children[columnIndex];
         if (index !== undefined && index < targetArray.length) {
@@ -249,9 +270,13 @@ export function useEditor(options: UseEditorOptions): UseEditorReturn {
     if (parent) {
       const index = parent.blocks.findIndex((b) => b.id === blockId);
       if (index !== -1) {
-        parent.blocks.splice(index, 1);
-        if (state.selectedBlockId === blockId) {
-          state.selectedBlockId = null;
+        const [removed] = parent.blocks.splice(index, 1);
+        if (state.selectedBlockId) {
+          const removedIds = new Set<string>();
+          collectBlockIds(removed, removedIds);
+          if (removedIds.has(state.selectedBlockId)) {
+            state.selectedBlockId = null;
+          }
         }
         state.isDirty = true;
       }
@@ -283,6 +308,9 @@ export function useEditor(options: UseEditorOptions): UseEditorReturn {
     if (targetSectionId) {
       const section = findBlockById(state.content.blocks, targetSectionId);
       if (!section || section.type !== "section") return;
+      if (columnIndex < 0 || columnIndex >= getColumnCount(section.columns)) {
+        return;
+      }
       section.children[columnIndex] = section.children[columnIndex] || [];
       targetArray = section.children[columnIndex];
     } else {

--- a/packages/core/tests/block-actions.test.ts
+++ b/packages/core/tests/block-actions.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
     createDefaultTemplateContent,
+    createMenuBlock,
     createParagraphBlock,
     createSectionBlock,
+    createSocialIconsBlock,
+    createTableBlock,
     createTitleBlock,
     type BlockDefaults,
+    type MenuBlock,
+    type SocialIconsBlock,
+    type TableBlock,
 } from '@templatical/types';
 import { useBlockActions, useEditor } from '../src';
 
@@ -158,6 +164,75 @@ describe('useBlockActions', () => {
 
         actions.duplicateBlock(original);
         expect(original.id).toBe(originalId);
+    });
+
+    it('duplicates table block with unique row and cell IDs', () => {
+        const opts = createMockOptions();
+        const actions = useBlockActions(opts);
+        const original = createTableBlock();
+        const sourceRowIds = original.rows.map((r) => r.id);
+        const sourceCellIds = original.rows.flatMap((r) => r.cells.map((c) => c.id));
+
+        const cloned = actions.duplicateBlock(original) as TableBlock;
+        expect(cloned.type).toBe('table');
+
+        const clonedRowIds = cloned.rows.map((r) => r.id);
+        const clonedCellIds = cloned.rows.flatMap((r) => r.cells.map((c) => c.id));
+
+        for (const id of clonedRowIds) {
+            expect(sourceRowIds).not.toContain(id);
+        }
+        for (const id of clonedCellIds) {
+            expect(sourceCellIds).not.toContain(id);
+        }
+        // Cloned IDs unique among themselves
+        expect(new Set(clonedRowIds).size).toBe(clonedRowIds.length);
+        expect(new Set(clonedCellIds).size).toBe(clonedCellIds.length);
+        // Cell content preserved
+        expect(cloned.rows[0].cells[0].content).toBe(original.rows[0].cells[0].content);
+    });
+
+    it('duplicates social icons block with unique icon IDs', () => {
+        const opts = createMockOptions();
+        const actions = useBlockActions(opts);
+        const original = createSocialIconsBlock({
+            icons: [
+                { id: 'icon-1', platform: 'twitter', url: 'https://twitter.com/x' },
+                { id: 'icon-2', platform: 'facebook', url: 'https://facebook.com/x' },
+            ],
+        });
+
+        const cloned = actions.duplicateBlock(original) as SocialIconsBlock;
+        expect(cloned.type).toBe('social');
+        expect(cloned.icons).toHaveLength(2);
+
+        expect(cloned.icons[0].id).not.toBe('icon-1');
+        expect(cloned.icons[1].id).not.toBe('icon-2');
+        expect(cloned.icons[0].id).not.toBe(cloned.icons[1].id);
+        // Non-id fields preserved
+        expect(cloned.icons[0].platform).toBe('twitter');
+        expect(cloned.icons[1].url).toBe('https://facebook.com/x');
+    });
+
+    it('duplicates menu block with unique item IDs', () => {
+        const opts = createMockOptions();
+        const actions = useBlockActions(opts);
+        const original = createMenuBlock({
+            items: [
+                { id: 'item-1', label: 'Home', url: 'https://example.com' },
+                { id: 'item-2', label: 'About', url: 'https://example.com/about' },
+            ],
+        });
+
+        const cloned = actions.duplicateBlock(original) as MenuBlock;
+        expect(cloned.type).toBe('menu');
+        expect(cloned.items).toHaveLength(2);
+
+        expect(cloned.items[0].id).not.toBe('item-1');
+        expect(cloned.items[1].id).not.toBe('item-2');
+        expect(cloned.items[0].id).not.toBe(cloned.items[1].id);
+        expect(cloned.items[0].label).toBe('Home');
+        expect(cloned.items[1].label).toBe('About');
     });
 });
 

--- a/packages/core/tests/editor.test.ts
+++ b/packages/core/tests/editor.test.ts
@@ -156,6 +156,45 @@ describe('useEditor', () => {
         expect(editor.state.selectedBlockId).toBeNull();
     });
 
+    it('clears selection when removing a section whose child is selected', () => {
+        const content = createDefaultTemplateContent();
+        const child = createParagraphBlock({ content: '<p>Child</p>' });
+        const section = createSectionBlock({ children: [[child]] });
+        content.blocks = [section];
+        const editor = useEditor({ content });
+        editor.selectBlock(child.id);
+        expect(editor.state.selectedBlockId).toBe(child.id);
+
+        editor.removeBlock(section.id);
+        expect(editor.state.content.blocks).toHaveLength(0);
+        expect(editor.state.selectedBlockId).toBeNull();
+    });
+
+    it('clears selection when removing a deeply nested ancestor', () => {
+        const content = createDefaultTemplateContent();
+        const leaf = createParagraphBlock({ content: '<p>Leaf</p>' });
+        const innerSection = createSectionBlock({ children: [[leaf]] });
+        const outerSection = createSectionBlock({ children: [[innerSection]] });
+        content.blocks = [outerSection];
+        const editor = useEditor({ content });
+        editor.selectBlock(leaf.id);
+
+        editor.removeBlock(outerSection.id);
+        expect(editor.state.selectedBlockId).toBeNull();
+    });
+
+    it('does not clear selection when removing an unrelated block', () => {
+        const content = createDefaultTemplateContent();
+        const a = createParagraphBlock({ content: '<p>A</p>' });
+        const b = createParagraphBlock({ content: '<p>B</p>' });
+        content.blocks = [a, b];
+        const editor = useEditor({ content });
+        editor.selectBlock(a.id);
+
+        editor.removeBlock(b.id);
+        expect(editor.state.selectedBlockId).toBe(a.id);
+    });
+
     it('moves block to new position', () => {
         const content = createDefaultTemplateContent();
         const block1 = createParagraphBlock({ content: '<p>First</p>' });
@@ -581,9 +620,10 @@ describe('moveBlock into section column', () => {
         const content = createDefaultTemplateContent();
         const rootBlock = createParagraphBlock({ content: '<p>Root</p>' });
         const section = createSectionBlock({
+            columns: '2',
             children: [[]],
         });
-        // Clear column to simulate undefined
+        // Clear column to simulate undefined within the declared layout
         (section as any).children[1] = undefined;
         content.blocks = [rootBlock, section];
         const editor = useEditor({ content });
@@ -595,6 +635,98 @@ describe('moveBlock into section column', () => {
         if (sec.type === 'section') {
             expect(sec.children[1]).toHaveLength(1);
             expect(sec.children[1][0].id).toBe(rootBlock.id);
+        }
+    });
+});
+
+describe('column index validation', () => {
+    it('addBlock rejects out-of-range columnIndex for "1" layout section', () => {
+        const content = createDefaultTemplateContent();
+        const section = createSectionBlock({ columns: '1', children: [[]] });
+        content.blocks = [section];
+        const editor = useEditor({ content });
+
+        const added = createParagraphBlock({ content: '<p>X</p>' });
+        editor.addBlock(added, section.id, 5);
+
+        const sec = editor.state.content.blocks[0];
+        expect(sec.type).toBe('section');
+        if (sec.type === 'section') {
+            expect(sec.children.length).toBe(1);
+        }
+    });
+
+    it('addBlock rejects out-of-range columnIndex for "2" layout section', () => {
+        const content = createDefaultTemplateContent();
+        const section = createSectionBlock({ columns: '2', children: [[], []] });
+        content.blocks = [section];
+        const editor = useEditor({ content });
+
+        const added = createParagraphBlock({ content: '<p>X</p>' });
+        editor.addBlock(added, section.id, 2);
+
+        const sec = editor.state.content.blocks[0];
+        if (sec.type === 'section') {
+            expect(sec.children.length).toBe(2);
+            expect(sec.children[0]).toHaveLength(0);
+            expect(sec.children[1]).toHaveLength(0);
+        }
+    });
+
+    it('addBlock accepts max valid columnIndex for "3" layout section', () => {
+        const content = createDefaultTemplateContent();
+        const section = createSectionBlock({
+            columns: '3',
+            children: [[], [], []],
+        });
+        content.blocks = [section];
+        const editor = useEditor({ content });
+
+        const added = createParagraphBlock({ content: '<p>X</p>' });
+        editor.addBlock(added, section.id, 2);
+
+        const sec = editor.state.content.blocks[0];
+        if (sec.type === 'section') {
+            expect(sec.children[2]).toHaveLength(1);
+            expect(sec.children[2][0].id).toBe(added.id);
+        }
+    });
+
+    it('addBlock accepts columnIndex 1 for "2-1" layout section', () => {
+        const content = createDefaultTemplateContent();
+        const section = createSectionBlock({
+            columns: '2-1',
+            children: [[], []],
+        });
+        content.blocks = [section];
+        const editor = useEditor({ content });
+
+        const added = createParagraphBlock({ content: '<p>X</p>' });
+        editor.addBlock(added, section.id, 1);
+
+        const sec = editor.state.content.blocks[0];
+        if (sec.type === 'section') {
+            expect(sec.children.length).toBe(2);
+            expect(sec.children[1]).toHaveLength(1);
+        }
+    });
+
+    it('moveBlock rejects out-of-range columnIndex and leaves source intact', () => {
+        const content = createDefaultTemplateContent();
+        const rootBlock = createParagraphBlock({ content: '<p>Root</p>' });
+        const section = createSectionBlock({ columns: '2', children: [[], []] });
+        content.blocks = [rootBlock, section];
+        const editor = useEditor({ content });
+
+        editor.moveBlock(rootBlock.id, 0, section.id, 7);
+
+        expect(editor.state.content.blocks).toHaveLength(2);
+        expect(editor.state.content.blocks[0].id).toBe(rootBlock.id);
+        const sec = editor.state.content.blocks[1];
+        if (sec.type === 'section') {
+            expect(sec.children.length).toBe(2);
+            expect(sec.children[0]).toHaveLength(0);
+            expect(sec.children[1]).toHaveLength(0);
         }
     });
 });

--- a/packages/editor/src/Editor.vue
+++ b/packages/editor/src/Editor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from "vue";
+import { onMounted, onUnmounted, ref } from "vue";
 import type { TemplaticalEditorConfig } from "./index";
 import { useEditor } from "@templatical/core";
 import type { TemplateContent, UiTheme } from "@templatical/types";
@@ -37,9 +37,14 @@ const editor = useEditor({
   templateDefaults: props.config.templateDefaults,
 });
 
+// Outer `.tpl` ref — passed to `useEditorCore` so the active-editor
+// tracker can route keyboard shortcuts when two editors share a page.
+const rootEl = ref<HTMLElement | null>(null);
+
 // --- Shared editor core (composables, provides, plugins, keyboard) ---
 const core = useEditorCore({
   editor,
+  containerEl: rootEl,
   config: {
     uiTheme: props.config.uiTheme,
     theme: props.config.theme,
@@ -88,6 +93,7 @@ defineExpose({
 
 <template>
   <div
+    ref="rootEl"
     class="tpl tpl:relative tpl:h-full tpl:overflow-hidden"
     :class="{ 'tpl:dark': editor.state.darkMode }"
     :data-tpl-theme="core.resolvedTheme.value"

--- a/packages/editor/src/cloud/CloudEditor.vue
+++ b/packages/editor/src/cloud/CloudEditor.vue
@@ -53,6 +53,10 @@ const cloudPanelsRef = ref<{
   filterCommentsByBlock: (blockId: string) => void;
 } | null>(null);
 
+// Outer `.tpl` ref forwarded to `useEditorCore` (via `useCloudInitialization`)
+// for multi-editor keyboard routing.
+const rootEl = ref<HTMLElement | null>(null);
+
 const init = useCloudInitialization({
   config: props.config,
   translations: props.translations,
@@ -63,6 +67,7 @@ const init = useCloudInitialization({
       ? { filterByBlock: cloudPanelsRef.value.filterCommentsByBlock }
       : null,
   editorRoot: props.shadowRoot,
+  containerEl: rootEl,
 });
 
 // Destructure heavily-used members for template readability.
@@ -183,6 +188,7 @@ defineExpose({
 
 <template>
   <div
+    ref="rootEl"
     class="tpl tpl:relative tpl:h-full tpl:overflow-hidden"
     :class="{ 'tpl:dark': editor.state.darkMode }"
     :data-tpl-theme="core.resolvedTheme.value"

--- a/packages/editor/src/cloud/composables/useCloudInitialization.ts
+++ b/packages/editor/src/cloud/composables/useCloudInitialization.ts
@@ -98,6 +98,11 @@ export interface UseCloudInitializationOptions {
    * cloud editor is mounted inside a shadow root (`shadowDom: true`).
    */
   editorRoot?: Document | ShadowRoot;
+  /**
+   * Outer `.tpl` container ref forwarded to `useEditorCore` for
+   * multi-editor keyboard routing.
+   */
+  containerEl?: Ref<HTMLElement | null>;
 }
 
 export interface UseCloudInitializationReturn {
@@ -303,6 +308,7 @@ export function useCloudInitialization(
       onBeforeUndo: () => collabWarningRef?.showCollabUndoWarning(),
     },
     editorRoot: options.editorRoot,
+    containerEl: options.containerEl,
   });
 
   // --- 7. Collab undo warning ---

--- a/packages/editor/src/components/blocks/ImageBlock.vue
+++ b/packages/editor/src/components/blocks/ImageBlock.vue
@@ -9,6 +9,7 @@ import { containsMergeTag } from "@templatical/types";
 import { Image } from "@lucide/vue";
 import { computed, inject } from "vue";
 import { ON_REQUEST_MEDIA_KEY } from "../../keys";
+import { useAliveFlag } from "../../composables/useAliveFlag";
 
 const props = defineProps<{
   block: ImageBlockType;
@@ -23,9 +24,11 @@ const { t } = useI18n();
 const { syntax } = useMergeTag();
 const onRequestMedia = inject(ON_REQUEST_MEDIA_KEY, null);
 const canBrowseMedia = computed(() => !!onRequestMedia);
+const aliveFlag = useAliveFlag();
 
 async function browseMedia(): Promise<void> {
   const result = await onRequestMedia?.({ accept: ["images"] });
+  if (!aliveFlag.alive) return;
   if (result) {
     const updates: Partial<ImageBlockType> = { src: result.url };
     if (result.alt) updates.alt = result.alt;

--- a/packages/editor/src/components/toolbar/ImageToolbar.vue
+++ b/packages/editor/src/components/toolbar/ImageToolbar.vue
@@ -8,6 +8,7 @@ import { containsMergeTag, SYNTAX_PRESETS } from "@templatical/types";
 import { Image } from "@lucide/vue";
 import { computed, inject, ref } from "vue";
 import { ON_REQUEST_MEDIA_KEY, MERGE_TAG_SYNTAX_KEY } from "../../keys";
+import { useAliveFlag } from "../../composables/useAliveFlag";
 import { useTimeoutFn } from "@vueuse/core";
 
 defineProps<{
@@ -21,6 +22,7 @@ const emit = defineEmits<{
 const { t } = useI18n();
 const onRequestMedia = inject(ON_REQUEST_MEDIA_KEY, null);
 const mergeTagSyntax = inject(MERGE_TAG_SYNTAX_KEY, SYNTAX_PRESETS.liquid);
+const aliveFlag = useAliveFlag();
 
 const canBrowseMedia = computed(() => !!onRequestMedia);
 
@@ -41,6 +43,7 @@ function updateField(field: string, value: unknown): void {
 
 async function openMediaBrowser(): Promise<void> {
   const result = await onRequestMedia?.({ accept: ["images"] });
+  if (!aliveFlag.alive) return;
   if (result) {
     updateField("src", result.url);
     if (result.alt) {

--- a/packages/editor/src/components/toolbar/VideoToolbar.vue
+++ b/packages/editor/src/components/toolbar/VideoToolbar.vue
@@ -8,6 +8,7 @@ import { containsMergeTag, SYNTAX_PRESETS } from "@templatical/types";
 import { Image } from "@lucide/vue";
 import { computed, inject, ref } from "vue";
 import { ON_REQUEST_MEDIA_KEY, MERGE_TAG_SYNTAX_KEY } from "../../keys";
+import { useAliveFlag } from "../../composables/useAliveFlag";
 import { useTimeoutFn } from "@vueuse/core";
 
 const props = defineProps<{
@@ -21,6 +22,7 @@ const emit = defineEmits<{
 const { t } = useI18n();
 const onRequestMedia = inject(ON_REQUEST_MEDIA_KEY, null);
 const mergeTagSyntax = inject(MERGE_TAG_SYNTAX_KEY, SYNTAX_PRESETS.liquid);
+const aliveFlag = useAliveFlag();
 
 const canBrowseMedia = computed(() => !!onRequestMedia);
 const urlHasMergeTag = computed(() =>
@@ -42,6 +44,7 @@ function updateField(field: keyof VideoBlock, value: unknown): void {
 
 async function openMediaBrowser(): Promise<void> {
   const result = await onRequestMedia?.({ accept: ["images"] });
+  if (!aliveFlag.alive) return;
   if (result) {
     updateField("thumbnailUrl", result.url);
     pulseThumbnail.value = true;

--- a/packages/editor/src/components/toolbar/fields/ImageField.vue
+++ b/packages/editor/src/components/toolbar/fields/ImageField.vue
@@ -5,6 +5,7 @@ import { inputClass } from "../../../constants/styleConstants";
 import { Image } from "@lucide/vue";
 import { computed, inject } from "vue";
 import { ON_REQUEST_MEDIA_KEY } from "../../../keys";
+import { useAliveFlag } from "../../../composables/useAliveFlag";
 import FieldWrapper from "./FieldWrapper.vue";
 
 defineProps<{
@@ -19,11 +20,13 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 const onRequestMedia = inject(ON_REQUEST_MEDIA_KEY, null);
+const aliveFlag = useAliveFlag();
 
 const canBrowseMedia = computed(() => !!onRequestMedia);
 
 async function browseMedia(): Promise<void> {
   const result = await onRequestMedia?.({ accept: ["images"] });
+  if (!aliveFlag.alive) return;
   if (result) {
     emit("update:modelValue", result.url);
   }

--- a/packages/editor/src/composables/useEditableTextBlock.ts
+++ b/packages/editor/src/composables/useEditableTextBlock.ts
@@ -6,6 +6,7 @@ import { useElementBounding } from "@vueuse/core";
 import { computed, inject, ref, type ComputedRef, type Ref } from "vue";
 import { MERGE_TAGS_KEY } from "../keys";
 import { useMergeTag } from "./useMergeTag";
+import { sanitizeRichTextHtml } from "../utils/sanitizeRichTextHtml";
 
 export interface UseEditableTextBlockReturn {
   isEditing: Ref<boolean>;
@@ -22,10 +23,17 @@ export function useEditableTextBlock(
   const mergeTags = inject(MERGE_TAGS_KEY, []);
   const { syntax } = useMergeTag();
 
+  // Sanitize before binding to `v-html`. TipTap-authored content is
+  // already safe, but template JSON loaded from a consumer can carry
+  // arbitrary HTML — including `<script>`, `<img onerror>`, or
+  // `javascript:` anchors that would otherwise execute when the block
+  // renders in the canvas.
   const resolvedContent = computed(() =>
-    resolveHtmlLogicMergeTagLabels(
-      resolveHtmlMergeTagLabels(blockContent(), mergeTags),
-      syntax,
+    sanitizeRichTextHtml(
+      resolveHtmlLogicMergeTagLabels(
+        resolveHtmlMergeTagLabels(blockContent(), mergeTags),
+        syntax,
+      ),
     ),
   );
 

--- a/packages/editor/src/composables/useEditorCore.ts
+++ b/packages/editor/src/composables/useEditorCore.ts
@@ -1,5 +1,7 @@
 import {
   computed,
+  getCurrentScope,
+  onScopeDispose,
   provide,
   ref,
   watch,
@@ -9,6 +11,7 @@ import {
   type Ref,
 } from "vue";
 import { useEventListener } from "@vueuse/core";
+import { registerEditorInstance } from "../utils/activeEditorTracker";
 import {
   useHistory,
   useHistoryInterceptor,
@@ -214,6 +217,16 @@ export interface UseEditorCoreOptions {
    * `document` if omitted — preserves current light-DOM behavior.
    */
   editorRoot?: Document | ShadowRoot;
+
+  /**
+   * Ref pointing at this editor's outer `.tpl` container. When two editors
+   * mount on the same page, the document-level keydown listener installed
+   * by each `useEditorCore` would otherwise fire on every instance. Passing
+   * the container ref lets the active-editor tracker route a keystroke to
+   * the instance the user most recently interacted with. Omit for
+   * single-editor pages — single-instance mode skips the routing check.
+   */
+  containerEl?: Ref<HTMLElement | null>;
 }
 
 export interface UseEditorCoreReturn {
@@ -326,7 +339,34 @@ export function useEditorCore(
   }
 
   // --- Keyboard shortcuts ---
+  // Register this editor with the page-wide active-instance tracker. On
+  // single-editor pages `isActive()` is always true. With two editors
+  // mounted, `claim()` runs on pointerdown inside this editor's
+  // container, and `handleKeyboard` only forwards when this is the
+  // active instance — otherwise a single Cmd+Z would fire both editors'
+  // undo handlers.
+  const instanceHandle = registerEditorInstance();
+  if (getCurrentScope()) {
+    onScopeDispose(instanceHandle.dispose);
+  }
+
+  if (options.containerEl) {
+    const containerEl = options.containerEl;
+    useEventListener(
+      document,
+      "pointerdown",
+      (e: PointerEvent) => {
+        const target = containerEl.value;
+        if (!target) return;
+        const path = e.composedPath?.() ?? [];
+        if (path.includes(target)) instanceHandle.claim();
+      },
+      { capture: true },
+    );
+  }
+
   function handleKeyboard(e: KeyboardEvent): void {
+    if (!instanceHandle.isActive()) return;
     handleEditorKeydown(e, {
       history,
       selectBlock: (id) => editor.selectBlock(id),
@@ -343,9 +383,8 @@ export function useEditorCore(
   // active element stays on `document.body` — a subsequent keystroke
   // never reaches the shadow root, only `document`. Listening at
   // `document` keeps Escape / Cmd+Z / Delete shortcuts working in both
-  // modes; multi-instance scoping (a future concern) will need to
-  // disambiguate per-editor at the handler level rather than via
-  // listener target.
+  // modes; multi-editor disambiguation is handled inside the listener
+  // via `activeEditorTracker`.
   useEventListener(document, "keydown", handleKeyboard);
 
   // --- Popover mount ---

--- a/packages/editor/src/composables/useFonts.ts
+++ b/packages/editor/src/composables/useFonts.ts
@@ -149,10 +149,11 @@ export function useFonts(config?: FontsConfig): UseFontsReturn {
   }
 
   const createdLinks: HTMLLinkElement[] = [];
+  let disposed = false;
 
   async function loadCustomFonts(): Promise<void> {
     if (customFonts.value.length === 0) {
-      isLoaded.value = true;
+      if (!disposed) isLoaded.value = true;
       return;
     }
 
@@ -188,6 +189,7 @@ export function useFonts(config?: FontsConfig): UseFontsReturn {
     });
 
     await Promise.allSettled(loadPromises);
+    if (disposed) return;
     isLoaded.value = true;
   }
 
@@ -199,7 +201,10 @@ export function useFonts(config?: FontsConfig): UseFontsReturn {
   }
 
   if (getCurrentScope()) {
-    onScopeDispose(cleanupFontLinks);
+    onScopeDispose(() => {
+      disposed = true;
+      cleanupFontLinks();
+    });
   }
 
   return {

--- a/packages/editor/src/composables/useMergeTagField.ts
+++ b/packages/editor/src/composables/useMergeTagField.ts
@@ -2,7 +2,15 @@ import {
   getLogicMergeTagKeyword,
   isLogicMergeTagValue,
 } from "@templatical/types";
-import { computed, nextTick, ref, type ComputedRef, type Ref } from "vue";
+import {
+  computed,
+  getCurrentScope,
+  nextTick,
+  onScopeDispose,
+  ref,
+  type ComputedRef,
+  type Ref,
+} from "vue";
 import { useMergeTag } from "./useMergeTag";
 
 export type MergeTagSegment =
@@ -45,6 +53,12 @@ export function useMergeTagField(
 
   const isEditing = ref(false);
   let insertingMergeTag = false;
+  let disposed = false;
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      disposed = true;
+    });
+  }
 
   const segments = computed((): MergeTagSegment[] => {
     const val = modelValue();
@@ -133,6 +147,8 @@ export function useMergeTagField(
       insertingMergeTag = false;
     }
 
+    if (disposed) return;
+
     if (mergeTag) {
       const before = modelValue().slice(0, cursorPos);
       const after = modelValue().slice(cursorPos);
@@ -141,6 +157,7 @@ export function useMergeTagField(
 
       isEditing.value = true;
       nextTick(() => {
+        if (disposed) return;
         const newPos = cursorPos + mergeTag.value.length;
         elementRef.value?.focus();
         elementRef.value?.setSelectionRange(newPos, newPos);

--- a/packages/editor/src/composables/useRichTextLinkDialog.ts
+++ b/packages/editor/src/composables/useRichTextLinkDialog.ts
@@ -30,24 +30,42 @@ export function useRichTextLinkDialog(
   function insertLink(): void {
     if (linkUrl.value) {
       const url = normalizeLinkUrl(linkUrl.value);
-      editor.value
-        ?.chain()
-        .focus()
-        .extendMarkRange("link")
-        .setLink({ href: url })
-        .run();
+      if (url !== null) {
+        editor.value
+          ?.chain()
+          .focus()
+          .extendMarkRange("link")
+          .setLink({ href: url })
+          .run();
+      }
     }
     closeLinkDialog();
   }
 
-  function normalizeLinkUrl(raw: string): string {
-    // Preserve any URL that already declares a scheme (mailto:, tel:, ftp:,
-    // http(s):, etc.) and any same-page anchor (#…). Only bare hostnames /
-    // paths get the https:// prefix.
-    if (/^[a-z][a-z0-9+.-]*:/i.test(raw) || raw.startsWith("#")) {
-      return raw;
+  // Allowlist mirroring @tiptap/extension-link defaults so URLs persisted
+  // via the dialog can't smuggle in javascript:/data:/vbscript: payloads
+  // that bypass TipTap's apply-time filter on JSON load.
+  const SAFE_SCHEMES = new Set([
+    "http",
+    "https",
+    "mailto",
+    "tel",
+    "ftp",
+    "ftps",
+    "sms",
+    "xmpp",
+    "cid",
+  ]);
+
+  function normalizeLinkUrl(raw: string): string | null {
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    if (trimmed.startsWith("#")) return trimmed;
+    const schemeMatch = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed);
+    if (schemeMatch) {
+      return SAFE_SCHEMES.has(schemeMatch[1].toLowerCase()) ? trimmed : null;
     }
-    return `https://${raw}`;
+    return `https://${trimmed}`;
   }
 
   function removeLink(): void {

--- a/packages/editor/src/extensions/MergeTagSuggestion.ts
+++ b/packages/editor/src/extensions/MergeTagSuggestion.ts
@@ -140,6 +140,7 @@ export const MergeTagSuggestion = Extension.create<MergeTagSuggestionOptions>({
         const listId = `tpl-merge-tag-suggestion-${++POPUP_ID_SEQ}`;
         let latestClientRect: (() => DOMRect | null) | null = null;
         let scrollTargets: Array<EventTarget> = [];
+        let pendingRaf: number | null = null;
 
         function reposition(): void {
           position(latestClientRect?.() ?? null);
@@ -157,7 +158,11 @@ export const MergeTagSuggestion = Extension.create<MergeTagSuggestionOptions>({
          */
         function repositionAfterPaint(): void {
           reposition();
-          requestAnimationFrame(reposition);
+          if (pendingRaf !== null) cancelAnimationFrame(pendingRaf);
+          pendingRaf = requestAnimationFrame(() => {
+            pendingRaf = null;
+            reposition();
+          });
         }
 
         function collectScrollAncestors(el: HTMLElement | null): HTMLElement[] {
@@ -373,6 +378,10 @@ export const MergeTagSuggestion = Extension.create<MergeTagSuggestionOptions>({
             return handled;
           },
           onExit: () => {
+            if (pendingRaf !== null) {
+              cancelAnimationFrame(pendingRaf);
+              pendingRaf = null;
+            }
             detachScrollListeners();
             setEditableAria(false);
             app?.unmount();

--- a/packages/editor/src/utils/activeEditorTracker.ts
+++ b/packages/editor/src/utils/activeEditorTracker.ts
@@ -1,0 +1,51 @@
+/**
+ * Module-level registry of editor instances mounted on the page. When
+ * two or more editors mount concurrently, the global `document` keydown
+ * listener registered by each `useEditorCore` would otherwise fire on
+ * every instance for a single keystroke (double undo, double save).
+ * The tracker routes shortcuts to a single active instance based on the
+ * user's most recent pointer interaction.
+ *
+ * Single-instance pages keep the original behavior (always active).
+ */
+
+const instances = new Set<number>();
+let lastActiveId = 0;
+let counter = 0;
+
+export interface EditorInstanceHandle {
+  id: number;
+  /** True when this instance should handle global keyboard shortcuts. */
+  isActive: () => boolean;
+  /** Mark this instance as active (typically on user pointer interaction). */
+  claim: () => void;
+  /** Remove this instance from the registry on unmount. */
+  dispose: () => void;
+}
+
+export function registerEditorInstance(): EditorInstanceHandle {
+  const id = ++counter;
+  instances.add(id);
+  if (lastActiveId === 0) lastActiveId = id;
+  return {
+    id,
+    isActive: () => instances.size <= 1 || lastActiveId === id,
+    claim: () => {
+      lastActiveId = id;
+    },
+    dispose: () => {
+      instances.delete(id);
+      if (lastActiveId === id) {
+        const remaining = Array.from(instances);
+        lastActiveId = remaining[remaining.length - 1] ?? 0;
+      }
+    },
+  };
+}
+
+/** Test-only: reset module state between tests. */
+export function _resetActiveEditorTrackerForTests(): void {
+  instances.clear();
+  lastActiveId = 0;
+  counter = 0;
+}

--- a/packages/editor/src/utils/sanitizeRichTextHtml.ts
+++ b/packages/editor/src/utils/sanitizeRichTextHtml.ts
@@ -1,0 +1,113 @@
+/**
+ * Strip XSS vectors from a rich-text HTML fragment before `v-html`-ing
+ * it into the canvas. TipTap-authored content is already safe; the
+ * attack surface is template JSON loaded by the consumer, where a
+ * malicious or compromised source can inject `<script>`, `<img
+ * onerror>`, or `javascript:` anchors.
+ *
+ * Strips:
+ *   - dangerous elements (script, style, iframe, object, embed, link, meta, base)
+ *   - every event handler attribute (`on*`)
+ *   - `href` / `xlink:href` / `formaction` / `action` values with disallowed schemes
+ *   - `src` values with disallowed schemes (except `data:image/...`)
+ *   - non-image `data:` URLs and any `javascript:` / `vbscript:` / `file:` URL
+ *
+ * Allowed URL schemes mirror the link-dialog allowlist. Uses the platform
+ * `DOMParser`; falls back to returning the input unchanged in environments
+ * without one (server-side renderers should never reach this code path,
+ * but we don't want to crash if they do).
+ */
+
+const SAFE_URL_SCHEMES = new Set([
+  "http",
+  "https",
+  "mailto",
+  "tel",
+  "ftp",
+  "ftps",
+  "sms",
+  "xmpp",
+  "cid",
+]);
+
+const FORBIDDEN_ELEMENTS = new Set([
+  "SCRIPT",
+  "STYLE",
+  "IFRAME",
+  "OBJECT",
+  "EMBED",
+  "LINK",
+  "META",
+  "BASE",
+  "FORM",
+]);
+
+const URL_ATTRIBUTES = new Set([
+  "href",
+  "xlink:href",
+  "formaction",
+  "action",
+  "ping",
+  "background",
+  "poster",
+]);
+
+function isSafeUrl(value: string, allowDataImage: boolean): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  if (trimmed.startsWith("#")) return true;
+  const schemeMatch = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed);
+  if (!schemeMatch) return true;
+  const scheme = schemeMatch[1].toLowerCase();
+  if (SAFE_URL_SCHEMES.has(scheme)) return true;
+  if (allowDataImage && scheme === "data") {
+    return /^data:image\/(png|jpe?g|gif|webp|svg\+xml);/i.test(trimmed);
+  }
+  return false;
+}
+
+function scrubElement(el: Element): void {
+  if (FORBIDDEN_ELEMENTS.has(el.tagName)) {
+    el.remove();
+    return;
+  }
+  // Snapshot attribute names — removing during iteration breaks the live list.
+  const attrNames: string[] = [];
+  for (let i = 0; i < el.attributes.length; i++) {
+    attrNames.push(el.attributes[i].name);
+  }
+  for (const name of attrNames) {
+    const lower = name.toLowerCase();
+    if (lower.startsWith("on")) {
+      el.removeAttribute(name);
+      continue;
+    }
+    if (URL_ATTRIBUTES.has(lower)) {
+      const value = el.getAttribute(name) ?? "";
+      if (!isSafeUrl(value, false)) el.removeAttribute(name);
+      continue;
+    }
+    if (lower === "src") {
+      const value = el.getAttribute(name) ?? "";
+      if (!isSafeUrl(value, true)) el.removeAttribute(name);
+      continue;
+    }
+    if (lower === "srcdoc") {
+      el.removeAttribute(name);
+    }
+  }
+  const children = Array.from(el.children);
+  for (const child of children) scrubElement(child);
+}
+
+export function sanitizeRichTextHtml(html: string): string {
+  if (typeof DOMParser === "undefined") return html;
+  const doc = new DOMParser().parseFromString(
+    `<!doctype html><body>${html}</body>`,
+    "text/html",
+  );
+  const body = doc.body;
+  const children = Array.from(body.children);
+  for (const child of children) scrubElement(child);
+  return body.innerHTML;
+}

--- a/packages/editor/tests/activeEditorTracker.test.ts
+++ b/packages/editor/tests/activeEditorTracker.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetActiveEditorTrackerForTests,
+  registerEditorInstance,
+} from "../src/utils/activeEditorTracker";
+
+describe("activeEditorTracker", () => {
+  beforeEach(() => {
+    _resetActiveEditorTrackerForTests();
+  });
+
+  it("single instance is always active", () => {
+    const instance = registerEditorInstance();
+    expect(instance.isActive()).toBe(true);
+  });
+
+  it("first-registered instance is active before any claim", () => {
+    const first = registerEditorInstance();
+    const second = registerEditorInstance();
+    expect(first.isActive()).toBe(true);
+    expect(second.isActive()).toBe(false);
+  });
+
+  it("claim swaps active instance", () => {
+    const first = registerEditorInstance();
+    const second = registerEditorInstance();
+    second.claim();
+    expect(first.isActive()).toBe(false);
+    expect(second.isActive()).toBe(true);
+  });
+
+  it("disposing the active instance falls back to remaining instance", () => {
+    const first = registerEditorInstance();
+    const second = registerEditorInstance();
+    second.claim();
+    second.dispose();
+    expect(first.isActive()).toBe(true);
+  });
+
+  it("disposing a non-active instance does not change active", () => {
+    const first = registerEditorInstance();
+    const second = registerEditorInstance();
+    second.dispose();
+    expect(first.isActive()).toBe(true);
+  });
+
+  it("returns to single-instance always-active behavior after one disposes", () => {
+    const first = registerEditorInstance();
+    const second = registerEditorInstance();
+    second.dispose();
+    expect(first.isActive()).toBe(true);
+    // No second instance remains — first is sole owner.
+    expect(first.id).toBe(1);
+  });
+
+  it("instances get unique sequential IDs", () => {
+    const a = registerEditorInstance();
+    const b = registerEditorInstance();
+    const c = registerEditorInstance();
+    expect(a.id).toBe(1);
+    expect(b.id).toBe(2);
+    expect(c.id).toBe(3);
+  });
+});

--- a/packages/editor/tests/blockHtmlSanitization.test.ts
+++ b/packages/editor/tests/blockHtmlSanitization.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { SYNTAX_PRESETS } from "@templatical/types";
+import enTranslations from "../src/i18n/locales/en";
+import {
+  MERGE_TAGS_KEY,
+  MERGE_TAG_SYNTAX_KEY,
+  TRANSLATIONS_KEY,
+} from "../src/keys";
+import ParagraphBlock from "../src/components/blocks/ParagraphBlock.vue";
+import TitleBlock from "../src/components/blocks/TitleBlock.vue";
+
+function baseProvide() {
+  return {
+    [TRANSLATIONS_KEY as symbol]: enTranslations,
+    [MERGE_TAG_SYNTAX_KEY as symbol]: SYNTAX_PRESETS.liquid,
+    [MERGE_TAGS_KEY as symbol]: [],
+  };
+}
+
+describe("rich-text block HTML sanitization", () => {
+  it("ParagraphBlock strips inline event handlers from block.content", () => {
+    const wrapper = mount(ParagraphBlock, {
+      props: {
+        block: {
+          id: "p-1",
+          type: "paragraph",
+          content: '<p>hi <img src="x.png" onerror="window.__pwn = 1"></p>',
+          styles: {},
+        } as any,
+        viewport: "desktop",
+      },
+      global: { provide: baseProvide() },
+    });
+
+    const html = wrapper.html();
+    expect(html).not.toContain("onerror");
+    expect(html).not.toContain("__pwn");
+    expect(html).toContain("hi");
+  });
+
+  it("ParagraphBlock strips <script> from block.content", () => {
+    const wrapper = mount(ParagraphBlock, {
+      props: {
+        block: {
+          id: "p-1",
+          type: "paragraph",
+          content:
+            '<p>before</p><script>window.__pwn = 1</script><p>after</p>',
+          styles: {},
+        } as any,
+        viewport: "desktop",
+      },
+      global: { provide: baseProvide() },
+    });
+
+    const html = wrapper.html();
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("__pwn");
+    expect(html).toContain("before");
+    expect(html).toContain("after");
+  });
+
+  it("ParagraphBlock removes javascript: anchor hrefs from block.content", () => {
+    const wrapper = mount(ParagraphBlock, {
+      props: {
+        block: {
+          id: "p-1",
+          type: "paragraph",
+          content: '<p><a href="javascript:alert(1)">click</a></p>',
+          styles: {},
+        } as any,
+        viewport: "desktop",
+      },
+      global: { provide: baseProvide() },
+    });
+
+    const html = wrapper.html();
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain("click");
+  });
+
+  it("ParagraphBlock preserves safe HTML (bold, italic, https links)", () => {
+    const wrapper = mount(ParagraphBlock, {
+      props: {
+        block: {
+          id: "p-1",
+          type: "paragraph",
+          content:
+            '<p><strong>bold</strong> <em>italic</em> <a href="https://example.com">link</a></p>',
+          styles: {},
+        } as any,
+        viewport: "desktop",
+      },
+      global: { provide: baseProvide() },
+    });
+
+    const html = wrapper.html();
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<em>italic</em>");
+    expect(html).toContain('href="https://example.com"');
+  });
+
+  it("TitleBlock strips inline event handlers from block.content", () => {
+    const wrapper = mount(TitleBlock, {
+      props: {
+        block: {
+          id: "t-1",
+          type: "title",
+          content: '<p>Hello <span onmouseover="window.__pwn = 1">world</span></p>',
+          level: 1,
+          styles: {},
+        } as any,
+        viewport: "desktop",
+      },
+      global: { provide: baseProvide() },
+    });
+
+    const html = wrapper.html();
+    expect(html).not.toContain("onmouseover");
+    expect(html).not.toContain("__pwn");
+    expect(html).toContain("Hello");
+    expect(html).toContain("world");
+  });
+
+  it("TitleBlock removes javascript: anchor hrefs", () => {
+    const wrapper = mount(TitleBlock, {
+      props: {
+        block: {
+          id: "t-1",
+          type: "title",
+          content: '<p><a href="javascript:alert(1)">x</a></p>',
+          level: 2,
+          styles: {},
+        } as any,
+        viewport: "desktop",
+      },
+      global: { provide: baseProvide() },
+    });
+
+    const html = wrapper.html();
+    expect(html).not.toContain("javascript:");
+  });
+});

--- a/packages/editor/tests/mediaPickerAliveGuard.test.ts
+++ b/packages/editor/tests/mediaPickerAliveGuard.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import { mount } from "@vue/test-utils";
+import { SYNTAX_PRESETS } from "@templatical/types";
+import enTranslations from "../src/i18n/locales/en";
+import {
+  MERGE_TAGS_KEY,
+  MERGE_TAG_SYNTAX_KEY,
+  ON_REQUEST_MEDIA_KEY,
+  TRANSLATIONS_KEY,
+} from "../src/keys";
+import ImageBlock from "../src/components/blocks/ImageBlock.vue";
+import ImageToolbar from "../src/components/toolbar/ImageToolbar.vue";
+import VideoToolbar from "../src/components/toolbar/VideoToolbar.vue";
+import ImageField from "../src/components/toolbar/fields/ImageField.vue";
+
+interface MediaResolver {
+  resolveWithObservable: () => { urlReadAfterResolve: () => boolean };
+}
+
+/**
+ * Builds an `onRequestMedia` stub that returns a controllable Promise.
+ * Resolving it provides a media object whose `url` getter sets a flag —
+ * this lets the test observe whether the caller's post-`await` branch
+ * runs (Vue silently no-ops `emit` on an unmounted instance, so checking
+ * `wrapper.emitted()` would mask the bug).
+ */
+function setupOnRequestMedia(): {
+  fn: ReturnType<typeof vi.fn>;
+  next: () => MediaResolver;
+} {
+  const queue: Array<(value: { url: string; alt?: string } | null) => void> = [];
+  const fn = vi.fn(
+    () =>
+      new Promise<{ url: string; alt?: string } | null>((resolve) => {
+        queue.push(resolve);
+      }),
+  );
+  return {
+    fn,
+    next: () => {
+      const resolve = queue.shift();
+      if (!resolve) throw new Error("no pending media request");
+      return {
+        resolveWithObservable: () => {
+          let urlRead = false;
+          const result = {
+            get url() {
+              urlRead = true;
+              return "after-unmount.png";
+            },
+            alt: "Late",
+          };
+          resolve(result);
+          return { urlReadAfterResolve: () => urlRead };
+        },
+      };
+    },
+  };
+}
+
+function baseProvide(onRequestMedia: unknown) {
+  return {
+    [ON_REQUEST_MEDIA_KEY as symbol]: onRequestMedia,
+    [TRANSLATIONS_KEY as symbol]: enTranslations,
+    [MERGE_TAG_SYNTAX_KEY as symbol]: SYNTAX_PRESETS.liquid,
+    [MERGE_TAGS_KEY as symbol]: [],
+  };
+}
+
+describe("media picker alive guard", () => {
+  it("ImageBlock does not emit update after the component unmounts", async () => {
+    const media = setupOnRequestMedia();
+    const wrapper = mount(ImageBlock, {
+      props: {
+        block: {
+          id: "img-1",
+          type: "image",
+          src: "",
+          alt: "",
+          width: "full",
+          align: "center",
+          linkUrl: "",
+          placeholderUrl: "",
+          styles: {},
+        } as any,
+        viewport: "desktop",
+      },
+      global: {
+        provide: baseProvide(media.fn),
+      },
+    });
+
+    const button = wrapper.find("button");
+    expect(button.exists()).toBe(true);
+    await button.trigger("click");
+    expect(media.fn).toHaveBeenCalled();
+
+    wrapper.unmount();
+    const observable = media.next().resolveWithObservable();
+    await nextTick();
+
+    expect(observable.urlReadAfterResolve()).toBe(false);
+  });
+
+  it("ImageToolbar does not emit update after the component unmounts", async () => {
+    const media = setupOnRequestMedia();
+    const wrapper = mount(ImageToolbar, {
+      props: {
+        block: {
+          id: "img-1",
+          type: "image",
+          src: "https://example.com/initial.png",
+          alt: "",
+          width: "full",
+          align: "center",
+          linkUrl: "",
+          placeholderUrl: "",
+          styles: {},
+        } as any,
+      },
+      global: {
+        provide: baseProvide(media.fn),
+      },
+    });
+
+    const browseButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes(enTranslations.image.browseMedia));
+    expect(browseButton).toBeTruthy();
+    await browseButton!.trigger("click");
+    expect(media.fn).toHaveBeenCalled();
+
+    wrapper.unmount();
+    const observable = media.next().resolveWithObservable();
+    await nextTick();
+
+    expect(observable.urlReadAfterResolve()).toBe(false);
+  });
+
+  it("VideoToolbar does not emit update after the component unmounts", async () => {
+    const media = setupOnRequestMedia();
+    const wrapper = mount(VideoToolbar, {
+      props: {
+        block: {
+          id: "vid-1",
+          type: "video",
+          url: "https://example.com/video.mp4",
+          thumbnailUrl: "",
+          width: "full",
+          align: "center",
+          styles: {},
+        } as any,
+      },
+      global: {
+        provide: baseProvide(media.fn),
+      },
+    });
+
+    const browseButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes(enTranslations.image.browseMedia));
+    expect(browseButton).toBeTruthy();
+    await browseButton!.trigger("click");
+    expect(media.fn).toHaveBeenCalled();
+
+    wrapper.unmount();
+    const observable = media.next().resolveWithObservable();
+    await nextTick();
+
+    expect(observable.urlReadAfterResolve()).toBe(false);
+  });
+
+  it("ImageField does not emit update:modelValue after the component unmounts", async () => {
+    const media = setupOnRequestMedia();
+    const wrapper = mount(ImageField, {
+      props: {
+        field: {
+          key: "hero",
+          type: "image",
+          label: "Hero image",
+        } as any,
+        modelValue: "",
+      },
+      global: {
+        provide: baseProvide(media.fn),
+      },
+    });
+
+    const browseButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes(enTranslations.image.browseMedia));
+    expect(browseButton).toBeTruthy();
+    await browseButton!.trigger("click");
+    expect(media.fn).toHaveBeenCalled();
+
+    wrapper.unmount();
+    const observable = media.next().resolveWithObservable();
+    await nextTick();
+
+    expect(observable.urlReadAfterResolve()).toBe(false);
+  });
+});

--- a/packages/editor/tests/mergeTagSuggestion.test.ts
+++ b/packages/editor/tests/mergeTagSuggestion.test.ts
@@ -230,6 +230,29 @@ describe('MergeTagSuggestion mount target', () => {
     expect(src).toContain('.dom');
     expect(src).not.toContain('editor.options.element');
   });
+
+  // Regression: repositionAfterPaint queues a requestAnimationFrame whose
+  // callback runs after onExit has cleared `container` and `app`. The null
+  // checks inside position() prevent a crash, but the closure still pins
+  // the unmounted Vue app and torn-down DOM nodes for one frame. onExit
+  // must cancel the pending rAF.
+  it('source stores rAF handle and cancels it in onExit', async () => {
+    const fs = await import('node:fs');
+    const src = fs.readFileSync(
+      'src/extensions/MergeTagSuggestion.ts',
+      'utf8',
+    );
+    expect(src).toContain('cancelAnimationFrame');
+    // The cancellation must live inside the onExit handler — not just
+    // anywhere in the file. Slice from onExit to the next `},` at the
+    // same indentation level.
+    const onExitStart = src.indexOf('onExit:');
+    expect(onExitStart).toBeGreaterThan(-1);
+    const onExitEnd = src.indexOf('},', onExitStart);
+    expect(onExitEnd).toBeGreaterThan(onExitStart);
+    const onExitBody = src.slice(onExitStart, onExitEnd);
+    expect(onExitBody).toContain('cancelAnimationFrame');
+  });
 });
 
 describe('MergeTagSuggestion extension ordering in editors', () => {

--- a/packages/editor/tests/sanitizeRichTextHtml.test.ts
+++ b/packages/editor/tests/sanitizeRichTextHtml.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { sanitizeRichTextHtml } from "../src/utils/sanitizeRichTextHtml";
+
+describe("sanitizeRichTextHtml", () => {
+  it("removes inline event handler attributes from arbitrary tags", () => {
+    const result = sanitizeRichTextHtml(
+      '<img src="x.png" onerror="window.__pwn = 1">',
+    );
+    expect(result).not.toContain("onerror");
+    expect(result).toContain('src="x.png"');
+  });
+
+  it("strips <script> elements entirely", () => {
+    const result = sanitizeRichTextHtml(
+      "<p>Hello</p><script>window.__pwn = 1</script><p>World</p>",
+    );
+    expect(result).not.toContain("<script");
+    expect(result).not.toContain("__pwn");
+    expect(result).toContain("Hello");
+    expect(result).toContain("World");
+  });
+
+  it("strips <style> and <iframe>", () => {
+    const result = sanitizeRichTextHtml(
+      "<style>body{display:none}</style><iframe src=\"https://evil.com\"></iframe><p>ok</p>",
+    );
+    expect(result).not.toContain("<style");
+    expect(result).not.toContain("<iframe");
+    expect(result).toContain("<p>ok</p>");
+  });
+
+  it("removes href with javascript: scheme", () => {
+    const result = sanitizeRichTextHtml(
+      '<a href="javascript:alert(1)">click</a>',
+    );
+    expect(result).not.toContain("javascript:");
+    expect(result).toContain("click");
+  });
+
+  it("removes href with vbscript: scheme", () => {
+    const result = sanitizeRichTextHtml(
+      '<a href="vbscript:msgbox(1)">click</a>',
+    );
+    expect(result).not.toContain("vbscript:");
+  });
+
+  it("keeps safe http/https/mailto/tel hrefs intact", () => {
+    expect(sanitizeRichTextHtml('<a href="https://example.com">x</a>')).toContain(
+      'href="https://example.com"',
+    );
+    expect(sanitizeRichTextHtml('<a href="mailto:x@y.com">x</a>')).toContain(
+      'href="mailto:x@y.com"',
+    );
+    expect(sanitizeRichTextHtml('<a href="tel:+1234">x</a>')).toContain(
+      'href="tel:+1234"',
+    );
+  });
+
+  it("keeps anchor (#) hrefs intact", () => {
+    expect(sanitizeRichTextHtml('<a href="#section">x</a>')).toContain(
+      'href="#section"',
+    );
+  });
+
+  it("removes src with javascript: scheme", () => {
+    const result = sanitizeRichTextHtml('<img src="javascript:alert(1)">');
+    expect(result).not.toContain("javascript:");
+  });
+
+  it("removes non-image data: src", () => {
+    const result = sanitizeRichTextHtml(
+      '<img src="data:text/html,<script>alert(1)</script>">',
+    );
+    expect(result).not.toContain("data:text/html");
+  });
+
+  it("keeps data:image/* src intact", () => {
+    const result = sanitizeRichTextHtml(
+      '<img src="data:image/png;base64,iVBORw0KGgo=">',
+    );
+    expect(result).toContain("data:image/png;base64,iVBORw0KGgo=");
+  });
+
+  it("rejects case-bypassed JAVASCRIPT: scheme", () => {
+    const result = sanitizeRichTextHtml('<a href="JaVaScRiPt:alert(1)">x</a>');
+    expect(result).not.toMatch(/JaVaScRiPt/i);
+  });
+
+  it("removes srcdoc attribute (defensive iframe-strip backup)", () => {
+    // <iframe> itself is stripped, but defensive: ensure srcdoc on any
+    // future allowed tag doesn't survive.
+    const result = sanitizeRichTextHtml(
+      '<p srcdoc="<script>alert(1)</script>">x</p>',
+    );
+    expect(result).not.toContain("srcdoc");
+  });
+
+  it("preserves rich-text content the editor itself produces", () => {
+    const editorOutput =
+      '<p><strong>bold</strong> <em>italic</em> <a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a></p>';
+    const result = sanitizeRichTextHtml(editorOutput);
+    expect(result).toContain("<strong>bold</strong>");
+    expect(result).toContain("<em>italic</em>");
+    expect(result).toContain('href="https://example.com"');
+    expect(result).toContain('target="_blank"');
+    expect(result).toContain('rel="noopener noreferrer"');
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(sanitizeRichTextHtml("")).toBe("");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(sanitizeRichTextHtml("just text")).toBe("just text");
+  });
+
+  it("strips event handlers across nested elements", () => {
+    const result = sanitizeRichTextHtml(
+      '<div><span onclick="x"><b onmouseover="y">deep</b></span></div>',
+    );
+    expect(result).not.toContain("onclick");
+    expect(result).not.toContain("onmouseover");
+    expect(result).toContain("deep");
+  });
+});

--- a/packages/editor/tests/useFonts.test.ts
+++ b/packages/editor/tests/useFonts.test.ts
@@ -477,6 +477,37 @@ describe('useFonts', () => {
       );
       warnSpy.mockRestore();
     });
+
+    it('does not set isLoaded when scope is disposed before fonts resolve', async () => {
+      // Capture the appended link without firing onload — caller controls
+      // when the load completes.
+      let appendedLink: any = null;
+      appendChildSpy = vi.fn((child: any) => {
+        appendedLink = child;
+        return child;
+      });
+      (document as any).head.appendChild = appendChildSpy;
+
+      const scope = effectScope();
+      let fonts!: ReturnType<typeof useFonts>;
+      scope.run(() => {
+        fonts = useFonts({
+          customFonts: [
+            { name: 'SlowFont', url: 'https://fonts.com/slow.css' },
+          ],
+        });
+      });
+
+      const loadPromise = fonts.loadCustomFonts();
+      expect(appendedLink).not.toBeNull();
+      expect(fonts.isLoaded.value).toBe(false);
+
+      scope.stop();
+      appendedLink.onload?.();
+      await loadPromise;
+
+      expect(fonts.isLoaded.value).toBe(false);
+    });
   });
 
   describe('cleanupFontLinks', () => {

--- a/packages/editor/tests/useMergeTagField.test.ts
+++ b/packages/editor/tests/useMergeTagField.test.ts
@@ -32,8 +32,33 @@ function withProvide<T>(
     app.provide(sym as InjectionKey<unknown>, provides[sym]);
   }
   app.mount(document.createElement('div'));
-  app.unmount();
+  // App is intentionally left mounted so scope-aware composables
+  // (e.g. ones using `onScopeDispose`) keep their effects live for
+  // the duration of the test. Tests that need disposal mount manually.
   return result!;
+}
+
+// Manual mount/unmount pair used by tests that need to assert
+// post-unmount behavior — call `mountField` to mount, run the
+// scenario, then `app.unmount()` at the precise moment under test.
+function mountField(
+  setup: () => unknown,
+  provides: Record<string | symbol, unknown> = {},
+) {
+  let result: unknown;
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = setup();
+        return () => h('div');
+      },
+    }),
+  );
+  for (const sym of Object.getOwnPropertySymbols(provides)) {
+    app.provide(sym as InjectionKey<unknown>, provides[sym]);
+  }
+  app.mount(document.createElement('div'));
+  return { app, result };
 }
 
 const sampleTags: MergeTag[] = [
@@ -547,6 +572,38 @@ describe('useMergeTagField', () => {
       expect(isEditing.value).toBe(false);
       await insertMergeTag();
       expect(isEditing.value).toBe(true);
+    });
+
+    it('does not emit when component unmounts before request resolves', async () => {
+      const elementRef = createElementRef();
+      const emitFn = vi.fn();
+      let resolveRequest!: (value: MergeTag) => void;
+      const requestCallback = vi.fn(
+        () =>
+          new Promise<MergeTag>((resolve) => {
+            resolveRequest = resolve;
+          }),
+      );
+
+      const { app, result } = mountField(
+        () =>
+          useMergeTagField({
+            modelValue: () => 'Hello ',
+            emit: emitFn,
+            elementRef,
+          }),
+        defaultProvides({
+          [ON_REQUEST_MERGE_TAG_KEY as symbol]: requestCallback,
+        }),
+      );
+      const { insertMergeTag } = result as ReturnType<typeof useMergeTagField>;
+
+      const insertPromise = insertMergeTag();
+      app.unmount();
+      resolveRequest({ label: 'Name', value: '{{name}}' });
+      await insertPromise;
+
+      expect(emitFn).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/editor/tests/useRichTextLinkDialog.test.ts
+++ b/packages/editor/tests/useRichTextLinkDialog.test.ts
@@ -150,6 +150,100 @@ describe("useRichTextLinkDialog", () => {
       expect(editor.value.chain).not.toHaveBeenCalled();
     });
 
+    it("rejects javascript: scheme", () => {
+      const editor = createMockEditor();
+      const result = useRichTextLinkDialog(editor);
+
+      result.linkUrl.value = "javascript:alert(1)";
+      result.showLinkDialog.value = true;
+      result.insertLink();
+
+      const chain = editor.value._chain;
+      expect(chain.setLink).not.toHaveBeenCalled();
+      expect(result.showLinkDialog.value).toBe(false);
+    });
+
+    it("rejects data: scheme", () => {
+      const editor = createMockEditor();
+      const result = useRichTextLinkDialog(editor);
+
+      result.linkUrl.value = "data:text/html,<script>alert(1)</script>";
+      result.insertLink();
+
+      const chain = editor.value._chain;
+      expect(chain.setLink).not.toHaveBeenCalled();
+    });
+
+    it("rejects vbscript: scheme", () => {
+      const editor = createMockEditor();
+      const result = useRichTextLinkDialog(editor);
+
+      result.linkUrl.value = "vbscript:msgbox(1)";
+      result.insertLink();
+
+      const chain = editor.value._chain;
+      expect(chain.setLink).not.toHaveBeenCalled();
+    });
+
+    it("rejects file: scheme", () => {
+      const editor = createMockEditor();
+      const result = useRichTextLinkDialog(editor);
+
+      result.linkUrl.value = "file:///etc/passwd";
+      result.insertLink();
+
+      const chain = editor.value._chain;
+      expect(chain.setLink).not.toHaveBeenCalled();
+    });
+
+    it("rejects case-bypassed JAVASCRIPT: scheme", () => {
+      const editor = createMockEditor();
+      const result = useRichTextLinkDialog(editor);
+
+      result.linkUrl.value = "JaVaScRiPt:alert(1)";
+      result.insertLink();
+
+      const chain = editor.value._chain;
+      expect(chain.setLink).not.toHaveBeenCalled();
+    });
+
+    it("rejects whitespace-padded javascript: scheme", () => {
+      const editor = createMockEditor();
+      const result = useRichTextLinkDialog(editor);
+
+      result.linkUrl.value = "  javascript:alert(1)";
+      result.insertLink();
+
+      const chain = editor.value._chain;
+      expect(chain.setLink).not.toHaveBeenCalled();
+    });
+
+    it("preserves ftp: and ftps: URLs", () => {
+      const editor = createMockEditor();
+      const result = useRichTextLinkDialog(editor);
+
+      result.linkUrl.value = "ftp://example.com/file";
+      result.insertLink();
+
+      const chain = editor.value._chain;
+      expect(chain.setLink).toHaveBeenCalledWith({
+        href: "ftp://example.com/file",
+      });
+    });
+
+    it("preserves sms: URLs", () => {
+      const editor = createMockEditor();
+      const result = useRichTextLinkDialog(editor);
+
+      result.linkUrl.value = "sms:+15555550100";
+      result.insertLink();
+
+      const chain = editor.value._chain;
+      expect(chain.setLink).toHaveBeenCalledWith({
+        href: "sms:+15555550100",
+      });
+    });
+
     it("closes dialog after inserting link", () => {
       const editor = createMockEditor();
       const result = useRichTextLinkDialog(editor);


### PR DESCRIPTION
- **Link dialog rejects dangerous URL schemes.** `javascript:`, `data:`, `vbscript:`, `file:` (plus case-bypasses like `JaVaScRiPt:` and whitespace-padded variants) are now dropped at link-insert time. Safe schemes (`http`, `https`, `mailto`, `tel`, `ftp`, `ftps`, `sms`, `xmpp`, `cid`) and `#` anchors still pass through.
- **`v-html` content sanitized before render.** `ParagraphBlock` and `TitleBlock` now scrub `<script>`/`<style>`/`<iframe>`/`on*` event handlers and unsafe `href` / `src` schemes from `block.content` before binding it to `v-html`. Closes the XSS path where a malicious or compromised template JSON could execute code on canvas load. TipTap-authored content (the common case) is unaffected.
- **Block duplication regenerates nested IDs.** Cloning a `table`, `social`, or `menu` block previously reused identical `rows[].id` / `cells[].id` / `icons[].id` / `items[].id` from the source, violating the unique-id invariant.
- **Removing a section clears descendant selection.** Previously, deleting an ancestor with a child selected left `selectedBlockId` dangling on the now-orphan id. The full subtree is walked on remove and selection is cleared if any descendant id matches.
- **`addBlock` / `moveBlock` validate `columnIndex` against the section layout.** Passing `columnIndex: 5` on a `"2"`-layout section no longer creates phantom columns persisted into JSON; out-of-range indices are rejected and `moveBlock` leaves the source intact.
- **Media-picker callers guard against post-unmount writes.** `ImageBlock`, `ImageToolbar`, `VideoToolbar`, and the custom-block `ImageField` now check an alive flag after `await onRequestMedia()`. Closing the editor mid-pick no longer triggers zombie `emit("update")` / pulse-ref writes on a torn-down component.
- **Keyboard shortcuts scoped to the active editor when two are mounted.** Each `useEditorCore` instance previously installed its own `document` keydown listener, so a single `Cmd+Z` fired both editors' undo handlers. The new `activeEditorTracker` routes shortcuts to the editor the user most recently interacted with (single-editor pages keep the original always-active behavior).
- **`MergeTagSuggestion` cancels its pending `requestAnimationFrame` on exit.** The reposition-after-paint frame previously ran after the popup tore down, pinning the Vue app and DOM nodes for one frame.
- **`useMergeTagField.insertMergeTag` no longer emits after the host component unmounts.** A scope-dispose flag now gates the post-`await requestMergeTag()` writes (emit + `isEditing` + `nextTick`).
- **`useFonts.loadCustomFonts` no longer flips `isLoaded` after dispose.** The post-`Promise.allSettled` write is gated by the same scope-dispose flag.