### PR TITLE
Add link linting rules to `@templatical/quality`

### DIFF
--- a/.changeset/quality-structure-linter-and-lint-rename.md
+++ b/.changeset/quality-structure-linter-and-lint-rename.md
@@ -3,18 +3,26 @@
 "@templatical/editor": minor
 ---
 
-Add `lintStructure` and reshape the quality package around a shared linting surface.
+Add `lintStructure` + `lintLinks` and reshape the quality package around a shared linting surface.
 
 **`@templatical/quality`**
 
 - New `lintStructure(content, options?)` linter — 5 rules: `structure.duplicate-block-id`, `structure.section-column-mismatch`, `structure.nested-section`, `structure.empty-section` (auto-fix removes the section), `structure.empty-column`.
-- Rule IDs are now namespaced. Every accessibility rule is prefixed with `a11y.` (e.g. `img-missing-alt` → `a11y.img-missing-alt`); structure rules use `structure.`. Severity overrides and message-map keys must use the prefixed form.
-- Type names renamed for cross-linter reuse: `A11yIssue` → `LintIssue`, `A11yOptions` → `LintOptions`, `A11yPatch` → `LintPatch`, `A11yPatchContext` → `LintPatchContext` (now also exposes `removeBlock`), `A11yThresholds` → `LintThresholds`, `DEFAULT_THRESHOLDS` → `DEFAULT_A11Y_THRESHOLDS`. The `RULES` export is now `ACCESSIBILITY_RULES`; a new `STRUCTURE_RULES` export sits alongside it.
-- New exports: `lintStructure`, `STRUCTURE_RULES`, `formatStructureMessage`, `getStructureMessages`, `SUPPORTED_STRUCTURE_MESSAGE_LOCALES`, `StructureMessageMap`, `StructureRuleMessageId`.
+- New `lintLinks(content, options?)` linter — 5 rules covering URL hygiene across every URL-bearing field in the template (anchors in rich text + `button.url`, `image.linkUrl`, `video.url`, `menu.items[].url`, `social.icons[].url`):
+  - `link.javascript-protocol` (error) — flags `javascript:` hrefs that the render-time sanitizer would silently strip.
+  - `link.unsupported-protocol` (warning) — flags explicit schemes outside `http`, `https`, `mailto`, `tel`, `sms`.
+  - `link.malformed-mailto` (warning) — sanity-checks `mailto:` recipient + domain shape.
+  - `link.malformed-tel` (warning) — rejects letters in `tel:` URIs.
+  - `link.localhost-or-staging` (warning) — flags URL hosts matching `options.links.nonProductionHosts` (default catches `localhost`, `127.0.0.1`, `0.0.0.0`, `*.local`, `*.staging.*`, `*.dev.*`).
+- New `walkUrls(content) → UrlOccurrence[]` helper for headless callers building URL-scoped rules.
+- `LintOptions` gains `links?: { nonProductionHosts?: string[] }` for `link.localhost-or-staging` configuration. `DEFAULT_NON_PRODUCTION_HOSTS` is exported as the baseline.
+- Rule IDs are now namespaced. Every accessibility rule is prefixed with `a11y.` (e.g. `img-missing-alt` → `a11y.img-missing-alt`); structure rules use `structure.`; link rules use `link.`. Severity overrides and message-map keys must use the prefixed form.
+- Type names renamed for cross-linter reuse: `A11yIssue` → `LintIssue`, `A11yOptions` → `LintOptions`, `A11yPatch` → `LintPatch`, `A11yPatchContext` → `LintPatchContext` (now also exposes `removeBlock`), `A11yThresholds` → `LintThresholds`, `DEFAULT_THRESHOLDS` → `DEFAULT_A11Y_THRESHOLDS`. The `RULES` export is now `ACCESSIBILITY_RULES`; new `STRUCTURE_RULES` and `LINK_RULES` exports sit alongside it.
+- New exports: `lintStructure`, `STRUCTURE_RULES`, `formatStructureMessage`, `getStructureMessages`, `SUPPORTED_STRUCTURE_MESSAGE_LOCALES`, `StructureMessageMap`, `StructureRuleMessageId`, `lintLinks`, `LINK_RULES`, `walkUrls`, `UrlOccurrence`, `UrlSource`, `formatLinkMessage`, `getLinkMessages`, `SUPPORTED_LINK_MESSAGE_LOCALES`, `LinkMessageMap`, `LinkRuleMessageId`, `LintLinksOptions`, `ResolvedLinksOptions`, `DEFAULT_NON_PRODUCTION_HOSTS`.
 
 **`@templatical/editor`**
 
-- `init({ accessibility })` is renamed to `init({ lint })` — the same option object now drives every linter exported by `@templatical/quality` (accessibility + structure).
-- Sidebar tab renamed from "Accessibility" to "Issues" and now shows both linter families. The composable is `useTemplateLint` (was `useAccessibilityLint`); the inject key is `TEMPLATE_LINT_KEY`; the components are `IssuesPanel.vue` and `BlockIssueBadge.vue`.
+- `init({ accessibility })` is renamed to `init({ lint })` — the same option object now drives every linter exported by `@templatical/quality` (accessibility + structure + links).
+- Sidebar tab renamed from "Accessibility" to "Issues" and now shows all three linter families. The composable is `useTemplateLint` (was `useAccessibilityLint`); the inject key is `TEMPLATE_LINT_KEY`; the components are `IssuesPanel.vue` and `BlockIssueBadge.vue`.
 - Section toolbar now rebalances `children` when the columns layout changes (1↔2↔3 / 1-2 / 2-1) — grows pad with empty columns, shrinks merge trailing columns into the last kept column so blocks are never silently dropped. Eliminates the `structure.section-column-mismatch` error that previously fired on every layout change.
 - Editor button reset (`.tpl button { background: none }`) now wrapped in `:where()` so its specificity drops to (0,0,1) and per-button utility classes (e.g. `tpl:bg-[var(--tpl-primary)]`) win. Fixes the Fix-button-renders-transparent bug introduced by the canvas reset; affects every primary-bg button in the editor.

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -37,6 +37,13 @@ const enSidebar: DefaultTheme.SidebarMulti = {
         { text: "Rule catalog", link: "/quality/structure/rule-catalog" },
       ],
     },
+    {
+      text: "Links",
+      items: [
+        { text: "Overview", link: "/quality/links/" },
+        { text: "Rule catalog", link: "/quality/links/rule-catalog" },
+      ],
+    },
   ],
   "/cloud/": [
     {
@@ -181,6 +188,13 @@ const deSidebar: DefaultTheme.SidebarMulti = {
       items: [
         { text: "Überblick", link: "/de/quality/structure/" },
         { text: "Regelkatalog", link: "/de/quality/structure/rule-catalog" },
+      ],
+    },
+    {
+      text: "Links",
+      items: [
+        { text: "Überblick", link: "/de/quality/links/" },
+        { text: "Regelkatalog", link: "/de/quality/links/rule-catalog" },
       ],
     },
   ],

--- a/apps/docs/de/getting-started/installation.md
+++ b/apps/docs/de/getting-started/installation.md
@@ -78,7 +78,7 @@ Wenn Sie `editor.toMjml()` aufrufen, ohne dass der Renderer installiert ist, wir
 | `@templatical/types`           | Gemeinsame TypeScript-Typen, Block-Factory-Funktionen, Type Guards                                                      | Automatisch installiert                                                                                      |
 | `@templatical/core`            | Framework-agnostische Editor-Logik (State, History)                                                                     | Automatisch installiert                                                                                      |
 | `@templatical/renderer`        | Rendert Templates zu MJML                                                                                               | Optional – installieren, wo Sie `editor.toMjml()` (Browser) oder `renderToMjml()` (Node.js, Server) aufrufen |
-| `@templatical/quality`         | Template-Linter (Barrierefreiheit + Struktur) für das Issues-Panel des Editors und Headless- / CI-Checks                | Optional – installieren, um den Issues-Sidebar-Tab und die Inline-Block-Badges zu aktivieren                 |
+| `@templatical/quality`         | Template-Linter (Barrierefreiheit, Struktur, Links) für das Issues-Panel des Editors und Headless- / CI-Checks                | Optional – installieren, um den Issues-Sidebar-Tab und die Inline-Block-Badges zu aktivieren                 |
 | `@templatical/media-library`   | Eigenständige Medienbibliothek (Typen, Composable, API-Client, Vue-Komponenten), wird von `initCloud()` genutzt         | Optional – nur nötig, wenn Sie `initCloud()` für den Medien-Browser verwenden                                |
 | `@templatical/import-beefree`  | Konvertiert BeeFree-JSON-Templates in das Templatical-Format                                                            | Optional                                                                                                     |
 | `@templatical/import-unlayer`  | Konvertiert Unlayer-JSON-Design-Templates in das Templatical-Format                                                     | Optional                                                                                                     |
@@ -93,7 +93,7 @@ Der Editor lädt vier optionale Peers zur Laufzeit per dynamischem `import()`, a
 | Peer                         | Wann geladen                                   | Installieren, wenn Sie                   |
 | ---------------------------- | ---------------------------------------------- | ---------------------------------------- |
 | `@templatical/renderer`      | Erster Aufruf von `editor.toMjml()`            | MJML-Export aus dem Browser benötigen    |
-| `@templatical/quality`       | Beim Mounten des Editors (Issues-Panel)        | Barrierefreiheit + Struktur-Lint in der Issues-Sidebar nutzen möchten |
+| `@templatical/quality`       | Beim Mounten des Editors (Issues-Panel)        | Barrierefreiheit, Struktur und Link-Lint in der Issues-Sidebar nutzen möchten |
 | `@templatical/media-library` | Erstes Öffnen des Medien-Browsers              | `initCloud()` verwenden                  |
 | `pusher-js`                  | Cloud-Realtime-Verbindung                      | `initCloud()` verwenden                  |
 

--- a/apps/docs/de/quality/contributing-locales.md
+++ b/apps/docs/de/quality/contributing-locales.md
@@ -5,8 +5,9 @@
 1. **Barrierefreiheits-Regelnachrichten** (`src/accessibility/messages/{locale}.ts`) — die Texte, die der Editor für jedes `a11y.*`-Issue zeigt.
 2. **Vague-Text-Dictionaries** (`src/accessibility/dictionaries/{locale}.ts`) — Phrasenlisten, die von `a11y.link-vague-text`, `a11y.button-vague-label` und `a11y.img-linked-no-context` genutzt werden.
 3. **Struktur-Regelnachrichten** (`src/structure/messages/{locale}.ts`) — Texte für jedes `structure.*`-Issue.
+4. **Link-Regelnachrichten** (`src/links/messages/{locale}.ts`) — Texte für jedes `link.*`-Issue.
 
-Jede Datenmenge spiegelt die Locale-Auswahl des Editors. Der Struktur-Linter hat kein Vague-Text-Dictionary-Pendant — seine Regeln sind deterministisch und sprachunabhängig, nur der Nachrichtentext muss übersetzt werden.
+Jede Datenmenge spiegelt die Locale-Auswahl des Editors. Der Struktur- und der Link-Linter haben kein Vague-Text-Dictionary-Pendant — ihre Regeln sind deterministisch und sprachunabhängig, nur der Nachrichtentext muss übersetzt werden.
 
 ## Verzeichnisstruktur
 
@@ -25,6 +26,11 @@ packages/quality/src/structure/messages/
   en.ts       ← Source of Truth
   de.ts       ← annotiert mit `typeof en`
   index.ts    ← exportiert formatStructureMessage(), getStructureMessages()
+
+packages/quality/src/links/messages/
+  en.ts       ← Source of Truth
+  de.ts       ← annotiert mit `typeof en`
+  index.ts    ← exportiert formatLinkMessage(), getLinkMessages()
 ```
 
 ## Eine Locale hinzufügen
@@ -88,7 +94,26 @@ const pt: typeof en = {
 export default pt;
 ```
 
-Das war's — `SUPPORTED_MESSAGE_LOCALES`, `SUPPORTED_DICTIONARY_LOCALES` und `SUPPORTED_STRUCTURE_MESSAGE_LOCALES` reflektieren die neue Locale automatisch. Keine Registry zu editieren, kein Test zu aktualisieren.
+### 4. Link-Regelnachrichten
+
+`links/messages/<lang>.ts` ablegen:
+
+```ts
+// links/messages/pt.ts
+import type en from "./en";
+
+const pt: typeof en = {
+  "link.javascript-protocol":
+    'URL usa o protocolo "javascript:", que é removido na renderização por segurança. Substitua por um link real ou remova a URL.',
+  "link.unsupported-protocol":
+    'URL usa o protocolo "{protocol}", que a maioria dos clientes de e-mail não suporta. Use http, https, mailto, tel ou sms.',
+  // …ein Key pro Link-Regel
+};
+
+export default pt;
+```
+
+Das war's — `SUPPORTED_MESSAGE_LOCALES`, `SUPPORTED_DICTIONARY_LOCALES`, `SUPPORTED_STRUCTURE_MESSAGE_LOCALES` und `SUPPORTED_LINK_MESSAGE_LOCALES` reflektieren die neue Locale automatisch. Keine Registry zu editieren, kein Test zu aktualisieren.
 
 ## Phrasen-Richtlinien (Vague-Text-Dictionary)
 
@@ -102,4 +127,4 @@ Das war's — `SUPPORTED_MESSAGE_LOCALES`, `SUPPORTED_DICTIONARY_LOCALES` und `S
 ## Wie das Matching aufgelöst wird
 
 - **Vague-Text-Dictionary** — `getDictionary(locale)` liefert eine Vereinigung der Phrasen (und Action-Hints) aller registrierten Locales. Das `locale`-Argument wird der API-Symmetrie wegen akzeptiert, ändert aber aktuell nichts an der zurückgegebenen Menge — eine vage Phrase ist universell vage, und ein Action-Verb in einer beliebigen registrierten Sprache zählt als Link-Ziel-Kontext. Die Erkennung ist by design sprachübergreifend.
-- **Regelnachrichten** — `formatMessage(locale, ruleId, params?)` (Barrierefreiheit) und `formatStructureMessage(locale, ruleId, params?)` (Struktur) lösen das lokalisierte Template über die jeweilige `messages/{locale}.ts`-Datei auf und interpolieren `{name}`-Platzhalter. Beide fallen auf Englisch zurück, wenn die Locale nicht gebündelt ist.
+- **Regelnachrichten** — `formatMessage(locale, ruleId, params?)` (Barrierefreiheit), `formatStructureMessage(locale, ruleId, params?)` (Struktur) und `formatLinkMessage(locale, ruleId, params?)` (Links) lösen das lokalisierte Template über die jeweilige `messages/{locale}.ts`-Datei auf und interpolieren `{name}`-Platzhalter. Alle drei fallen auf Englisch zurück, wenn die Locale nicht gebündelt ist.

--- a/apps/docs/de/quality/headless-usage.md
+++ b/apps/docs/de/quality/headless-usage.md
@@ -2,20 +2,25 @@
 
 `@templatical/quality` ist ausschließlich JSON-basiert und hat keine DOM-Abhängigkeit — dieselben Linter laufen in jedem Node.js-Kontext: CI, Build-Pipelines, serverseitige Validierung, Batch-Jobs.
 
-Sowohl `lintAccessibility(content, options?)` als auch `lintStructure(content, options?)` liefern dieselbe `LintIssue[]`-Struktur — du kannst sie unabhängig aufrufen oder Ergebnisse zusammenführen.
+`lintAccessibility(content, options?)`, `lintStructure(content, options?)` und `lintLinks(content, options?)` liefern alle dieselbe `LintIssue[]`-Struktur — du kannst sie unabhängig aufrufen oder Ergebnisse zusammenführen.
 
 ## Vor dem Speichern validieren
 
 Verweigere Template-JSON, das die Linter nicht besteht, dort wo es in dein System eintritt — CMS-Save-Handler, API-Endpunkt, Ingestion-Job:
 
 ```ts
-import { lintAccessibility, lintStructure } from "@templatical/quality";
+import {
+  lintAccessibility,
+  lintLinks,
+  lintStructure,
+} from "@templatical/quality";
 import type { TemplateContent } from "@templatical/types";
 
 export function assertValid(content: TemplateContent): void {
   const issues = [
     ...lintAccessibility(content),
     ...lintStructure(content),
+    ...lintLinks(content),
   ];
   const errors = issues.filter((i) => i.severity === "error");
   if (errors.length > 0) {
@@ -28,7 +33,7 @@ export function assertValid(content: TemplateContent): void {
 }
 ```
 
-`structure.*`-Fehler signalisieren typischerweise Datenkorruption (doppelte IDs, Layout/Children-Mismatch) und sollten ein Save immer blocken. `a11y.*`-Fehler sind Inhaltsqualität — hier kann eine weichere Policy sinnvoll sein.
+`structure.*`-Fehler signalisieren typischerweise Datenkorruption (doppelte IDs, Layout/Children-Mismatch) und sollten ein Save immer blocken. `link.javascript-protocol` ist ebenfalls ein Fehler — ein gefährliches Schema, das der Render-Sanitizer im Editor stillschweigend entfernen würde. `a11y.*`-Fehler sind Inhaltsqualität — hier kann eine weichere Policy sinnvoll sein.
 
 ## CI-Schutz für gespeicherte Templates
 
@@ -36,7 +41,11 @@ Wenn deine Anwendung `TemplateContent`-JSON in einer Datenbank speichert, lass d
 
 ```ts
 // scripts/lint-templates.ts
-import { lintAccessibility, lintStructure } from "@templatical/quality";
+import {
+  lintAccessibility,
+  lintLinks,
+  lintStructure,
+} from "@templatical/quality";
 import { templates } from "../fixtures/templates";
 
 const SEVERITY_RANK = { error: 3, warning: 2, info: 1 };
@@ -47,6 +56,7 @@ for (const [name, content] of Object.entries(templates)) {
   const issues = [
     ...lintAccessibility(content),
     ...lintStructure(content),
+    ...lintLinks(content),
   ].filter((i) => SEVERITY_RANK[i.severity] >= SEVERITY_RANK.warning);
 
   if (issues.length === 0) {
@@ -68,15 +78,17 @@ Per `tsx scripts/lint-templates.ts` ausführen und in deinen CI-Workflow einbind
 
 ## Nach Kategorie filtern
 
-Regel-IDs sind namensraum-getrennt (`a11y.*`, `structure.*`), also ist Gruppieren oder Filtern nach Linter ein `startsWith`-Check:
+Regel-IDs sind namensraum-getrennt (`a11y.*`, `structure.*`, `link.*`), also ist Gruppieren oder Filtern nach Linter ein `startsWith`-Check:
 
 ```ts
 const issues = [
   ...lintAccessibility(content),
   ...lintStructure(content),
+  ...lintLinks(content),
 ];
 const a11y = issues.filter((i) => i.ruleId.startsWith("a11y."));
 const structural = issues.filter((i) => i.ruleId.startsWith("structure."));
+const links = issues.filter((i) => i.ruleId.startsWith("link."));
 ```
 
 ## Eigene Schweregrad-Policy
@@ -112,4 +124,16 @@ walkBlocks(content, (block, ctx) => {
 
 `walkBlocks` löst den nächsten opaken Vorfahren-Hintergrund pro Block auf — Kontrast-Checks „funktionieren einfach", ohne dass du die Section/Column-Traversierung neu implementieren musst.
 
-Wenn deine Custom-Regel beim Orchestrator mitmachen soll (Schweregrad-Overrides, lokalisierte Nachrichten, das Editor-Issues-Panel), implementiere das `Rule`-Interface — `block` / `template` liefern einen `RuleHit` (`blockId`, optionale `params`, optionaler `fix`), und der Orchestrator kombiniert ihn mit `meta` und dem Nachrichtentemplate der aktiven Locale. Dasselbe `runRules`-Helper-Modul betreibt sowohl `lintAccessibility` als auch `lintStructure`.
+Für URL-bezogene Regeln nutze stattdessen `walkUrls` — es liefert pro URL-Feld im Template (Anker, Button, Image-Link, Video, Menüpunkt, Social-Icon) eine `UrlOccurrence`, ohne den Baum pro Regel neu zu durchlaufen:
+
+```ts
+import { walkUrls } from "@templatical/quality";
+
+for (const { url, blockId, source } of walkUrls(content)) {
+  if (source === "anchor" && url.startsWith("https://tracking.")) {
+    console.warn(`Block ${blockId} läuft über eine Tracking-Domain`);
+  }
+}
+```
+
+Wenn deine Custom-Regel beim Orchestrator mitmachen soll (Schweregrad-Overrides, lokalisierte Nachrichten, das Editor-Issues-Panel), implementiere das `Rule`-Interface — `block` / `template` liefern einen `RuleHit` (`blockId`, optionale `params`, optionaler `fix`), und der Orchestrator kombiniert ihn mit `meta` und dem Nachrichtentemplate der aktiven Locale. Dasselbe `runRules`-Helper-Modul betreibt `lintAccessibility`, `lintStructure` und `lintLinks`.

--- a/apps/docs/de/quality/index.md
+++ b/apps/docs/de/quality/index.md
@@ -8,8 +8,9 @@
 |---|---|---|
 | **[Barrierefreiheit](./accessibility/)** | Fehlender Alt-Text, niedriger Kontrast, vage CTAs, übersprungene Überschriftenebenen, zu kleine Touch-Ziele, lange GROSSBUCHSTABEN, target=_blank ohne rel, fehlender Preheader, … | überwiegend error/warning |
 | **[Struktur](./structure/)** | Doppelte Block-IDs, Sektionen mit falscher Spaltenanzahl, verschachtelte Sektionen, leere Sektionen, leere Spalten | überwiegend error; einige warning |
+| **[Links](./links/)** | Gefährliche URL-Schemata (`javascript:`), nicht unterstützte Protokolle, fehlerhafte `mailto:` / `tel:`, Staging-/localhost-URLs, die ins Template lecken | überwiegend warning; `link.javascript-protocol` ist error |
 
-Beide Linter liefern dieselbe `LintIssue`-Struktur und teilen sich dieselbe Optionsfläche (`LintOptions`) — Konsumenten können sie also in jeder Kombination ausführen, Ergebnisse zusammenführen und beim Gruppieren nach `ruleId`-Präfix (`a11y.*`, `structure.*`) filtern.
+Alle drei Linter liefern dieselbe `LintIssue`-Struktur und teilen sich dieselbe Optionsfläche (`LintOptions`) — Konsumenten können sie also in jeder Kombination ausführen, Ergebnisse zusammenführen und beim Gruppieren nach `ruleId`-Präfix (`a11y.*`, `structure.*`, `link.*`) filtern.
 
 ## Architektur
 
@@ -24,12 +25,15 @@ Beide Linter liefern dieselbe `LintIssue`-Struktur und teilen sich dieselbe Opti
   <text x="100" y="60" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748b" text-anchor="middle">JSON-Blockbaum</text>
   <text x="100" y="76" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748b" text-anchor="middle">aus Editor oder DB</text>
   <line x1="190" y1="50" x2="225" y2="50" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ah-quality-de)"/>
-  <rect x="230" y="2" width="180" height="44" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5" rx="8"/>
-  <text x="320" y="22" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e293b" text-anchor="middle">lintAccessibility()</text>
-  <text x="320" y="38" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#92400e" text-anchor="middle">a11y.* Regeln</text>
-  <rect x="230" y="54" width="180" height="44" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5" rx="8"/>
-  <text x="320" y="74" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e293b" text-anchor="middle">lintStructure()</text>
-  <text x="320" y="90" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#92400e" text-anchor="middle">structure.* Regeln</text>
+  <rect x="230" y="2" width="180" height="30" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5" rx="8"/>
+  <text x="320" y="16" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e293b" text-anchor="middle">lintAccessibility()</text>
+  <text x="320" y="28" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#92400e" text-anchor="middle">a11y.* Regeln</text>
+  <rect x="230" y="38" width="180" height="30" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5" rx="8"/>
+  <text x="320" y="52" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e293b" text-anchor="middle">lintStructure()</text>
+  <text x="320" y="64" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#92400e" text-anchor="middle">structure.* Regeln</text>
+  <rect x="230" y="74" width="180" height="30" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5" rx="8"/>
+  <text x="320" y="88" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e293b" text-anchor="middle">lintLinks()</text>
+  <text x="320" y="100" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#92400e" text-anchor="middle">link.* Regeln</text>
   <line x1="410" y1="50" x2="445" y2="50" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ah-quality-de)"/>
   <rect x="450" y="10" width="180" height="80" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.5" rx="10"/>
   <text x="540" y="36" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600" fill="#1e293b" text-anchor="middle">LintIssue[]</text>
@@ -88,8 +92,10 @@ const editor = init({
       "a11y.img-missing-alt": "warning",      // von Standard 'error' herabstufen
       "a11y.text-all-caps": "off",            // komplett deaktivieren
       "structure.empty-column": "info",       // von warning auf info herabstufen
+      "link.localhost-or-staging": "error",   // vor Versand zu error hochstufen
     },
     thresholds: { minFontSize: 16 },
+    links: { nonProductionHosts: ["*.staging.*", "*.preview.*"] },
   },
 });
 ```
@@ -104,3 +110,4 @@ Der Issues-Tab und die Canvas-Badges erscheinen automatisch, sobald der optional
 - [Lokalen beitragen](./contributing-locales) — Regel-Nachrichten + Vague-Text-Dictionaries hinzufügen.
 - [Barrierefreiheits-Linter](./accessibility/) — was er erkennt, Regelkatalog.
 - [Struktur-Linter](./structure/) — was er erkennt, Regelkatalog.
+- [Links-Linter](./links/) — was er erkennt, Regelkatalog.

--- a/apps/docs/de/quality/links/index.md
+++ b/apps/docs/de/quality/links/index.md
@@ -1,0 +1,96 @@
+# Links-Linter
+
+`lintLinks(content, options?)` ist der URL-Hygiene-Checker in [`@templatical/quality`](../). Er durchläuft jede URL im Template — Anker in Rich-Text, `button.url`, `image.linkUrl`, `video.url`, `menu.items[].url`, `social.icons[].url` — und meldet URL-förmige Daten, die kaputt, gefährlich oder versehentlich auf die falsche Umgebung gerichtet sind.
+
+## Warum
+
+E-Mail-URLs sind eine Langschwanz-Fehlerquelle:
+
+- Ein `javascript:`-Href schleicht sich aus einem Import in ein Template; der Render-Sanitizer entfernt ihn aus Sicherheitsgründen, aber der Autor erfährt nie, dass der Link kaputt ist.
+- Eine Staging-URL geht in Produktion, weil niemand das JSON vor dem Versand diff't.
+- Ein fehlerhafter `mailto:` macht „Contact us" stillschweigend tot.
+- Ein `tel:` mit Buchstaben drin wählt nirgendwohin.
+- Ein `data:` oder App-Deep-Link sieht im JSON in Ordnung aus, aber kein E-Mail-Client rendert ihn.
+
+Das sind keine Inhalts-Qualitätsprobleme (andere Zielgruppe als a11y) und keine Baum-Korruptions-Probleme (das JSON validiert). Sie bilden ihre eigene Kategorie.
+
+## Wechselwirkung mit Editor-Sicherheit
+
+Der Editor liefert bereits zwei URL-Schema-Verteidigungen:
+
+- **`useRichTextLinkDialog.normalizeLinkUrl`** — der Rich-Text-Link-Dialog weist URLs außerhalb seiner Safe-Scheme-Allowlist (`http`, `https`, `mailto`, `tel`, `ftp`, `ftps`, `sms`, `xmpp`, `cid`) beim Einfügen zurück.
+- **`sanitizeRichTextHtml`** — ein Render-Scrubber entfernt `javascript:` / `vbscript:` / `file:` (und weitere unsichere) `href` / `src` / `formaction`-Werte aus `paragraph.content` / `title.content` / `html.content`, bevor sie `v-html` erreichen.
+
+Das sind **Sicherheitsgrenzen** — sie verhindern XSS, indem sie gefährliche Werte stillschweigend entfernen. `lintLinks` ist ein **Authoring-Werkzeug**: es macht dieselben Werte sichtbar, damit der Autor das JSON korrigieren kann statt nur den Render-Pfad zu reparieren.
+
+Die zwei Ebenen ergänzen sich:
+
+| Quelle eines `javascript:`-Links | `normalizeLinkUrl` | `sanitizeRichTextHtml` | `lintLinks` |
+|---|---|---|---|
+| Nutzer tippt im Rich-Text-Link-Dialog | ✅ beim Einfügen blockiert | n/a (erreicht den Inhalt nie) | n/a |
+| Importiertes BeeFree- / Unlayer- / HTML-JSON | ❌ umgeht den Dialog | ✅ beim Rendern entfernt | ✅ zeigt dem Autor an |
+| Programmatisches `setContent()` mit fehlerhaftem Anker | ❌ | ✅ beim Rendern entfernt | ✅ zeigt dem Autor an |
+| `button.url`, `image.linkUrl`, `video.url`, `menu.items[].url`, `social.icons[].url` (strukturierte Felder, kein HTML) | ❌ | ❌ Sanitizer scannt nur Rich-Text-HTML | ✅ zeigt dem Autor an |
+
+`lintLinks` ist also das **einzige Authoring-Signal** für unsichere URLs in strukturierten Feldern und der **einzige Feedback-Kanal**, wenn ein entfernter Wert sonst lautlos aus Rich-Text-Importen verschwinden würde.
+
+## API
+
+```ts
+import { lintLinks } from "@templatical/quality";
+
+const issues = lintLinks(content, options?);
+// issues: LintIssue[] — jeder Eintrag hat eine ruleId, die mit "link." beginnt
+```
+
+Gleiche Signatur wie `lintAccessibility` und `lintStructure`. Gleiche `LintOptions`-Struktur. Gleicher `LintIssue`-Rückgabewert. Du kannst alle drei Linter unabhängig aufrufen oder Ergebnisse zusammenführen.
+
+Im Editor lädt das `useTemplateLint`-Composable `@templatical/quality` per dynamischem Import und führt jeden Linter bei jeder (entprellten) Inhaltsänderung aus. Link-Issues erscheinen im **Issues**-Sidebar-Tab neben Barrierefreiheits- und Struktur-Issues.
+
+## Konfiguration
+
+`lintLinks` liest einen optionalen Knopf unter `LintOptions.links`:
+
+```ts
+interface LintLinksOptions {
+  nonProductionHosts?: string[];
+}
+```
+
+### `links.nonProductionHosts`
+
+| Standard | `['localhost', '127.0.0.1', '0.0.0.0', '*.local', '*.staging.*', '*.dev.*']` |
+|---|---|
+
+Glob-Muster, die gegen den URL-Host abgeglichen werden. `*` matcht eine beliebige Zeichenfolge (auch über `.` hinweg) — `*.staging.*` matcht also `app.staging.example.com` und `*.local` matcht `acme.local` oder `a.b.c.local`. Muster sind verankert; `*.local` matcht damit NICHT `acme.local-tools`. Groß-/Kleinschreibung wird ignoriert.
+
+Übergib ein leeres Array, um `link.localhost-or-staging` stumm zu schalten, ohne die Regel komplett zu deaktivieren:
+
+```ts
+lintLinks(content, {
+  links: { nonProductionHosts: [] },
+});
+```
+
+Oder erweitere / ersetze mit eigenen Mustern:
+
+```ts
+lintLinks(content, {
+  links: {
+    nonProductionHosts: [
+      "*.preview.*",       // erfasst einen Vendor-Preview-Host
+      "*.internal.acme.io" // erfasst internes Staging
+    ],
+  },
+});
+```
+
+Die Konstante `DEFAULT_NON_PRODUCTION_HOSTS` wird exportiert, falls du den Standard programmatisch referenzieren musst.
+
+## Schnellzugriff
+
+- [Regelkatalog](./rule-catalog) — jede Link-Regel mit Schweregrad, Scope und Begründung.
+- [Optionen](../options) — geteilt über alle Linter.
+- [Schweregrade & Fixes](../severity-and-fixes) — wie Schweregrad-Overrides landen und das Fix-Modell.
+- [Headless-Nutzung](../headless-usage) — Validierung gespeicherter Templates in CI.
+- [Beiträge zu Locales](../contributing-locales) — Link-Regelnachrichten hinzufügen.

--- a/apps/docs/de/quality/links/rule-catalog.md
+++ b/apps/docs/de/quality/links/rule-catalog.md
@@ -1,0 +1,32 @@
+# Link-Regelkatalog
+
+Die 5 Regeln, die `lintLinks` ausliefert. Jede Regel lebt in `packages/quality/src/links/rules/`; der Schweregrad ist über [Optionen](../options) pro Konsument überschreibbar. Alle Regeln scannen jede URL-Quelle, die `walkUrls` liefert — Anker in Rich-Text plus `button.url`, `image.linkUrl`, `video.url`, `menu.items[].url`, `social.icons[].url`.
+
+## Gefährliche Protokolle
+
+| Regel | Standard-Schweregrad | Auto-Fix | Was sie prüft |
+|---|---|---|---|
+| `link.javascript-protocol` | error | — | Href beginnt mit `javascript:` (oder Whitespace-/Case-Bypass-Varianten wie ` JaVaScRiPt:`). `sanitizeRichTextHtml` entfernt diese bereits beim Render aus Rich-Text-Inhalten, sodass sie nicht ausgeführt werden, und der Link-Dialog blockiert das Einfügen — aber Werte aus importiertem JSON, programmatischen API-Aufrufen oder strukturierten Feldern (`button.url`, `image.linkUrl`, `menu.items[].url`, `social.icons[].url`) liegen still im Template. Diese Regel macht sie zur Authoring-Zeit sichtbar, damit das JSON korrigiert wird und nicht nur der Render-Pfad. |
+
+## Nicht unterstützte Protokolle
+
+| Regel | Standard-Schweregrad | Auto-Fix | Was sie prüft |
+|---|---|---|---|
+| `link.unsupported-protocol` | warning | — | Href verwendet ein explizites Protokoll außer `http`, `https`, `mailto`, `tel` oder `sms`. Eigene Protokolle (`ftp:`, `file:`, `data:`, App-Deep-Links) funktionieren typischerweise nicht aus E-Mail-Clients und deuten entweder auf einen Copy-Paste-Fehler oder eine nicht unterstützte Integration hin. Relative URLs und reine Pfade werden ignoriert. `javascript:` ist ausgenommen — dafür gibt es eine eigene Regel. |
+
+## Fehlerhafte URIs
+
+| Regel | Standard-Schweregrad | Auto-Fix | Was sie prüft |
+|---|---|---|---|
+| `link.malformed-mailto` | warning | — | `mailto:`-Href ist leer, hat kein `@`, der Local- oder Domain-Teil fehlt oder die Domain hat keinen Punkt. Querystring-Fragmente (`?subject=…`, `?cc=…`, `?body=…`) werden akzeptiert. Mehrfach-Empfänger `mailto:a@x.com,b@y.com` werden akzeptiert. Pragmatisch — kein vollständiger RFC-Validator. |
+| `link.malformed-tel` | warning | — | `tel:`-Href enthält Zeichen außerhalb von `+`, Ziffern, Leerzeichen, Bindestrichen, Klammern und Punkten. Die meisten Clients scheitern an fehlerhaften `tel:`-URIs lautlos (z. B. `tel:CALL-NOW`). |
+
+## Umgebungs-Leaks
+
+| Regel | Standard-Schweregrad | Auto-Fix | Was sie prüft |
+|---|---|---|---|
+| `link.localhost-or-staging` | warning | — | URL-Host matcht die konfigurierte Nicht-Produktions-Hostliste. Der Standard erfasst `localhost`, `127.0.0.1`, `0.0.0.0`, `*.local`, `*.staging.*`, `*.dev.*`. Konfigurierbar via `options.links.nonProductionHosts` — Standard-Erweiterungs- / Ersatz-Muster siehe [Übersicht](./). Feuert nur auf `http(s)`- und `ftp(s)`-URLs; mailto/tel/sms werden übersprungen. |
+
+## Warum keine Auto-Fixes?
+
+Jede Link-Regel ist destruktiv (Href entfernen / Protokoll ändern) und die richtige Antwort hängt vom Intent ab — `javascript:alert(1)` kann auf einem Button stehen, der gelöscht gehört, oder ein Tippfehler für `mailto:` sein. Reine Erkennung ist sicherer als Raten. Headless-Aufrufer können `LintIssue[]` nach `ruleId.startsWith("link.")` filtern und eigene Policy anwenden (Save blockieren, in Review-Queue schicken, …).

--- a/apps/docs/de/quality/options.md
+++ b/apps/docs/de/quality/options.md
@@ -1,6 +1,6 @@
 # Optionen
 
-`lintAccessibility` und `lintStructure` akzeptieren dieselbe `LintOptions`-Struktur. Jedes Feld ist optional.
+`lintAccessibility`, `lintStructure` und `lintLinks` akzeptieren dieselbe `LintOptions`-Struktur. Jedes Feld ist optional.
 
 ```ts
 interface LintOptions {
@@ -8,12 +8,13 @@ interface LintOptions {
   locale?: string;
   rules?: Record<string, Severity>;
   thresholds?: Partial<LintThresholds>;
+  links?: LintLinksOptions;
 }
 
 type Severity = "error" | "warning" | "info" | "off";
 ```
 
-Dasselbe Objekt steuert auch die `init({ lint })`-Konfiguration des Editors — jede Option hier wirkt sich über das geteilte `useTemplateLint`-Composable auf beide Linter aus.
+Dasselbe Objekt steuert auch die `init({ lint })`-Konfiguration des Editors — jede Option hier wirkt sich über das geteilte `useTemplateLint`-Composable auf jeden Linter aus.
 
 ## `disabled`
 
@@ -40,6 +41,7 @@ Steuert die Nachrichtentemplates des Linters (eine Datei pro Locale pro Linter) 
 // Headless — explizit setzen
 lintAccessibility(content, { locale: "de" });
 lintStructure(content, { locale: "de" });
+lintLinks(content, { locale: "de" });
 
 // Editor — Linter folgt automatisch der Editor-Locale
 init({ locale: "de" });
@@ -48,7 +50,7 @@ init({ locale: "de" });
 ::: warning Im Editor-Modus wird `lint.locale` ignoriert
 Im Editor-Modus wird die Linter-Locale **erzwungen** auf den `locale`-Wert aus `init({ locale })`. `lint.locale` zu setzen, hat keinen Effekt — es wird auf dem Weg überschrieben.
 
-Headless-Aufrufer (`lintAccessibility(...)` / `lintStructure(...)` direkt) behalten volle Kontrolle.
+Headless-Aufrufer (`lintAccessibility(...)` / `lintStructure(...)` / `lintLinks(...)` direkt) behalten volle Kontrolle.
 :::
 
 ::: tip Vague-Text-Dictionaries sind sprachübergreifend
@@ -68,12 +70,13 @@ Schweregrad-Override pro Regel. Setze eine Regel auf `'off'`, um sie komplett zu
   "a11y.text-all-caps": "off",         // deaktivieren
   "a11y.missing-preheader": "warning", // info → warning hochstufen
   "structure.empty-column": "info",    // warning → info herabstufen
+  "link.localhost-or-staging": "error",// vor Versand zu error hochstufen
 }
 ```
 
-Regel-IDs sind nach Linter namensraum-getrennt: `a11y.*` für Barrierefreiheit, `structure.*` für Struktur. Override-Schlüssel müssen die volle, mit Präfix versehene ID verwenden.
+Regel-IDs sind nach Linter namensraum-getrennt: `a11y.*` für Barrierefreiheit, `structure.*` für Struktur, `link.*` für Links. Override-Schlüssel müssen die volle, mit Präfix versehene ID verwenden.
 
-Der Override greift, bevor die Regel läuft — deaktivierte Regeln werden also gar nicht erst ausgeführt. Standardschweregrade pro Regel: [Barrierefreiheit](./accessibility/rule-catalog) · [Struktur](./structure/rule-catalog).
+Der Override greift, bevor die Regel läuft — deaktivierte Regeln werden also gar nicht erst ausgeführt. Standardschweregrade pro Regel: [Barrierefreiheit](./accessibility/rule-catalog) · [Struktur](./structure/rule-catalog) · [Links](./links/rule-catalog).
 
 ## `thresholds`
 
@@ -98,3 +101,31 @@ lintAccessibility(content, {
 ```
 
 Die Konstante `DEFAULT_A11Y_THRESHOLDS` wird ebenfalls exportiert, falls du die Baseline programmatisch referenzieren willst.
+
+## `links`
+
+`lintLinks` liest ein optionales Unter-Objekt:
+
+```ts
+interface LintLinksOptions {
+  nonProductionHosts?: string[];
+}
+```
+
+### `links.nonProductionHosts`
+
+| Standard | `['localhost', '127.0.0.1', '0.0.0.0', '*.local', '*.staging.*', '*.dev.*']` |
+|---|---|
+
+Glob-Muster, die gegen den URL-Host abgeglichen werden. `*` matcht eine beliebige Zeichenfolge (auch über `.` hinweg) — `*.staging.*` matcht also `app.staging.example.com` und `*.local` matcht `acme.local` oder `a.b.c.local`. Muster sind verankert; `*.local` matcht damit NICHT `acme.local-tools`. Groß-/Kleinschreibung wird ignoriert.
+
+```ts
+lintLinks(content, {
+  links: { nonProductionHosts: ["*.preview.*"] },
+});
+
+// Oder die Regel still schalten, ohne sie zu deaktivieren:
+lintLinks(content, { links: { nonProductionHosts: [] } });
+```
+
+`DEFAULT_NON_PRODUCTION_HOSTS` wird als Baseline exportiert. Mehr in der [Links-Übersicht](./links/).

--- a/apps/docs/de/quality/severity-and-fixes.md
+++ b/apps/docs/de/quality/severity-and-fixes.md
@@ -1,6 +1,6 @@
 # Schweregrade & Fixes
 
-Beide Linter teilen sich dasselbe Schweregrad-Modell und dieselbe Patch-Struktur, daher behandelt diese Seite `lintAccessibility` und `lintStructure` gemeinsam.
+Alle Linter teilen sich dasselbe Schweregrad-Modell und dieselbe Patch-Struktur, daher behandelt diese Seite `lintAccessibility`, `lintStructure` und `lintLinks` gemeinsam.
 
 ## Schweregrad-Modell
 
@@ -37,11 +37,16 @@ Im Editor läuft `apply` über den bestehenden `editor.updateBlock` / `editor.up
 Headless-Aufrufer können einen eigenen `LintPatchContext` konstruieren und Patches programmatisch anwenden:
 
 ```ts
-import { lintAccessibility, lintStructure } from "@templatical/quality";
+import {
+  lintAccessibility,
+  lintLinks,
+  lintStructure,
+} from "@templatical/quality";
 
 const issues = [
   ...lintAccessibility(content),
   ...lintStructure(content),
+  ...lintLinks(content),
 ];
 const fixable = issues.filter((i) => i.fix);
 
@@ -60,5 +65,6 @@ Siehe die **Auto-Fix**-Spalte in den jeweiligen Katalogen. Aktuell mit Auto-Fix:
 
 - Barrierefreiheit — `a11y.img-alt-is-filename`, `a11y.img-decorative-needs-empty-alt`, `a11y.link-target-blank-no-rel`.
 - Struktur — `structure.empty-section`.
+- Links — keine. Jede Link-Regel ist beim Auto-Fix destruktiv (Href entfernen, Protokoll ändern), und die richtige Antwort hängt vom Intent ab.
 
 Auto-Fixes werden konservativ ergänzt — nur wenn die richtige Antwort eindeutig ist. `structure.empty-column` hat z. B. keinen Auto-Fix, weil das Entfernen einer leeren Spalte das `columns`-Layout der Sektion ändern muss und die richtige Antwort (in Nachbar-Spalte zusammenführen vs. Sektion entfernen vs. Layout-Key ändern) von der Intention abhängt.

--- a/apps/docs/getting-started/installation.md
+++ b/apps/docs/getting-started/installation.md
@@ -76,7 +76,7 @@ If you call `editor.toMjml()` without the renderer installed, it throws a clear 
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `@templatical/editor`          | Visual drag-and-drop editor and `init()` entry point. Self-contained — Vue, TipTap, and `@templatical/core`/`/types` are bundled inside. | Required                                                                                            |
 | `@templatical/renderer`        | Converts templates to MJML for email sending.                                                                                            | Optional — install where you call `editor.toMjml()` (browser) or `renderToMjml()` (Node.js, server) |
-| `@templatical/quality`         | Template linters (accessibility + structure) that drive the editor's Issues panel and a headless / CI check.                             | Optional — install to turn on the Issues sidebar tab and inline block badges                        |
+| `@templatical/quality`         | Template linters (accessibility, structure, links) that drive the editor's Issues panel and a headless / CI check.                             | Optional — install to turn on the Issues sidebar tab and inline block badges                        |
 | `@templatical/media-library`   | Standalone media library (types, composable, API client, Vue components) used by `initCloud()`.                                          | Optional — required only when using `initCloud()` for the media browser                             |
 | `@templatical/types`           | Shared TypeScript types, block factory functions, type guards.                                                                           | Only if you build templates programmatically without the editor (e.g. server-side workflows)        |
 | `@templatical/core`            | Framework-agnostic editor logic (state, history) for headless setups.                                                                    | Only for headless / non-editor consumers                                                            |
@@ -93,7 +93,7 @@ The editor lazy-loads four optional peers via dynamic `import()` at runtime, gat
 | Peer                         | When loaded                     | Install if you                    |
 | ---------------------------- | ------------------------------- | --------------------------------- |
 | `@templatical/renderer`      | First call to `editor.toMjml()` | Need MJML export from the browser |
-| `@templatical/quality`       | Editor mount (Issues panel)     | Want accessibility + structure lint in the Issues sidebar |
+| `@templatical/quality`       | Editor mount (Issues panel)     | Want accessibility, structure, and link lint in the Issues sidebar |
 | `@templatical/media-library` | First open of the media browser | Use `initCloud()`                 |
 | `pusher-js`                  | Cloud realtime connect          | Use `initCloud()`                 |
 

--- a/apps/docs/quality/contributing-locales.md
+++ b/apps/docs/quality/contributing-locales.md
@@ -5,8 +5,9 @@
 1. **Accessibility rule messages** (`src/accessibility/messages/{locale}.ts`) — strings the editor shows for each `a11y.*` issue.
 2. **Vague-text dictionaries** (`src/accessibility/dictionaries/{locale}.ts`) — phrase lists used by `a11y.link-vague-text`, `a11y.button-vague-label`, and `a11y.img-linked-no-context`.
 3. **Structure rule messages** (`src/structure/messages/{locale}.ts`) — strings for each `structure.*` issue.
+4. **Link rule messages** (`src/links/messages/{locale}.ts`) — strings for each `link.*` issue.
 
-Each set mirrors the editor's locale set. The structure linter has no equivalent of vague-text dictionaries — its rules are deterministic and locale-agnostic, only the message text needs translating.
+Each set mirrors the editor's locale set. The structure and link linters have no equivalent of vague-text dictionaries — their rules are deterministic and locale-agnostic, only the message text needs translating.
 
 ## File layout
 
@@ -25,6 +26,11 @@ packages/quality/src/structure/messages/
   en.ts       ← source of truth
   de.ts       ← annotated `typeof en`
   index.ts    ← exports formatStructureMessage(), getStructureMessages()
+
+packages/quality/src/links/messages/
+  en.ts       ← source of truth
+  de.ts       ← annotated `typeof en`
+  index.ts    ← exports formatLinkMessage(), getLinkMessages()
 ```
 
 ## Adding a locale
@@ -88,7 +94,26 @@ const pt: typeof en = {
 export default pt;
 ```
 
-That's it — `SUPPORTED_MESSAGE_LOCALES`, `SUPPORTED_DICTIONARY_LOCALES`, and `SUPPORTED_STRUCTURE_MESSAGE_LOCALES` reflect the new locale automatically. No registry edit, no test update.
+### 4. Link rule messages
+
+Drop `links/messages/<lang>.ts`:
+
+```ts
+// links/messages/pt.ts
+import type en from "./en";
+
+const pt: typeof en = {
+  "link.javascript-protocol":
+    'URL usa o protocolo "javascript:", que é removido na renderização por segurança. Substitua por um link real ou remova a URL.',
+  "link.unsupported-protocol":
+    'URL usa o protocolo "{protocol}", que a maioria dos clientes de e-mail não suporta. Use http, https, mailto, tel ou sms.',
+  // …one key per link rule
+};
+
+export default pt;
+```
+
+That's it — `SUPPORTED_MESSAGE_LOCALES`, `SUPPORTED_DICTIONARY_LOCALES`, `SUPPORTED_STRUCTURE_MESSAGE_LOCALES`, and `SUPPORTED_LINK_MESSAGE_LOCALES` reflect the new locale automatically. No registry edit, no test update.
 
 ## Phrase guidelines (vague-text dictionary)
 
@@ -102,4 +127,4 @@ That's it — `SUPPORTED_MESSAGE_LOCALES`, `SUPPORTED_DICTIONARY_LOCALES`, and `
 ## How matching resolves
 
 - **Vague-text dictionary** — `getDictionary(locale)` returns a union of every registered locale's phrases (and action hints). The `locale` argument is accepted for API symmetry but currently doesn't change the returned set; a vague phrase is universally vague, and an action verb in any registered language counts as link-destination context, so detection is cross-locale by design.
-- **Rule messages** — `formatMessage(locale, ruleId, params?)` (accessibility) and `formatStructureMessage(locale, ruleId, params?)` (structure) resolve the localized template via the matching `messages/{locale}.ts` file and interpolate `{name}` placeholders. Both fall back to English when the locale isn't bundled.
+- **Rule messages** — `formatMessage(locale, ruleId, params?)` (accessibility), `formatStructureMessage(locale, ruleId, params?)` (structure), and `formatLinkMessage(locale, ruleId, params?)` (links) resolve the localized template via the matching `messages/{locale}.ts` file and interpolate `{name}` placeholders. All three fall back to English when the locale isn't bundled.

--- a/apps/docs/quality/headless-usage.md
+++ b/apps/docs/quality/headless-usage.md
@@ -2,20 +2,25 @@
 
 `@templatical/quality` is JSON-only and has no DOM dependency, so the same linters run in any Node.js context: CI, build pipelines, server-side validation, batch jobs.
 
-Both `lintAccessibility(content, options?)` and `lintStructure(content, options?)` return the same `LintIssue[]` shape, so you can call them independently or merge results.
+`lintAccessibility(content, options?)`, `lintStructure(content, options?)`, and `lintLinks(content, options?)` all return the same `LintIssue[]` shape, so you can call them independently or merge results.
 
 ## Validate before storing
 
 Reject template JSON that fails the linter at the point it enters your system — CMS save handler, API endpoint, ingestion job:
 
 ```ts
-import { lintAccessibility, lintStructure } from "@templatical/quality";
+import {
+  lintAccessibility,
+  lintLinks,
+  lintStructure,
+} from "@templatical/quality";
 import type { TemplateContent } from "@templatical/types";
 
 export function assertValid(content: TemplateContent): void {
   const issues = [
     ...lintAccessibility(content),
     ...lintStructure(content),
+    ...lintLinks(content),
   ];
   const errors = issues.filter((i) => i.severity === "error");
   if (errors.length > 0) {
@@ -28,7 +33,7 @@ export function assertValid(content: TemplateContent): void {
 }
 ```
 
-`structure.*` errors typically indicate data corruption (duplicate IDs, layout/children mismatch) and should always block a save. `a11y.*` errors are content quality and may warrant a softer policy.
+`structure.*` errors typically indicate data corruption (duplicate IDs, layout/children mismatch) and should always block a save. `link.javascript-protocol` is also an error — a dangerous scheme that the editor's render-time sanitizer would strip silently. `a11y.*` errors are content quality and may warrant a softer policy.
 
 ## CI guard for stored templates
 
@@ -36,7 +41,11 @@ If your application stores `TemplateContent` JSON in a database, run the linters
 
 ```ts
 // scripts/lint-templates.ts
-import { lintAccessibility, lintStructure } from "@templatical/quality";
+import {
+  lintAccessibility,
+  lintLinks,
+  lintStructure,
+} from "@templatical/quality";
 import { templates } from "../fixtures/templates";
 
 const SEVERITY_RANK = { error: 3, warning: 2, info: 1 };
@@ -47,6 +56,7 @@ for (const [name, content] of Object.entries(templates)) {
   const issues = [
     ...lintAccessibility(content),
     ...lintStructure(content),
+    ...lintLinks(content),
   ].filter((i) => SEVERITY_RANK[i.severity] >= SEVERITY_RANK.warning);
 
   if (issues.length === 0) {
@@ -68,15 +78,17 @@ Run via `tsx scripts/lint-templates.ts` and wire it into your CI workflow. The T
 
 ## Filtering by category
 
-Rule IDs are namespaced (`a11y.*`, `structure.*`), so grouping or filtering by linter is a `startsWith` check:
+Rule IDs are namespaced (`a11y.*`, `structure.*`, `link.*`), so grouping or filtering by linter is a `startsWith` check:
 
 ```ts
 const issues = [
   ...lintAccessibility(content),
   ...lintStructure(content),
+  ...lintLinks(content),
 ];
 const a11y = issues.filter((i) => i.ruleId.startsWith("a11y."));
 const structural = issues.filter((i) => i.ruleId.startsWith("structure."));
+const links = issues.filter((i) => i.ruleId.startsWith("link."));
 ```
 
 ## Custom severity policy
@@ -112,4 +124,16 @@ walkBlocks(content, (block, ctx) => {
 
 `walkBlocks` resolves the nearest opaque ancestor background per block, so contrast checks "just work" without re-implementing the section/column traversal.
 
-If you'd like your custom rule to participate in the orchestrator alongside the built-ins (severity overrides, localized messages, the editor Issues panel), implement the `Rule` interface — `block` / `template` return a `RuleHit` (`blockId`, optional `params`, optional `fix`) and the orchestrator combines it with the rule's `meta` and the active locale's message template. The same `runRules` helper powers both `lintAccessibility` and `lintStructure`.
+For URL-scoped rules, use `walkUrls` instead — it yields one `UrlOccurrence` per URL field across the template (anchors, button, image-link, video, menu-item, social-icon) without re-walking the tree per rule:
+
+```ts
+import { walkUrls } from "@templatical/quality";
+
+for (const { url, blockId, source } of walkUrls(content)) {
+  if (source === "anchor" && url.startsWith("https://tracking.")) {
+    console.warn(`Block ${blockId} routes through tracking domain`);
+  }
+}
+```
+
+If you'd like your custom rule to participate in the orchestrator alongside the built-ins (severity overrides, localized messages, the editor Issues panel), implement the `Rule` interface — `block` / `template` return a `RuleHit` (`blockId`, optional `params`, optional `fix`) and the orchestrator combines it with the rule's `meta` and the active locale's message template. The same `runRules` helper powers `lintAccessibility`, `lintStructure`, and `lintLinks`.

--- a/apps/docs/quality/index.md
+++ b/apps/docs/quality/index.md
@@ -8,8 +8,9 @@
 |---|---|---|
 | **[Accessibility](./accessibility/)** | Missing alt text, low contrast, vague CTAs, heading-skip, undersized touch targets, ALL CAPS body, target=_blank missing rel, missing preheader, … | mostly error/warning |
 | **[Structure](./structure/)** | Duplicate block IDs, sections with the wrong column count, nested sections, empty sections, empty columns | mostly error; some warning |
+| **[Links](./links/)** | Dangerous URL schemes (`javascript:`), unsupported protocols, malformed `mailto:` / `tel:`, staging / localhost URLs leaking into a template | mostly warning; `link.javascript-protocol` is error |
 
-Both linters return the same `LintIssue` shape and share the same options surface (`LintOptions`) — so consumers can run them in any combination, merge results, and filter by `ruleId` prefix (`a11y.*`, `structure.*`) when grouping.
+All three linters return the same `LintIssue` shape and share the same options surface (`LintOptions`) — so consumers can run them in any combination, merge results, and filter by `ruleId` prefix (`a11y.*`, `structure.*`, `link.*`) when grouping.
 
 ## Architecture
 
@@ -26,13 +27,16 @@ Both linters return the same `LintIssue` shape and share the same options surfac
   <text x="100" y="76" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748b" text-anchor="middle">from the editor or DB</text>
   <!-- Arrow -->
   <line x1="190" y1="50" x2="225" y2="50" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ah-quality)"/>
-  <!-- Step 2: Engines (two boxes stacked) -->
-  <rect x="230" y="2" width="180" height="44" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5" rx="8"/>
-  <text x="320" y="22" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e293b" text-anchor="middle">lintAccessibility()</text>
-  <text x="320" y="38" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#92400e" text-anchor="middle">a11y.* rules</text>
-  <rect x="230" y="54" width="180" height="44" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5" rx="8"/>
-  <text x="320" y="74" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e293b" text-anchor="middle">lintStructure()</text>
-  <text x="320" y="90" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#92400e" text-anchor="middle">structure.* rules</text>
+  <!-- Step 2: Engines (three boxes stacked) -->
+  <rect x="230" y="2" width="180" height="30" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5" rx="8"/>
+  <text x="320" y="16" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e293b" text-anchor="middle">lintAccessibility()</text>
+  <text x="320" y="28" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#92400e" text-anchor="middle">a11y.* rules</text>
+  <rect x="230" y="38" width="180" height="30" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5" rx="8"/>
+  <text x="320" y="52" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e293b" text-anchor="middle">lintStructure()</text>
+  <text x="320" y="64" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#92400e" text-anchor="middle">structure.* rules</text>
+  <rect x="230" y="74" width="180" height="30" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5" rx="8"/>
+  <text x="320" y="88" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e293b" text-anchor="middle">lintLinks()</text>
+  <text x="320" y="100" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#92400e" text-anchor="middle">link.* rules</text>
   <!-- Arrow -->
   <line x1="410" y1="50" x2="445" y2="50" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ah-quality)"/>
   <!-- Step 3: Output -->
@@ -95,8 +99,10 @@ const editor = init({
       "a11y.img-missing-alt": "warning",      // soften from default 'error'
       "a11y.text-all-caps": "off",            // turn off entirely
       "structure.empty-column": "info",       // demote to info
+      "link.localhost-or-staging": "error",   // promote to error before send
     },
     thresholds: { minFontSize: 16 },
+    links: { nonProductionHosts: ["*.staging.*", "*.preview.*"] },
   },
 });
 ```
@@ -111,3 +117,4 @@ The Issues tab and inline canvas badges appear automatically once the optional p
 - [Contributing locales](./contributing-locales) — adding rule messages + vague-text dictionaries.
 - [Accessibility linter](./accessibility/) — what it catches, rule catalog.
 - [Structure linter](./structure/) — what it catches, rule catalog.
+- [Links linter](./links/) — what it catches, rule catalog.

--- a/apps/docs/quality/links/index.md
+++ b/apps/docs/quality/links/index.md
@@ -1,0 +1,96 @@
+# Links linter
+
+`lintLinks(content, options?)` is the URL-hygiene checker inside [`@templatical/quality`](../). It walks every URL in the template — anchors inside rich text, `button.url`, `image.linkUrl`, `video.url`, `menu.items[].url`, `social.icons[].url` — and flags URL-shaped data that's broken, dangerous, or accidentally pointing at the wrong environment.
+
+## Why
+
+Email URLs are a long-tail bug source:
+
+- A `javascript:` href slips into a template from an import; the render-time sanitizer drops it for safety, but the author never finds out the link is broken until a recipient complains.
+- A staging URL ships to production because nobody diffed the JSON before send.
+- A malformed `mailto:` makes "Contact us" silently dead.
+- A `tel:` with letters in it doesn't dial anywhere.
+- A `data:` or app-deep-link `href` looks fine in JSON but no email client renders it.
+
+These aren't content-quality issues (different audience from a11y) and they aren't tree-corruption issues (the JSON validates). They live in their own category.
+
+## Interaction with editor security
+
+The editor already ships two URL-scheme defenses:
+
+- **`useRichTextLinkDialog.normalizeLinkUrl`** — the rich-text link dialog rejects URLs outside its safe-scheme allowlist (`http`, `https`, `mailto`, `tel`, `ftp`, `ftps`, `sms`, `xmpp`, `cid`) at insert time.
+- **`sanitizeRichTextHtml`** — a render-time scrubber strips `javascript:` / `vbscript:` / `file:` (and other unsafe-scheme) `href` / `src` / `formaction` values from `paragraph.content` / `title.content` / `html.content` before they reach `v-html`.
+
+Those are **security boundaries** — they prevent XSS by silently dropping dangerous values. `lintLinks` is an **authoring tool**: it surfaces the same values so the author can fix the JSON rather than have it stripped at render.
+
+The two layers complement each other:
+
+| Source of a `javascript:` link | `normalizeLinkUrl` | `sanitizeRichTextHtml` | `lintLinks` |
+|---|---|---|---|
+| User typing in the rich-text link dialog | ✅ blocks at insert | n/a (never reaches content) | n/a |
+| Imported BeeFree / Unlayer / HTML JSON | ❌ bypasses dialog | ✅ stripped at render | ✅ surfaces to author |
+| Programmatic `setContent()` with bad anchor | ❌ | ✅ stripped at render | ✅ surfaces to author |
+| `button.url`, `image.linkUrl`, `video.url`, `menu.items[].url`, `social.icons[].url` (structured fields, not HTML) | ❌ | ❌ sanitizer only scans rich-text HTML | ✅ surfaces to author |
+
+So `lintLinks` is the **only authoring-time signal** for unsafe URLs in structured fields, and the **only feedback channel** when a stripped value would otherwise vanish silently from rich-text imports.
+
+## API
+
+```ts
+import { lintLinks } from "@templatical/quality";
+
+const issues = lintLinks(content, options?);
+// issues: LintIssue[] — each entry has ruleId starting with "link."
+```
+
+Same signature as `lintAccessibility` and `lintStructure`. Same `LintOptions` shape. Same `LintIssue` return type. You can run all three linters independently or merge results.
+
+In the editor, the `useTemplateLint` composable lazy-imports `@templatical/quality` and runs every linter on every (debounced) content change. Link issues appear in the **Issues** sidebar tab alongside accessibility and structure issues.
+
+## Configuration
+
+`lintLinks` reads one optional knob under `LintOptions.links`:
+
+```ts
+interface LintLinksOptions {
+  nonProductionHosts?: string[];
+}
+```
+
+### `links.nonProductionHosts`
+
+| Default | `['localhost', '127.0.0.1', '0.0.0.0', '*.local', '*.staging.*', '*.dev.*']` |
+|---|---|
+
+Glob-style patterns matched against the URL host. `*` matches any run of characters (including `.`) — so `*.staging.*` matches `app.staging.example.com` and `*.local` matches `acme.local` or `a.b.c.local`. Patterns are anchored, so `*.local` does NOT match `acme.local-tools`. Case-insensitive.
+
+Pass an empty array to silence `link.localhost-or-staging` without disabling the rule outright:
+
+```ts
+lintLinks(content, {
+  links: { nonProductionHosts: [] },
+});
+```
+
+Or extend / replace with your own patterns:
+
+```ts
+lintLinks(content, {
+  links: {
+    nonProductionHosts: [
+      "*.preview.*",       // catch a vendor preview host
+      "*.internal.acme.io" // catch internal staging
+    ],
+  },
+});
+```
+
+The `DEFAULT_NON_PRODUCTION_HOSTS` constant is exported if you need to reference the baseline programmatically.
+
+## Quick links
+
+- [Rule catalog](./rule-catalog) — every link rule with severity, scope, and rationale.
+- [Options](../options) — shared across every linter.
+- [Severity & fixes](../severity-and-fixes) — how severity overrides land and the fix-application model.
+- [Headless usage](../headless-usage) — validating stored templates in CI.
+- [Contributing locales](../contributing-locales) — adding link rule messages.

--- a/apps/docs/quality/links/rule-catalog.md
+++ b/apps/docs/quality/links/rule-catalog.md
@@ -1,0 +1,32 @@
+# Link rule catalog
+
+The 5 rules `lintLinks` ships. Each rule lives in `packages/quality/src/links/rules/`; severity is user-overridable per [Options](../options). All rules scan every URL source returned by `walkUrls` — anchors inside rich text plus `button.url`, `image.linkUrl`, `video.url`, `menu.items[].url`, `social.icons[].url`.
+
+## Dangerous protocols
+
+| Rule | Default severity | Auto-fix | What it checks |
+|---|---|---|---|
+| `link.javascript-protocol` | error | — | Href starts with `javascript:` (or whitespace-padded / case-bypass variants like ` JaVaScRiPt:`). The editor's `sanitizeRichTextHtml` already strips these from rich-text content at render so they can't execute, and the rich-text link dialog blocks insertion — but values from imported JSON, programmatic API calls, or structured fields (`button.url`, `image.linkUrl`, `menu.items[].url`, `social.icons[].url`) sit in the template silently. This rule surfaces them at authoring time so the JSON gets fixed, not just rendered around. |
+
+## Unsupported protocols
+
+| Rule | Default severity | Auto-fix | What it checks |
+|---|---|---|---|
+| `link.unsupported-protocol` | warning | — | Href uses an explicit protocol other than `http`, `https`, `mailto`, `tel`, or `sms`. Custom protocols (`ftp:`, `file:`, `data:`, app deep-links) typically don't work from email clients and indicate either a copy-paste mistake or an unsupported integration. Relative URLs and bare paths are ignored. `javascript:` is excluded — its own rule covers that. |
+
+## Malformed URIs
+
+| Rule | Default severity | Auto-fix | What it checks |
+|---|---|---|---|
+| `link.malformed-mailto` | warning | — | `mailto:` href is empty, has no `@`, is missing the local or domain part, or the domain has no `.`. Query-string fragments (`?subject=…`, `?cc=…`, `?body=…`) are accepted. Multi-recipient `mailto:a@x.com,b@y.com` is accepted. Pragmatic — not a full RFC validator. |
+| `link.malformed-tel` | warning | — | `tel:` href contains characters outside `+`, digits, spaces, dashes, parentheses, and dots. Most clients silently fail on bad `tel:` URIs (e.g. `tel:CALL-NOW`). |
+
+## Environment leaks
+
+| Rule | Default severity | Auto-fix | What it checks |
+|---|---|---|---|
+| `link.localhost-or-staging` | warning | — | URL host matches the configured non-production host list. Default list catches `localhost`, `127.0.0.1`, `0.0.0.0`, `*.local`, `*.staging.*`, `*.dev.*`. Configurable via `options.links.nonProductionHosts` — see the [overview](./) for default extension / replacement patterns. Only fires on `http(s)` and `ftp(s)` URLs; mailto/tel/sms are skipped. |
+
+## Why no auto-fixes?
+
+Each link rule is destructive (strip href / change protocol) and the right answer depends on intent — `javascript:alert(1)` may belong on a button that should be deleted, or it may be a typo for `mailto:`. Detection-only is safer than guessing. Headless callers can filter `LintIssue[]` by `ruleId.startsWith("link.")` and apply their own policy (block save, send to review queue, …).

--- a/apps/docs/quality/options.md
+++ b/apps/docs/quality/options.md
@@ -1,6 +1,6 @@
 # Options
 
-`lintAccessibility` and `lintStructure` accept the same `LintOptions` shape. Every field is optional.
+`lintAccessibility`, `lintStructure`, and `lintLinks` accept the same `LintOptions` shape. Every field is optional.
 
 ```ts
 interface LintOptions {
@@ -8,12 +8,13 @@ interface LintOptions {
   locale?: string;
   rules?: Record<string, Severity>;
   thresholds?: Partial<LintThresholds>;
+  links?: LintLinksOptions;
 }
 
 type Severity = "error" | "warning" | "info" | "off";
 ```
 
-The same object also gates the editor's `init({ lint })` config — every option here applies to both linters via the shared `useTemplateLint` composable.
+The same object also gates the editor's `init({ lint })` config — every option here applies to every linter via the shared `useTemplateLint` composable.
 
 ## `disabled`
 
@@ -40,6 +41,7 @@ Drives the message templates the linter returns (one file per locale per linter)
 // Headless — set explicitly
 lintAccessibility(content, { locale: "de" });
 lintStructure(content, { locale: "de" });
+lintLinks(content, { locale: "de" });
 
 // Editor — linter automatically follows the editor locale
 init({ locale: "de" });
@@ -48,7 +50,7 @@ init({ locale: "de" });
 ::: warning Editor mode ignores `lint.locale`
 In editor mode the linter locale is **forced** to the editor's `locale` from `init({ locale })`. Setting `lint.locale` has no effect — it's overwritten on the way through.
 
-Headless callers (`lintAccessibility(...)` / `lintStructure(...)` directly) keep full control.
+Headless callers (`lintAccessibility(...)` / `lintStructure(...)` / `lintLinks(...)` directly) keep full control.
 :::
 
 ::: tip Vague-text dictionaries are cross-locale
@@ -68,12 +70,13 @@ Per-rule severity override. Set a rule to `'off'` to disable it entirely. Set to
   "a11y.text-all-caps": "off",         // disable
   "a11y.missing-preheader": "warning", // promote info → warning
   "structure.empty-column": "info",    // demote warning → info
+  "link.localhost-or-staging": "error",// promote to error before send
 }
 ```
 
-Rule IDs are namespaced by linter: `a11y.*` for accessibility rules, `structure.*` for structure rules. Override keys must use the full prefixed ID.
+Rule IDs are namespaced by linter: `a11y.*` for accessibility rules, `structure.*` for structure rules, `link.*` for link rules. Override keys must use the full prefixed ID.
 
-The override applies before the rule runs, so disabled rules don't even execute. See each linter's rule catalog for default severities: [accessibility](./accessibility/rule-catalog) · [structure](./structure/rule-catalog).
+The override applies before the rule runs, so disabled rules don't even execute. See each linter's rule catalog for default severities: [accessibility](./accessibility/rule-catalog) · [structure](./structure/rule-catalog) · [links](./links/rule-catalog).
 
 ## `thresholds`
 
@@ -98,3 +101,31 @@ lintAccessibility(content, {
 ```
 
 The `DEFAULT_A11Y_THRESHOLDS` constant is also exported if you need to reference the baseline programmatically.
+
+## `links`
+
+`lintLinks` reads one optional sub-object:
+
+```ts
+interface LintLinksOptions {
+  nonProductionHosts?: string[];
+}
+```
+
+### `links.nonProductionHosts`
+
+| Default | `['localhost', '127.0.0.1', '0.0.0.0', '*.local', '*.staging.*', '*.dev.*']` |
+|---|---|
+
+Glob-style patterns matched against the URL host. `*` matches any run of characters (including `.`) — so `*.staging.*` matches `app.staging.example.com` and `*.local` matches `acme.local` or `a.b.c.local`. Patterns are anchored, so `*.local` does NOT match `acme.local-tools`. Case-insensitive.
+
+```ts
+lintLinks(content, {
+  links: { nonProductionHosts: ["*.preview.*"] },
+});
+
+// Or silence the rule without disabling it:
+lintLinks(content, { links: { nonProductionHosts: [] } });
+```
+
+`DEFAULT_NON_PRODUCTION_HOSTS` is exported as the baseline. See the [links overview](./links/) for more.

--- a/apps/docs/quality/severity-and-fixes.md
+++ b/apps/docs/quality/severity-and-fixes.md
@@ -1,6 +1,6 @@
 # Severity & fixes
 
-Both linters share the same severity model and patch shape, so this page covers `lintAccessibility` and `lintStructure` together.
+Every linter shares the same severity model and patch shape, so this page covers `lintAccessibility`, `lintStructure`, and `lintLinks` together.
 
 ## Severity model
 
@@ -37,11 +37,16 @@ In the editor, `apply` runs through the existing `editor.updateBlock` / `editor.
 Headless callers can construct their own `LintPatchContext` and apply patches programmatically:
 
 ```ts
-import { lintAccessibility, lintStructure } from "@templatical/quality";
+import {
+  lintAccessibility,
+  lintLinks,
+  lintStructure,
+} from "@templatical/quality";
 
 const issues = [
   ...lintAccessibility(content),
   ...lintStructure(content),
+  ...lintLinks(content),
 ];
 const fixable = issues.filter((i) => i.fix);
 
@@ -60,5 +65,6 @@ See the **Auto-fix** column in each catalog. Today's auto-fixable rules:
 
 - Accessibility — `a11y.img-alt-is-filename`, `a11y.img-decorative-needs-empty-alt`, `a11y.link-target-blank-no-rel`.
 - Structure — `structure.empty-section`.
+- Links — none. Every link rule is destructive to auto-fix (strip the href, change the protocol) and the right answer depends on intent.
 
 Auto-fixes are added conservatively — only when the right answer is unambiguous. `structure.empty-column`, for example, has no auto-fix because removing an empty column requires changing the section's `columns` layout, and the right answer (merge into a sibling vs. drop the section vs. change the layout key) depends on intent.

--- a/apps/playground/e2e/tests/lint.spec.ts
+++ b/apps/playground/e2e/tests/lint.spec.ts
@@ -58,4 +58,25 @@ test.describe("Template lint (a11y + structure)", () => {
     await tab.waitFor();
     await expect(tab).toContainText(/2/);
   });
+
+  test("link.javascript-protocol fires when a button URL is `javascript:`", async ({
+    blankEditorReady: { editorPage },
+    page,
+  }) => {
+    await editorPage.dragBlockFromSidebar("button");
+    await editorPage.selectBlockByType("button");
+
+    // Fill the URL input in the button toolbar. There is only one
+    // `type="url"` input on the right panel — match it directly.
+    const urlInput = page
+      .locator(SELECTORS.rightPanelContent)
+      .locator('input[type="url"]');
+    await urlInput.fill("javascript:alert(1)");
+    // Blur so the model-update is committed before lint runs.
+    await urlInput.blur();
+
+    await editorPage.openIssuesTab();
+    const row = editorPage.getIssueRow("link.javascript-protocol");
+    await expect(row).toBeVisible();
+  });
 });

--- a/packages/editor/src/composables/useTemplateLint.ts
+++ b/packages/editor/src/composables/useTemplateLint.ts
@@ -11,6 +11,7 @@ import type {
   LintOptions,
   lintAccessibility as LintAccessibilityFn,
   lintStructure as LintStructureFn,
+  lintLinks as LintLinksFn,
 } from "@templatical/quality";
 
 export type { LintIssue, LintOptions } from "@templatical/quality";
@@ -38,6 +39,7 @@ export interface UseTemplateLintReturn {
 interface Loaded {
   lintAccessibility: typeof LintAccessibilityFn;
   lintStructure: typeof LintStructureFn;
+  lintLinks: typeof LintLinksFn;
 }
 
 /**
@@ -77,6 +79,7 @@ export function useTemplateLint(
       loaded.value = {
         lintAccessibility: mod.lintAccessibility,
         lintStructure: mod.lintStructure,
+        lintLinks: mod.lintLinks,
       };
       ready.value = true;
       runLint();
@@ -102,7 +105,8 @@ export function useTemplateLint(
       opts.content.value,
       opts.options,
     );
-    issues.value = [...a11y, ...structure];
+    const links = loaded.value.lintLinks(opts.content.value, opts.options);
+    issues.value = [...a11y, ...structure, ...links];
   }
 
   // Re-run when severity overrides change at runtime (rare, but useful for

--- a/packages/editor/tests/useTemplateLint.test.ts
+++ b/packages/editor/tests/useTemplateLint.test.ts
@@ -13,6 +13,7 @@ function createContent(): TemplateContent {
 interface QualityMockHandle {
   lintAccessibility: ReturnType<typeof vi.fn>;
   lintStructure: ReturnType<typeof vi.fn>;
+  lintLinks: ReturnType<typeof vi.fn>;
   resolveImport: () => void;
   rejectImport: (err: unknown) => void;
 }
@@ -26,6 +27,7 @@ async function setupQualityMock(): Promise<QualityMockHandle> {
 
   const lintAccessibility = vi.fn(() => [] as unknown[]);
   const lintStructure = vi.fn(() => [] as unknown[]);
+  const lintLinks = vi.fn(() => [] as unknown[]);
   let resolve!: () => void;
   let reject!: (err: unknown) => void;
   const importPromise = new Promise<void>((res, rej) => {
@@ -35,12 +37,13 @@ async function setupQualityMock(): Promise<QualityMockHandle> {
 
   vi.doMock("@templatical/quality", async () => {
     await importPromise;
-    return { lintAccessibility, lintStructure };
+    return { lintAccessibility, lintStructure, lintLinks };
   });
 
   return {
     lintAccessibility,
     lintStructure,
+    lintLinks,
     resolveImport: resolve,
     rejectImport: reject,
   };
@@ -82,6 +85,7 @@ describe("useTemplateLint", () => {
 
     expect(mock.lintAccessibility).not.toHaveBeenCalled();
     expect(mock.lintStructure).not.toHaveBeenCalled();
+    expect(mock.lintLinks).not.toHaveBeenCalled();
     expect(result.ready.value).toBe(false);
 
     // Mutate content. If a leaked watcher exists, it would fire runLint after
@@ -94,9 +98,10 @@ describe("useTemplateLint", () => {
 
     expect(mock.lintAccessibility).not.toHaveBeenCalled();
     expect(mock.lintStructure).not.toHaveBeenCalled();
+    expect(mock.lintLinks).not.toHaveBeenCalled();
   });
 
-  it("runs both linters on content changes when alive", async () => {
+  it("runs every linter on content changes when alive", async () => {
     const mock = await setupQualityMock();
     const useTemplateLint = await loadComposable();
 
@@ -118,6 +123,7 @@ describe("useTemplateLint", () => {
 
     expect(mock.lintAccessibility).toHaveBeenCalledTimes(1);
     expect(mock.lintStructure).toHaveBeenCalledTimes(1);
+    expect(mock.lintLinks).toHaveBeenCalledTimes(1);
 
     content.value = {
       blocks: [{ id: "b2", type: "paragraph" }],
@@ -127,15 +133,19 @@ describe("useTemplateLint", () => {
 
     expect(mock.lintAccessibility).toHaveBeenCalledTimes(2);
     expect(mock.lintStructure).toHaveBeenCalledTimes(2);
+    expect(mock.lintLinks).toHaveBeenCalledTimes(2);
   });
 
-  it("merges issues from both linters", async () => {
+  it("merges issues from every linter", async () => {
     const mock = await setupQualityMock();
     mock.lintAccessibility.mockReturnValue([
       { ruleId: "a11y.x", blockId: "b1", severity: "error", message: "a" },
     ]);
     mock.lintStructure.mockReturnValue([
       { ruleId: "structure.x", blockId: "b1", severity: "error", message: "b" },
+    ]);
+    mock.lintLinks.mockReturnValue([
+      { ruleId: "link.x", blockId: "b1", severity: "error", message: "c" },
     ]);
     const useTemplateLint = await loadComposable();
 
@@ -155,6 +165,7 @@ describe("useTemplateLint", () => {
     expect(result.issues.value.map((i) => i.ruleId)).toEqual([
       "a11y.x",
       "structure.x",
+      "link.x",
     ]);
   });
 
@@ -177,5 +188,6 @@ describe("useTemplateLint", () => {
 
     expect(mock.lintAccessibility).not.toHaveBeenCalled();
     expect(mock.lintStructure).not.toHaveBeenCalled();
+    expect(mock.lintLinks).not.toHaveBeenCalled();
   });
 });

--- a/packages/quality/src/index.ts
+++ b/packages/quality/src/index.ts
@@ -1,7 +1,10 @@
 export { lintAccessibility, ACCESSIBILITY_RULES } from "./accessibility";
 export { lintStructure, STRUCTURE_RULES } from "./structure";
+export { lintLinks, LINK_RULES } from "./links";
 export { walkBlocks } from "./walk";
 export type { Visitor } from "./walk";
+export { walkUrls } from "./url-walker";
+export type { UrlOccurrence, UrlSource } from "./url-walker";
 export { getContrastRatio, parseHex, isOpaqueHex } from "./contrast";
 export { extractAnchors, extractText } from "./html-utils";
 export type { AnchorInfo } from "./html-utils";
@@ -25,12 +28,20 @@ export type {
   StructureMessageMap,
   StructureRuleMessageId,
 } from "./structure/messages";
+export {
+  formatLinkMessage,
+  getLinkMessages,
+  SUPPORTED_LINK_MESSAGE_LOCALES,
+} from "./links/messages";
+export type { LinkMessageMap, LinkRuleMessageId } from "./links/messages";
 export type {
   LintIssue,
+  LintLinksOptions,
   LintOptions,
   LintPatch,
   LintPatchContext,
   LintThresholds,
+  ResolvedLinksOptions,
   ResolvedOptions,
   Rule,
   RuleHit,
@@ -38,4 +49,4 @@ export type {
   Severity,
   WalkContext,
 } from "./types";
-export { DEFAULT_A11Y_THRESHOLDS } from "./types";
+export { DEFAULT_A11Y_THRESHOLDS, DEFAULT_NON_PRODUCTION_HOSTS } from "./types";

--- a/packages/quality/src/links/index.ts
+++ b/packages/quality/src/links/index.ts
@@ -1,0 +1,26 @@
+import type { TemplateContent } from "@templatical/types";
+import type { LintIssue, LintOptions, Rule } from "../types";
+import { runRules } from "../run-rules";
+import { formatLinkMessage, type LinkRuleMessageId } from "./messages";
+import { javascriptProtocol } from "./rules/javascript-protocol";
+import { unsupportedProtocol } from "./rules/unsupported-protocol";
+import { malformedMailto } from "./rules/malformed-mailto";
+import { malformedTel } from "./rules/malformed-tel";
+import { localhostOrStaging } from "./rules/localhost-or-staging";
+
+export const LINK_RULES: Rule[] = [
+  javascriptProtocol,
+  unsupportedProtocol,
+  malformedMailto,
+  malformedTel,
+  localhostOrStaging,
+];
+
+export function lintLinks(
+  content: TemplateContent,
+  options: LintOptions = {},
+): LintIssue[] {
+  return runRules(content, LINK_RULES, options, (locale, id, params) =>
+    formatLinkMessage(locale, id as LinkRuleMessageId, params),
+  );
+}

--- a/packages/quality/src/links/messages/de.ts
+++ b/packages/quality/src/links/messages/de.ts
@@ -1,0 +1,16 @@
+import type en from "./en";
+
+const de: typeof en = {
+  "link.javascript-protocol":
+    'Die URL verwendet das „javascript:"-Protokoll, das aus Sicherheitsgründen beim Rendern entfernt wird. Ersetze sie durch eine echte URL oder entferne sie.',
+  "link.unsupported-protocol":
+    'Die URL verwendet das Protokoll „{protocol}", das von den meisten E-Mail-Clients nicht unterstützt wird. Verwende http, https, mailto, tel oder sms.',
+  "link.malformed-mailto":
+    "Der mailto:-Link ist fehlerhaft. Erwartet wird eine einzelne Empfängeradresse vor einer eventuellen Querystring (z. B. mailto:hallo@example.com).",
+  "link.malformed-tel":
+    "Der tel:-Link enthält Zeichen, die keine Ziffern, +, Leerzeichen, Bindestriche, Klammern oder Punkte sind.",
+  "link.localhost-or-staging":
+    'Der URL-Host „{host}" entspricht einem Nicht-Produktionsmuster. Ersetze ihn vor dem Versand durch die Produktions-URL.',
+};
+
+export default de;

--- a/packages/quality/src/links/messages/en.ts
+++ b/packages/quality/src/links/messages/en.ts
@@ -1,0 +1,20 @@
+/**
+ * English link-rule messages. The source of truth — other locales annotate
+ * themselves `typeof en` so missing or extra keys fail typecheck.
+ *
+ * Templates use `{name}` placeholders, interpolated by `formatLinkMessage`.
+ */
+const en = {
+  "link.javascript-protocol":
+    'URL uses the "javascript:" protocol, which is stripped at render time for safety. Replace it with a real link or remove the URL.',
+  "link.unsupported-protocol":
+    'URL uses the "{protocol}" protocol, which most email clients do not support. Use http, https, mailto, tel, or sms.',
+  "link.malformed-mailto":
+    "mailto: link is malformed. Expected a single recipient address before any query string (e.g. mailto:hello@example.com).",
+  "link.malformed-tel":
+    "tel: link contains characters that are not digits, +, spaces, dashes, parentheses, or dots.",
+  "link.localhost-or-staging":
+    'URL host "{host}" matches a non-production pattern. Replace with the production URL before sending.',
+};
+
+export default en;

--- a/packages/quality/src/links/messages/index.ts
+++ b/packages/quality/src/links/messages/index.ts
@@ -1,0 +1,38 @@
+import en from "./en";
+
+export type LinkMessageMap = typeof en;
+export type LinkRuleMessageId = keyof LinkMessageMap;
+
+const modules = import.meta.glob<{ default: LinkMessageMap }>("./*.ts", {
+  eager: true,
+});
+
+const MESSAGES: Record<string, LinkMessageMap> = {};
+for (const path in modules) {
+  const match = /\.\/([^/]+)\.ts$/.exec(path);
+  if (!match) continue;
+  const locale = match[1];
+  if (locale === "index") continue;
+  MESSAGES[locale] = modules[path].default;
+}
+
+export const SUPPORTED_LINK_MESSAGE_LOCALES = Object.keys(MESSAGES);
+
+export function getLinkMessages(locale: string): LinkMessageMap {
+  const base = locale.split("-")[0]?.toLowerCase() ?? "en";
+  return MESSAGES[base] ?? MESSAGES.en ?? en;
+}
+
+export function formatLinkMessage(
+  locale: string,
+  ruleId: LinkRuleMessageId,
+  params?: Record<string, string | number>,
+): string {
+  const map = getLinkMessages(locale);
+  const template = map[ruleId] ?? en[ruleId];
+  if (!params) return template;
+  return template.replace(/\{(\w+)\}/g, (_, key: string) => {
+    const value = params[key];
+    return value === undefined ? `{${key}}` : String(value);
+  });
+}

--- a/packages/quality/src/links/rules/javascript-protocol.ts
+++ b/packages/quality/src/links/rules/javascript-protocol.ts
@@ -1,0 +1,31 @@
+import type { Rule, RuleHit, RuleMeta } from "../../types";
+import { walkUrls } from "../../url-walker";
+
+export const meta: RuleMeta = {
+  id: "link.javascript-protocol",
+  severity: "error",
+};
+
+/**
+ * Match `javascript:` even when the value is whitespace-padded or mixed-case.
+ * Mirrors what HTML attribute parsers see at insert time — leading whitespace
+ * (spaces, tabs, newlines) is stripped before scheme parsing.
+ */
+function isJavascriptProtocol(url: string): boolean {
+  if (!url) return false;
+  const stripped = url.replace(/\s+/g, "");
+  return /^javascript:/i.test(stripped);
+}
+
+export const javascriptProtocol: Rule = {
+  meta,
+  template(content): RuleHit[] {
+    const hits: RuleHit[] = [];
+    for (const occ of walkUrls(content)) {
+      if (isJavascriptProtocol(occ.url)) {
+        hits.push({ blockId: occ.blockId });
+      }
+    }
+    return hits;
+  },
+};

--- a/packages/quality/src/links/rules/localhost-or-staging.ts
+++ b/packages/quality/src/links/rules/localhost-or-staging.ts
@@ -1,0 +1,50 @@
+import type { ResolvedOptions, Rule, RuleHit, RuleMeta } from "../../types";
+import { walkUrls } from "../../url-walker";
+
+export const meta: RuleMeta = {
+  id: "link.localhost-or-staging",
+  severity: "warning",
+};
+
+/**
+ * Glob → RegExp for the `nonProductionHosts` pattern set. `*` is a wildcard
+ * that matches any run of characters (including `.`) so `*.staging.*`
+ * matches `app.staging.example.com` and `*.local` matches both `acme.local`
+ * and `a.b.c.local`. Case-insensitive.
+ */
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  const expanded = escaped.replace(/\*/g, ".*");
+  return new RegExp(`^${expanded}$`, "i");
+}
+
+function extractHost(url: string): string | null {
+  if (!url) return null;
+  const trimmed = url.trim();
+  // mailto/tel/sms have no host concept worth matching.
+  if (!/^(https?|ftps?):\/\//i.test(trimmed)) return null;
+  try {
+    return new URL(trimmed).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export const localhostOrStaging: Rule = {
+  meta,
+  template(content, opts: ResolvedOptions): RuleHit[] {
+    const patterns = opts.links.nonProductionHosts;
+    if (patterns.length === 0) return [];
+    const regexes = patterns.map(globToRegex);
+    const hits: RuleHit[] = [];
+
+    for (const occ of walkUrls(content)) {
+      const host = extractHost(occ.url);
+      if (host === null) continue;
+      if (regexes.some((re) => re.test(host))) {
+        hits.push({ blockId: occ.blockId, params: { host } });
+      }
+    }
+    return hits;
+  },
+};

--- a/packages/quality/src/links/rules/malformed-mailto.ts
+++ b/packages/quality/src/links/rules/malformed-mailto.ts
@@ -1,0 +1,47 @@
+import type { Rule, RuleHit, RuleMeta } from "../../types";
+import { walkUrls } from "../../url-walker";
+
+export const meta: RuleMeta = {
+  id: "link.malformed-mailto",
+  severity: "warning",
+};
+
+/**
+ * Pragmatic RFC-5321-ish sanity check, not a full validator. Splits on `?`,
+ * requires the left side to contain exactly one `@` with a non-empty local
+ * part and a domain that includes at least one dot.
+ *
+ * Multi-recipient `mailto:a@x.com,b@y.com` is accepted (commas pass through;
+ * each recipient is validated individually).
+ */
+function isMalformedMailto(url: string): boolean {
+  const trimmed = url.trim();
+  if (!/^mailto:/i.test(trimmed)) return false;
+  const value = trimmed.slice("mailto:".length);
+  const [recipients] = value.split("?", 2);
+  if (recipients.trim() === "") return true;
+
+  const list = recipients.split(",").map((r) => r.trim());
+  for (const recipient of list) {
+    if (recipient === "") return true;
+    const at = recipient.split("@");
+    if (at.length !== 2) return true;
+    const [local, domain] = at;
+    if (local === "" || domain === "") return true;
+    if (!domain.includes(".")) return true;
+  }
+  return false;
+}
+
+export const malformedMailto: Rule = {
+  meta,
+  template(content): RuleHit[] {
+    const hits: RuleHit[] = [];
+    for (const occ of walkUrls(content)) {
+      if (isMalformedMailto(occ.url)) {
+        hits.push({ blockId: occ.blockId });
+      }
+    }
+    return hits;
+  },
+};

--- a/packages/quality/src/links/rules/malformed-tel.ts
+++ b/packages/quality/src/links/rules/malformed-tel.ts
@@ -1,0 +1,30 @@
+import type { Rule, RuleHit, RuleMeta } from "../../types";
+import { walkUrls } from "../../url-walker";
+
+export const meta: RuleMeta = {
+  id: "link.malformed-tel",
+  severity: "warning",
+};
+
+const VALID_TEL_CHARS = /^[+0-9\s().\-]+$/;
+
+function isMalformedTel(url: string): boolean {
+  const trimmed = url.trim();
+  if (!/^tel:/i.test(trimmed)) return false;
+  const value = trimmed.slice("tel:".length).trim();
+  if (value === "") return true;
+  return !VALID_TEL_CHARS.test(value);
+}
+
+export const malformedTel: Rule = {
+  meta,
+  template(content): RuleHit[] {
+    const hits: RuleHit[] = [];
+    for (const occ of walkUrls(content)) {
+      if (isMalformedTel(occ.url)) {
+        hits.push({ blockId: occ.blockId });
+      }
+    }
+    return hits;
+  },
+};

--- a/packages/quality/src/links/rules/unsupported-protocol.ts
+++ b/packages/quality/src/links/rules/unsupported-protocol.ts
@@ -1,0 +1,37 @@
+import type { Rule, RuleHit, RuleMeta } from "../../types";
+import { walkUrls } from "../../url-walker";
+
+export const meta: RuleMeta = {
+  id: "link.unsupported-protocol",
+  severity: "warning",
+};
+
+const SUPPORTED = new Set(["http", "https", "mailto", "tel", "sms"]);
+
+/**
+ * Treat `javascript:` (covered by its own rule) and bare/relative URLs as
+ * "not unsupported" — this rule fires only for explicitly named schemes that
+ * email clients typically refuse.
+ */
+function getProtocol(url: string): string | null {
+  if (!url) return null;
+  const trimmed = url.trim();
+  const match = /^([a-z][a-z0-9+\-.]*):/i.exec(trimmed);
+  if (!match) return null;
+  return match[1].toLowerCase();
+}
+
+export const unsupportedProtocol: Rule = {
+  meta,
+  template(content): RuleHit[] {
+    const hits: RuleHit[] = [];
+    for (const occ of walkUrls(content)) {
+      const protocol = getProtocol(occ.url);
+      if (protocol === null) continue;
+      if (protocol === "javascript") continue;
+      if (SUPPORTED.has(protocol)) continue;
+      hits.push({ blockId: occ.blockId, params: { protocol } });
+    }
+    return hits;
+  },
+};

--- a/packages/quality/src/run-rules.ts
+++ b/packages/quality/src/run-rules.ts
@@ -7,7 +7,7 @@ import type {
   RuleHit,
   Severity,
 } from "./types";
-import { DEFAULT_A11Y_THRESHOLDS } from "./types";
+import { DEFAULT_A11Y_THRESHOLDS, DEFAULT_NON_PRODUCTION_HOSTS } from "./types";
 import { walkBlocks } from "./walk";
 
 export type MessageFormatter = (
@@ -81,12 +81,17 @@ export function resolveOptions(
     ...DEFAULT_A11Y_THRESHOLDS,
     ...(options.thresholds ?? {}),
   };
+  const links = {
+    nonProductionHosts:
+      options.links?.nonProductionHosts ?? DEFAULT_NON_PRODUCTION_HOSTS,
+  };
   const locale = options.locale ?? "en";
 
   return {
     locale,
     rules: overrides,
     thresholds,
+    links,
     severity: (ruleId: string): Severity => {
       const override = overrides[ruleId];
       if (override !== undefined) {

--- a/packages/quality/src/types.ts
+++ b/packages/quality/src/types.ts
@@ -34,6 +34,19 @@ export interface LintThresholds {
   minTouchTargetPx: number;
 }
 
+export interface LintLinksOptions {
+  /**
+   * Host patterns that should flag as "staging / non-production".
+   * Each entry is a glob-style pattern matched against the URL host.
+   * `*` matches any run of characters (including `.`), so `*.staging.*`
+   * matches `app.staging.example.com`.
+   *
+   * Default: ['localhost', '127.0.0.1', '0.0.0.0', '*.local',
+   *           '*.staging.*', '*.dev.*']
+   */
+  nonProductionHosts?: string[];
+}
+
 export interface LintOptions {
   /**
    * Fully disable linting. When true, the editor skips lazy-loading the
@@ -45,12 +58,19 @@ export interface LintOptions {
   /** Per-rule severity override. Set to `'off'` to disable a specific rule. */
   rules?: Record<string, Severity>;
   thresholds?: Partial<LintThresholds>;
+  /** Per-linter knobs. Only `lintLinks` reads `links` today. */
+  links?: LintLinksOptions;
+}
+
+export interface ResolvedLinksOptions {
+  nonProductionHosts: string[];
 }
 
 export interface ResolvedOptions {
   locale: string;
   rules: Record<string, Severity>;
   thresholds: LintThresholds;
+  links: ResolvedLinksOptions;
   /** Returns the effective severity for a rule (override or default). */
   severity: (ruleId: string) => Severity;
 }
@@ -104,3 +124,12 @@ export const DEFAULT_A11Y_THRESHOLDS: LintThresholds = {
   allCapsMinLength: 20,
   minTouchTargetPx: 44,
 };
+
+export const DEFAULT_NON_PRODUCTION_HOSTS: string[] = [
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "*.local",
+  "*.staging.*",
+  "*.dev.*",
+];

--- a/packages/quality/src/url-walker.ts
+++ b/packages/quality/src/url-walker.ts
@@ -1,0 +1,119 @@
+import type { TemplateContent } from "@templatical/types";
+import {
+  isButton,
+  isHtml,
+  isImage,
+  isMenu,
+  isParagraph,
+  isSocialIcons,
+  isTitle,
+  isVideo,
+} from "@templatical/types";
+import { walkBlocks } from "./walk";
+import { extractAnchors } from "./html-utils";
+
+export type UrlSource =
+  | "anchor"
+  | "button"
+  | "image-link"
+  | "video"
+  | "menu-item"
+  | "social-icon";
+
+export interface UrlOccurrence {
+  url: string;
+  blockId: string;
+  source: UrlSource;
+  /** Anchor text or block-derived label, if applicable. */
+  label?: string;
+}
+
+/**
+ * Visit every URL-bearing field in the template tree.
+ *
+ * Sources covered:
+ *  - anchor      — `<a href>` inside `title.content`, `paragraph.content`,
+ *                  `html.content` (parsed via extractAnchors)
+ *  - button      — `button.url`
+ *  - image-link  — `image.linkUrl` (only when present + non-empty)
+ *  - video       — `video.url`
+ *  - menu-item   — `menu.items[i].url`
+ *  - social-icon — `social.icons[i].url`
+ *
+ * Each rule iterates this list once and decides per occurrence.
+ */
+export function walkUrls(content: TemplateContent): UrlOccurrence[] {
+  const occurrences: UrlOccurrence[] = [];
+
+  walkBlocks(content, (block) => {
+    if (isTitle(block) || isParagraph(block) || isHtml(block)) {
+      for (const anchor of extractAnchors(block.content)) {
+        occurrences.push({
+          url: anchor.href,
+          blockId: block.id,
+          source: "anchor",
+          label: anchor.text,
+        });
+      }
+      return;
+    }
+
+    if (isButton(block)) {
+      occurrences.push({
+        url: block.url,
+        blockId: block.id,
+        source: "button",
+        label: block.text,
+      });
+      return;
+    }
+
+    if (isImage(block)) {
+      if (block.linkUrl && block.linkUrl !== "") {
+        occurrences.push({
+          url: block.linkUrl,
+          blockId: block.id,
+          source: "image-link",
+          label: block.alt || undefined,
+        });
+      }
+      return;
+    }
+
+    if (isVideo(block)) {
+      occurrences.push({
+        url: block.url,
+        blockId: block.id,
+        source: "video",
+        label: block.alt || undefined,
+      });
+      return;
+    }
+
+    if (isMenu(block)) {
+      for (const item of block.items) {
+        occurrences.push({
+          url: item.url,
+          blockId: block.id,
+          source: "menu-item",
+          label: item.text,
+        });
+      }
+      return;
+    }
+
+    if (isSocialIcons(block)) {
+      for (const icon of block.icons) {
+        occurrences.push({
+          url: icon.url,
+          blockId: block.id,
+          source: "social-icon",
+          label: icon.platform,
+        });
+      }
+      return;
+    }
+  });
+
+  return occurrences;
+}

--- a/packages/quality/tests/links/javascript-protocol.test.ts
+++ b/packages/quality/tests/links/javascript-protocol.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  createButtonBlock,
+  createDefaultTemplateContent,
+  createImageBlock,
+  createMenuBlock,
+  createParagraphBlock,
+  createSocialIconsBlock,
+  createVideoBlock,
+} from "@templatical/types";
+import { lintLinks } from "../../src";
+
+describe("link.javascript-protocol", () => {
+  it("does not fire on plain http/https URLs", () => {
+    const content = createDefaultTemplateContent();
+    const button = createButtonBlock({ url: "https://example.com" });
+    content.blocks = [button];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.javascript-protocol",
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("fires on a button.url with javascript: scheme", () => {
+    const content = createDefaultTemplateContent();
+    const button = createButtonBlock({ url: "javascript:alert(1)" });
+    content.blocks = [button];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.javascript-protocol",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe("error");
+    expect(issues[0].blockId).toBe(button.id);
+  });
+
+  it("fires on a paragraph anchor with javascript: href", () => {
+    const content = createDefaultTemplateContent();
+    const paragraph = createParagraphBlock({
+      content: '<p><a href="javascript:void(0)">click</a></p>',
+    });
+    content.blocks = [paragraph];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.javascript-protocol",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].blockId).toBe(paragraph.id);
+  });
+
+  it("fires on image.linkUrl", () => {
+    const content = createDefaultTemplateContent();
+    const image = createImageBlock({
+      src: "https://example.com/x.png",
+      linkUrl: "javascript:alert(1)",
+    });
+    content.blocks = [image];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.javascript-protocol",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].blockId).toBe(image.id);
+  });
+
+  it("fires on video.url", () => {
+    const content = createDefaultTemplateContent();
+    const video = createVideoBlock({ url: "javascript:alert(1)" });
+    content.blocks = [video];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.javascript-protocol",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].blockId).toBe(video.id);
+  });
+
+  it("fires on menu.items[i].url", () => {
+    const content = createDefaultTemplateContent();
+    const menu = createMenuBlock({
+      items: [
+        {
+          id: "m1",
+          text: "Home",
+          url: "javascript:alert(1)",
+          openInNewTab: false,
+          bold: false,
+          underline: false,
+        },
+      ],
+    });
+    content.blocks = [menu];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.javascript-protocol",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].blockId).toBe(menu.id);
+  });
+
+  it("fires on social.icons[i].url", () => {
+    const content = createDefaultTemplateContent();
+    const social = createSocialIconsBlock({
+      icons: [
+        { id: "i1", platform: "facebook", url: "javascript:alert(1)" },
+      ],
+    });
+    content.blocks = [social];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.javascript-protocol",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].blockId).toBe(social.id);
+  });
+
+  it("catches whitespace-padded and mixed-case variants", () => {
+    const content = createDefaultTemplateContent();
+    const a = createButtonBlock({ url: " JaVaScRiPt:alert(1)" });
+    const b = createButtonBlock({ url: "\tjavascript:alert(1)" });
+    content.blocks = [a, b];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.javascript-protocol",
+    );
+    expect(issues).toHaveLength(2);
+  });
+
+  it("respects severity override and `off` disables the rule", () => {
+    const content = createDefaultTemplateContent();
+    const button = createButtonBlock({ url: "javascript:alert(1)" });
+    content.blocks = [button];
+
+    const warned = lintLinks(content, {
+      rules: { "link.javascript-protocol": "warning" },
+    }).find((i) => i.ruleId === "link.javascript-protocol");
+    expect(warned?.severity).toBe("warning");
+
+    const off = lintLinks(content, {
+      rules: { "link.javascript-protocol": "off" },
+    }).filter((i) => i.ruleId === "link.javascript-protocol");
+    expect(off).toEqual([]);
+
+    expect(lintLinks(content, { disabled: true })).toEqual([]);
+  });
+});

--- a/packages/quality/tests/links/localhost-or-staging.test.ts
+++ b/packages/quality/tests/links/localhost-or-staging.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  createButtonBlock,
+  createDefaultTemplateContent,
+} from "@templatical/types";
+import { lintLinks } from "../../src";
+
+describe("link.localhost-or-staging", () => {
+  it("fires on localhost and 127.0.0.1 by default", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "http://localhost:3000/login" }),
+      createButtonBlock({ url: "http://127.0.0.1:8080/x" }),
+    ];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.localhost-or-staging",
+    );
+    expect(issues).toHaveLength(2);
+    expect(issues[0].severity).toBe("warning");
+    expect(issues[0].message).toContain("localhost");
+    expect(issues[1].message).toContain("127.0.0.1");
+  });
+
+  it("fires on glob patterns `*.local` and `*.staging.*`", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "https://app.local/x" }),
+      createButtonBlock({ url: "https://app.staging.example.com/x" }),
+    ];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.localhost-or-staging",
+    );
+    expect(issues).toHaveLength(2);
+  });
+
+  it("does not fire on production hosts", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "https://example.com/x" }),
+      createButtonBlock({ url: "https://www.acme.io" }),
+    ];
+    expect(
+      lintLinks(content).filter(
+        (i) => i.ruleId === "link.localhost-or-staging",
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not fire on mailto/tel even when address mentions a host", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "mailto:hi@localhost.example.com" }),
+      createButtonBlock({ url: "tel:+15551234567" }),
+    ];
+    expect(
+      lintLinks(content).filter(
+        (i) => i.ruleId === "link.localhost-or-staging",
+      ),
+    ).toEqual([]);
+  });
+
+  it("respects custom `nonProductionHosts` (only custom patterns fire)", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "https://app.preview.example.com/x" }),
+      createButtonBlock({ url: "http://localhost:3000/x" }),
+    ];
+    const issues = lintLinks(content, {
+      links: { nonProductionHosts: ["*.preview.*"] },
+    }).filter((i) => i.ruleId === "link.localhost-or-staging");
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("preview");
+  });
+
+  it("disables host matching entirely with empty array", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "http://localhost/x" })];
+    expect(
+      lintLinks(content, { links: { nonProductionHosts: [] } }).filter(
+        (i) => i.ruleId === "link.localhost-or-staging",
+      ),
+    ).toEqual([]);
+  });
+
+  it("anchors the host pattern so suffix-similar hosts do not match", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      // `*.local` is `^.*\.local$` — `app.example.com.local-tools` does NOT
+      // end in `.local` so the pattern doesn't match.
+      createButtonBlock({ url: "https://app.example.com.local-tools/x" }),
+    ];
+    const issues = lintLinks(content, {
+      links: { nonProductionHosts: ["*.local"] },
+    }).filter((i) => i.ruleId === "link.localhost-or-staging");
+    expect(issues).toEqual([]);
+  });
+
+  it("respects severity override and `off` disables the rule", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "http://localhost/x" })];
+
+    const promoted = lintLinks(content, {
+      rules: { "link.localhost-or-staging": "error" },
+    }).find((i) => i.ruleId === "link.localhost-or-staging");
+    expect(promoted?.severity).toBe("error");
+
+    const off = lintLinks(content, {
+      rules: { "link.localhost-or-staging": "off" },
+    }).filter((i) => i.ruleId === "link.localhost-or-staging");
+    expect(off).toEqual([]);
+
+    expect(lintLinks(content, { disabled: true })).toEqual([]);
+  });
+});

--- a/packages/quality/tests/links/malformed-mailto.test.ts
+++ b/packages/quality/tests/links/malformed-mailto.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  createButtonBlock,
+  createDefaultTemplateContent,
+} from "@templatical/types";
+import { lintLinks } from "../../src";
+
+describe("link.malformed-mailto", () => {
+  it("does not fire on a valid mailto", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "mailto:hi@example.com" })];
+    expect(
+      lintLinks(content).filter((i) => i.ruleId === "link.malformed-mailto"),
+    ).toEqual([]);
+  });
+
+  it("accepts query-string fragments (subject, cc, body)", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({
+        url: "mailto:hi@example.com?subject=Hi&body=Hello",
+      }),
+    ];
+    expect(
+      lintLinks(content).filter((i) => i.ruleId === "link.malformed-mailto"),
+    ).toEqual([]);
+  });
+
+  it("accepts multiple comma-separated recipients", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "mailto:a@example.com,b@example.com" }),
+    ];
+    expect(
+      lintLinks(content).filter((i) => i.ruleId === "link.malformed-mailto"),
+    ).toEqual([]);
+  });
+
+  it("fires when the address is empty", () => {
+    const content = createDefaultTemplateContent();
+    const b = createButtonBlock({ url: "mailto:" });
+    content.blocks = [b];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.malformed-mailto",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].blockId).toBe(b.id);
+    expect(issues[0].severity).toBe("warning");
+  });
+
+  it("fires when the address has no `@`", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "mailto:notanemail" })];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.malformed-mailto",
+    );
+    expect(issues).toHaveLength(1);
+  });
+
+  it("fires when the local or domain part is empty", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "mailto:@example.com" }),
+      createButtonBlock({ url: "mailto:hi@" }),
+    ];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.malformed-mailto",
+    );
+    expect(issues).toHaveLength(2);
+  });
+
+  it("fires when the domain is missing a dot", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "mailto:hi@localhost" })];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.malformed-mailto",
+    );
+    expect(issues).toHaveLength(1);
+  });
+
+  it("does not fire on non-mailto schemes", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "https://example.com" })];
+    expect(
+      lintLinks(content).filter((i) => i.ruleId === "link.malformed-mailto"),
+    ).toEqual([]);
+  });
+
+  it("respects severity override and `off` disables the rule", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "mailto:notanemail" })];
+
+    const promoted = lintLinks(content, {
+      rules: { "link.malformed-mailto": "error" },
+    }).find((i) => i.ruleId === "link.malformed-mailto");
+    expect(promoted?.severity).toBe("error");
+
+    const off = lintLinks(content, {
+      rules: { "link.malformed-mailto": "off" },
+    }).filter((i) => i.ruleId === "link.malformed-mailto");
+    expect(off).toEqual([]);
+
+    expect(lintLinks(content, { disabled: true })).toEqual([]);
+  });
+});

--- a/packages/quality/tests/links/malformed-tel.test.ts
+++ b/packages/quality/tests/links/malformed-tel.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  createButtonBlock,
+  createDefaultTemplateContent,
+} from "@templatical/types";
+import { lintLinks } from "../../src";
+
+describe("link.malformed-tel", () => {
+  it("accepts well-formed tel: URIs", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "tel:+15551234567" }),
+      createButtonBlock({ url: "tel:(555) 123-4567" }),
+      createButtonBlock({ url: "tel:555.123.4567" }),
+    ];
+    expect(
+      lintLinks(content).filter((i) => i.ruleId === "link.malformed-tel"),
+    ).toEqual([]);
+  });
+
+  it("fires when the value is empty", () => {
+    const content = createDefaultTemplateContent();
+    const b = createButtonBlock({ url: "tel:" });
+    content.blocks = [b];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.malformed-tel",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].blockId).toBe(b.id);
+    expect(issues[0].severity).toBe("warning");
+  });
+
+  it("fires when the value contains letters", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "tel:CALL-NOW" })];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.malformed-tel",
+    );
+    expect(issues).toHaveLength(1);
+  });
+
+  it("does not fire on non-tel schemes", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "https://example.com" })];
+    expect(
+      lintLinks(content).filter((i) => i.ruleId === "link.malformed-tel"),
+    ).toEqual([]);
+  });
+
+  it("respects severity override and `off` disables the rule", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "tel:CALL-NOW" })];
+
+    const promoted = lintLinks(content, {
+      rules: { "link.malformed-tel": "error" },
+    }).find((i) => i.ruleId === "link.malformed-tel");
+    expect(promoted?.severity).toBe("error");
+
+    const off = lintLinks(content, {
+      rules: { "link.malformed-tel": "off" },
+    }).filter((i) => i.ruleId === "link.malformed-tel");
+    expect(off).toEqual([]);
+
+    expect(lintLinks(content, { disabled: true })).toEqual([]);
+  });
+});

--- a/packages/quality/tests/links/messages.test.ts
+++ b/packages/quality/tests/links/messages.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import en from "../../src/links/messages/en";
+import de from "../../src/links/messages/de";
+import {
+  formatLinkMessage,
+  getLinkMessages,
+  SUPPORTED_LINK_MESSAGE_LOCALES,
+} from "../../src/links/messages";
+import { LINK_RULES } from "../../src";
+
+describe("link rule messages", () => {
+  it("en and de share the same key set", () => {
+    expect(Object.keys(de).sort()).toEqual(Object.keys(en).sort());
+  });
+
+  it("every registered link rule has an en + de message", () => {
+    for (const rule of LINK_RULES) {
+      expect(en).toHaveProperty(rule.meta.id);
+      expect(de).toHaveProperty(rule.meta.id);
+    }
+  });
+
+  it("placeholders match between locales for every key", () => {
+    const placeholders = (s: string) =>
+      Array.from(s.matchAll(/\{(\w+)\}/g))
+        .map((m) => m[1])
+        .sort();
+    for (const key of Object.keys(en) as Array<keyof typeof en>) {
+      expect(placeholders(de[key])).toEqual(placeholders(en[key]));
+    }
+  });
+
+  it("falls back to en for unsupported locales", () => {
+    expect(getLinkMessages("xx")).toBe(en);
+  });
+
+  it("strips region for matching", () => {
+    expect(getLinkMessages("de-AT")).toBe(de);
+  });
+
+  it("interpolates {protocol} for unsupported-protocol", () => {
+    const out = formatLinkMessage("en", "link.unsupported-protocol", {
+      protocol: "ftp",
+    });
+    expect(out).toContain('"ftp"');
+  });
+
+  it("interpolates {host} for localhost-or-staging", () => {
+    const out = formatLinkMessage("en", "link.localhost-or-staging", {
+      host: "localhost",
+    });
+    expect(out).toContain('"localhost"');
+  });
+
+  it("uses the German template when locale=de", () => {
+    const out = formatLinkMessage("de", "link.javascript-protocol");
+    expect(out).toContain("javascript");
+    expect(out).toContain("entfernt");
+  });
+
+  it("exports the supported locale list", () => {
+    expect(SUPPORTED_LINK_MESSAGE_LOCALES.sort()).toEqual(["de", "en"]);
+  });
+});

--- a/packages/quality/tests/links/unsupported-protocol.test.ts
+++ b/packages/quality/tests/links/unsupported-protocol.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  createButtonBlock,
+  createDefaultTemplateContent,
+  createParagraphBlock,
+} from "@templatical/types";
+import { lintLinks } from "../../src";
+
+describe("link.unsupported-protocol", () => {
+  it("does not fire on http/https/mailto/tel/sms", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "https://example.com" }),
+      createButtonBlock({ url: "http://example.com" }),
+      createButtonBlock({ url: "mailto:hi@example.com" }),
+      createButtonBlock({ url: "tel:+15551234567" }),
+      createButtonBlock({ url: "sms:+15551234567" }),
+    ];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.unsupported-protocol",
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("does not fire on relative URLs or bare paths", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "/path/to/page" }),
+      createButtonBlock({ url: "page.html" }),
+      createButtonBlock({ url: "#anchor" }),
+    ];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.unsupported-protocol",
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("does not fire on `javascript:` (its own rule covers that)", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "javascript:alert(1)" })];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.unsupported-protocol",
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("fires on ftp:, file:, data:, custom app schemes", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "ftp://example.com/file" }),
+      createButtonBlock({ url: "file:///etc/passwd" }),
+      createButtonBlock({ url: "data:text/plain,hello" }),
+      createButtonBlock({ url: "myapp://open?id=42" }),
+    ];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.unsupported-protocol",
+    );
+    expect(issues).toHaveLength(4);
+    expect(issues[0].severity).toBe("warning");
+    const protocols = issues.map((i) =>
+      i.message.match(/"([^"]+)"/)?.[1],
+    );
+    expect(protocols).toEqual(["ftp", "file", "data", "myapp"]);
+  });
+
+  it("fires on anchors inside paragraph content", () => {
+    const content = createDefaultTemplateContent();
+    const paragraph = createParagraphBlock({
+      content: '<p><a href="ftp://x">x</a></p>',
+    });
+    content.blocks = [paragraph];
+    const issues = lintLinks(content).filter(
+      (i) => i.ruleId === "link.unsupported-protocol",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].blockId).toBe(paragraph.id);
+  });
+
+  it("respects severity override and `off` disables the rule", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createButtonBlock({ url: "ftp://example.com" })];
+
+    const promoted = lintLinks(content, {
+      rules: { "link.unsupported-protocol": "error" },
+    }).find((i) => i.ruleId === "link.unsupported-protocol");
+    expect(promoted?.severity).toBe("error");
+
+    const off = lintLinks(content, {
+      rules: { "link.unsupported-protocol": "off" },
+    }).filter((i) => i.ruleId === "link.unsupported-protocol");
+    expect(off).toEqual([]);
+
+    expect(lintLinks(content, { disabled: true })).toEqual([]);
+  });
+});

--- a/packages/quality/tests/links/walk-urls.test.ts
+++ b/packages/quality/tests/links/walk-urls.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  createButtonBlock,
+  createDefaultTemplateContent,
+  createHtmlBlock,
+  createImageBlock,
+  createMenuBlock,
+  createParagraphBlock,
+  createSectionBlock,
+  createSocialIconsBlock,
+  createTitleBlock,
+  createVideoBlock,
+} from "@templatical/types";
+import { walkUrls } from "../../src";
+
+describe("walkUrls", () => {
+  it("returns an empty list for an empty template", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [];
+    expect(walkUrls(content)).toEqual([]);
+  });
+
+  it("emits one occurrence per anchor across title / paragraph / html", () => {
+    const content = createDefaultTemplateContent();
+    const title = createTitleBlock({
+      content: '<h2><a href="https://t.com">t</a></h2>',
+    });
+    const paragraph = createParagraphBlock({
+      content: '<p><a href="https://p.com">p</a></p>',
+    });
+    const html = createHtmlBlock({
+      content: '<div><a href="https://h.com">h</a></div>',
+    });
+    content.blocks = [title, paragraph, html];
+
+    const occurrences = walkUrls(content);
+    expect(occurrences).toHaveLength(3);
+    expect(occurrences.map((o) => o.url).sort()).toEqual([
+      "https://h.com",
+      "https://p.com",
+      "https://t.com",
+    ]);
+    expect(occurrences.every((o) => o.source === "anchor")).toBe(true);
+  });
+
+  it("emits button, image-link, video, menu-item, social-icon sources", () => {
+    const content = createDefaultTemplateContent();
+    const button = createButtonBlock({ url: "https://btn.com" });
+    const image = createImageBlock({
+      src: "https://example.com/x.png",
+      linkUrl: "https://img.com",
+    });
+    const video = createVideoBlock({ url: "https://video.com" });
+    const menu = createMenuBlock({
+      items: [
+        {
+          id: "m1",
+          text: "Home",
+          url: "https://menu.com",
+          openInNewTab: false,
+          bold: false,
+          underline: false,
+        },
+      ],
+    });
+    const social = createSocialIconsBlock({
+      icons: [{ id: "i1", platform: "facebook", url: "https://fb.com" }],
+    });
+    content.blocks = [button, image, video, menu, social];
+
+    const bySource = Object.fromEntries(
+      walkUrls(content).map((o) => [o.source, o.url]),
+    );
+    expect(bySource).toEqual({
+      button: "https://btn.com",
+      "image-link": "https://img.com",
+      video: "https://video.com",
+      "menu-item": "https://menu.com",
+      "social-icon": "https://fb.com",
+    });
+  });
+
+  it("skips image.linkUrl when empty/missing", () => {
+    const content = createDefaultTemplateContent();
+    const image = createImageBlock({ src: "https://example.com/x.png" });
+    content.blocks = [image];
+    expect(walkUrls(content)).toEqual([]);
+  });
+
+  it("descends into section columns", () => {
+    const content = createDefaultTemplateContent();
+    const section = createSectionBlock();
+    const inner = createButtonBlock({ url: "https://nested.com" });
+    section.children = [[inner]];
+    content.blocks = [section];
+
+    const occurrences = walkUrls(content);
+    expect(occurrences).toHaveLength(1);
+    expect(occurrences[0].blockId).toBe(inner.id);
+    expect(occurrences[0].source).toBe("button");
+  });
+
+  it("preserves anchor text as label", () => {
+    const content = createDefaultTemplateContent();
+    const paragraph = createParagraphBlock({
+      content: '<p><a href="https://x.com">click me</a></p>',
+    });
+    content.blocks = [paragraph];
+    const [occ] = walkUrls(content);
+    expect(occ.label).toBe("click me");
+  });
+});

--- a/packages/quality/tests/lint-links-integration.test.ts
+++ b/packages/quality/tests/lint-links-integration.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  createButtonBlock,
+  createDefaultTemplateContent,
+  createImageBlock,
+  createMenuBlock,
+  createParagraphBlock,
+  createSocialIconsBlock,
+  createVideoBlock,
+} from "@templatical/types";
+import { lintLinks } from "../src";
+
+function buildTroubledTemplate() {
+  const content = createDefaultTemplateContent();
+
+  // Anchor → bad scheme inside paragraph content.
+  const paragraph = createParagraphBlock({
+    content:
+      '<p>Hi <a href="javascript:alert(1)">click</a> and ' +
+      '<a href="http://localhost:3000">staging</a></p>',
+  });
+
+  // Button → unsupported protocol.
+  const button = createButtonBlock({ url: "ftp://example.com/file" });
+
+  // Image → linkUrl pointing at staging.
+  const image = createImageBlock({
+    src: "https://example.com/x.png",
+    linkUrl: "https://app.staging.acme.com/preview",
+  });
+
+  // Video → javascript: URL.
+  const video = createVideoBlock({ url: "javascript:alert(2)" });
+
+  // Menu → one malformed mailto, one localhost.
+  const menu = createMenuBlock({
+    items: [
+      {
+        id: "m1",
+        text: "Contact",
+        url: "mailto:not-an-email",
+        openInNewTab: false,
+        bold: false,
+        underline: false,
+      },
+      {
+        id: "m2",
+        text: "Local",
+        url: "http://127.0.0.1:8080/x",
+        openInNewTab: false,
+        bold: false,
+        underline: false,
+      },
+    ],
+  });
+
+  // Social → malformed tel.
+  const social = createSocialIconsBlock({
+    icons: [{ id: "s1", platform: "facebook", url: "tel:CALL-NOW" }],
+  });
+
+  content.blocks = [paragraph, button, image, video, menu, social];
+  return { content, paragraph, button, image, video, menu, social };
+}
+
+describe("lintLinks integration", () => {
+  it("emits issues across every URL source with the default options", () => {
+    const { content, paragraph, button, image, video, menu, social } =
+      buildTroubledTemplate();
+    const issues = lintLinks(content);
+
+    const byRule = (id: string) => issues.filter((i) => i.ruleId === id);
+
+    // javascript-protocol: paragraph anchor + video.url
+    const js = byRule("link.javascript-protocol");
+    expect(js.map((i) => i.blockId).sort()).toEqual(
+      [paragraph.id, video.id].sort(),
+    );
+
+    // unsupported-protocol: button ftp:
+    const unsupp = byRule("link.unsupported-protocol");
+    expect(unsupp).toHaveLength(1);
+    expect(unsupp[0].blockId).toBe(button.id);
+
+    // malformed-mailto: menu item
+    const mailto = byRule("link.malformed-mailto");
+    expect(mailto).toHaveLength(1);
+    expect(mailto[0].blockId).toBe(menu.id);
+
+    // malformed-tel: social icon
+    const tel = byRule("link.malformed-tel");
+    expect(tel).toHaveLength(1);
+    expect(tel[0].blockId).toBe(social.id);
+
+    // localhost-or-staging: paragraph anchor (localhost) + image.linkUrl
+    // (staging) + menu item (127.0.0.1)
+    const staging = byRule("link.localhost-or-staging");
+    expect(staging.map((i) => i.blockId).sort()).toEqual(
+      [paragraph.id, image.id, menu.id].sort(),
+    );
+  });
+
+  it("silences localhost-or-staging when nonProductionHosts is empty", () => {
+    const { content } = buildTroubledTemplate();
+    const issues = lintLinks(content, {
+      links: { nonProductionHosts: [] },
+    });
+    expect(
+      issues.filter((i) => i.ruleId === "link.localhost-or-staging"),
+    ).toEqual([]);
+  });
+
+  it("custom nonProductionHosts fires for the custom pattern only", () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createButtonBlock({ url: "https://x.preview.example.com" }),
+      createButtonBlock({ url: "http://localhost:3000" }),
+    ];
+    const issues = lintLinks(content, {
+      links: { nonProductionHosts: ["*.preview.*"] },
+    }).filter((i) => i.ruleId === "link.localhost-or-staging");
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("preview");
+  });
+});


### PR DESCRIPTION
Add `lintStructure` + `lintLinks` and reshape the quality package around a shared linting surface.

**`@templatical/quality`**

- New `lintStructure(content, options?)` linter — 5 rules: `structure.duplicate-block-id`, `structure.section-column-mismatch`, `structure.nested-section`, `structure.empty-section` (auto-fix removes the section), `structure.empty-column`.
- New `lintLinks(content, options?)` linter — 5 rules covering URL hygiene across every URL-bearing field in the template (anchors in rich text + `button.url`, `image.linkUrl`, `video.url`, `menu.items[].url`, `social.icons[].url`):
  - `link.javascript-protocol` (error) — flags `javascript:` hrefs that the render-time sanitizer would silently strip.
  - `link.unsupported-protocol` (warning) — flags explicit schemes outside `http`, `https`, `mailto`, `tel`, `sms`.
  - `link.malformed-mailto` (warning) — sanity-checks `mailto:` recipient + domain shape.
  - `link.malformed-tel` (warning) — rejects letters in `tel:` URIs.
  - `link.localhost-or-staging` (warning) — flags URL hosts matching `options.links.nonProductionHosts` (default catches `localhost`, `127.0.0.1`, `0.0.0.0`, `*.local`, `*.staging.*`, `*.dev.*`).
- New `walkUrls(content) → UrlOccurrence[]` helper for headless callers building URL-scoped rules.
- `LintOptions` gains `links?: { nonProductionHosts?: string[] }` for `link.localhost-or-staging` configuration. `DEFAULT_NON_PRODUCTION_HOSTS` is exported as the baseline.
- Rule IDs are now namespaced. Every accessibility rule is prefixed with `a11y.` (e.g. `img-missing-alt` → `a11y.img-missing-alt`); structure rules use `structure.`; link rules use `link.`. Severity overrides and message-map keys must use the prefixed form.
- Type names renamed for cross-linter reuse: `A11yIssue` → `LintIssue`, `A11yOptions` → `LintOptions`, `A11yPatch` → `LintPatch`, `A11yPatchContext` → `LintPatchContext` (now also exposes `removeBlock`), `A11yThresholds` → `LintThresholds`, `DEFAULT_THRESHOLDS` → `DEFAULT_A11Y_THRESHOLDS`. The `RULES` export is now `ACCESSIBILITY_RULES`; new `STRUCTURE_RULES` and `LINK_RULES` exports sit alongside it.
- New exports: `lintStructure`, `STRUCTURE_RULES`, `formatStructureMessage`, `getStructureMessages`, `SUPPORTED_STRUCTURE_MESSAGE_LOCALES`, `StructureMessageMap`, `StructureRuleMessageId`, `lintLinks`, `LINK_RULES`, `walkUrls`, `UrlOccurrence`, `UrlSource`, `formatLinkMessage`, `getLinkMessages`, `SUPPORTED_LINK_MESSAGE_LOCALES`, `LinkMessageMap`, `LinkRuleMessageId`, `LintLinksOptions`, `ResolvedLinksOptions`, `DEFAULT_NON_PRODUCTION_HOSTS`.

**`@templatical/editor`**

- `init({ accessibility })` is renamed to `init({ lint })` — the same option object now drives every linter exported by `@templatical/quality` (accessibility + structure + links).
- Sidebar tab renamed from "Accessibility" to "Issues" and now shows all three linter families. The composable is `useTemplateLint` (was `useAccessibilityLint`); the inject key is `TEMPLATE_LINT_KEY`; the components are `IssuesPanel.vue` and `BlockIssueBadge.vue`.
- Section toolbar now rebalances `children` when the columns layout changes (1↔2↔3 / 1-2 / 2-1) — grows pad with empty columns, shrinks merge trailing columns into the last kept column so blocks are never silently dropped. Eliminates the `structure.section-column-mismatch` error that previously fired on every layout change.
- Editor button reset (`.tpl button { background: none }`) now wrapped in `:where()` so its specificity drops to (0,0,1) and per-button utility classes (e.g. `tpl:bg-[var(--tpl-primary)]`) win. Fixes the Fix-button-renders-transparent bug introduced by the canvas reset; affects every primary-bg button in the editor.