### PR TITLE
fix(editor): center alignment in Video and Image blocks

### DIFF
--- a/.changeset/video-image-center-alignment.md
+++ b/.changeset/video-image-center-alignment.md
@@ -1,0 +1,9 @@
+---
+"@templatical/editor": patch
+---
+
+Fix center alignment in Video and Image blocks (issue #111). When a fixed pixel width was set and alignment was set to "center", the editor preview rendered the block flush-left instead of centered.
+
+Root cause: the alignment styles mixed the CSS `margin` shorthand with the `marginLeft` longhand in the same Vue style object. Vue patched `margin: "0 auto"` first (expanding to all four longhands including `margin-left: auto`), then patched `marginLeft: undefined` which cleared `margin-left` back to `0`. Result: `margin-right: auto` only, which is left-alignment with extra space on the right.
+
+Fix: use only longhand `marginLeft` / `marginRight` properties — no shorthand. MJML export was unaffected (the renderer emits `align="center"` on `<mj-image>` directly); only the editor preview was broken.

--- a/packages/editor/src/components/blocks/ImageBlock.vue
+++ b/packages/editor/src/components/blocks/ImageBlock.vue
@@ -40,13 +40,16 @@ const containerStyle = computed(() => ({
   textAlign: props.block.align,
 }));
 
-const imageStyle = computed(() => ({
-  maxWidth: "100%",
-  width: props.block.width === "full" ? "100%" : `${props.block.width}px`,
-  display: "block",
-  margin: props.block.align === "center" ? "0 auto" : undefined,
-  marginLeft: props.block.align === "right" ? "auto" : undefined,
-}));
+const imageStyle = computed(() => {
+  const align = props.block.align;
+  return {
+    maxWidth: "100%",
+    width: props.block.width === "full" ? "100%" : `${props.block.width}px`,
+    display: "block",
+    marginLeft: align === "center" || align === "right" ? "auto" : undefined,
+    marginRight: align === "center" ? "auto" : undefined,
+  };
+});
 
 const hasMergeTagSrc = computed(() =>
   containsMergeTag(props.block.src, syntax),

--- a/packages/editor/src/components/blocks/VideoBlock.vue
+++ b/packages/editor/src/components/blocks/VideoBlock.vue
@@ -33,13 +33,16 @@ const containerStyle = computed(() => ({
   textAlign: props.block.align,
 }));
 
-const thumbnailStyle = computed(() => ({
-  maxWidth: "100%",
-  width: props.block.width === "full" ? "100%" : `${props.block.width}px`,
-  display: "block",
-  margin: props.block.align === "center" ? "0 auto" : undefined,
-  marginLeft: props.block.align === "right" ? "auto" : undefined,
-}));
+const thumbnailStyle = computed(() => {
+  const align = props.block.align;
+  return {
+    maxWidth: "100%",
+    width: props.block.width === "full" ? "100%" : `${props.block.width}px`,
+    display: "block",
+    marginLeft: align === "center" || align === "right" ? "auto" : undefined,
+    marginRight: align === "center" ? "auto" : undefined,
+  };
+});
 
 const mergeTagLabel = computed(() => {
   if (containsMergeTag(props.block.url, syntax)) return props.block.url;

--- a/packages/editor/tests/imageBlock.test.ts
+++ b/packages/editor/tests/imageBlock.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import "./dom-stubs";
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { SYNTAX_PRESETS, createImageBlock } from "@templatical/types";
+import enTranslations from "../src/i18n/locales/en";
+import {
+  MERGE_TAGS_KEY,
+  MERGE_TAG_SYNTAX_KEY,
+  TRANSLATIONS_KEY,
+} from "../src/keys";
+import ImageBlock from "../src/components/blocks/ImageBlock.vue";
+
+function baseProvide() {
+  return {
+    [TRANSLATIONS_KEY as symbol]: enTranslations,
+    [MERGE_TAG_SYNTAX_KEY as symbol]: SYNTAX_PRESETS.liquid,
+    [MERGE_TAGS_KEY as symbol]: [],
+  };
+}
+
+describe("ImageBlock alignment (regression: #111)", () => {
+  function mountImage(align: "left" | "center" | "right", width: number | "full") {
+    const block = createImageBlock({
+      src: "https://picsum.photos/600/400",
+      width,
+      align,
+    });
+    return mount(ImageBlock, {
+      props: { block, viewport: "desktop" },
+      global: { provide: baseProvide() },
+    });
+  }
+
+  it("center alignment applies marginLeft: auto and marginRight: auto", () => {
+    const wrapper = mountImage("center", 400);
+    const img = wrapper.find("img");
+    expect(img.exists()).toBe(true);
+    const style = (img.element as HTMLElement).style;
+    expect(style.marginLeft).toBe("auto");
+    expect(style.marginRight).toBe("auto");
+    expect(style.width).toBe("400px");
+  });
+
+  it("right alignment applies marginLeft: auto only", () => {
+    const wrapper = mountImage("right", 400);
+    const img = wrapper.find("img");
+    const style = (img.element as HTMLElement).style;
+    expect(style.marginLeft).toBe("auto");
+    expect(style.marginRight).toBe("");
+  });
+
+  it("left alignment applies no auto margins", () => {
+    const wrapper = mountImage("left", 400);
+    const img = wrapper.find("img");
+    const style = (img.element as HTMLElement).style;
+    expect(style.marginLeft).toBe("");
+    expect(style.marginRight).toBe("");
+  });
+
+  it("does not use the margin shorthand (prevents Vue's longhand-clear regression)", () => {
+    const wrapper = mountImage("center", 400);
+    const img = wrapper.find("img");
+    const inline = img.attributes("style") ?? "";
+    expect(inline).not.toMatch(/(^|;)\s*margin\s*:/);
+  });
+});

--- a/packages/editor/tests/videoBlock.test.ts
+++ b/packages/editor/tests/videoBlock.test.ts
@@ -1,28 +1,93 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from 'vitest';
-import { mount } from '@vue/test-utils';
-import VideoPlayButton from '../src/components/blocks/VideoPlayButton.vue';
+import "./dom-stubs";
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { SYNTAX_PRESETS, createVideoBlock } from "@templatical/types";
+import enTranslations from "../src/i18n/locales/en";
+import {
+  MERGE_TAGS_KEY,
+  MERGE_TAG_SYNTAX_KEY,
+  TRANSLATIONS_KEY,
+} from "../src/keys";
+import VideoPlayButton from "../src/components/blocks/VideoPlayButton.vue";
+import VideoBlock from "../src/components/blocks/VideoBlock.vue";
 
-describe('VideoPlayButton', () => {
-  it('renders an SVG play triangle', () => {
+function baseProvide() {
+  return {
+    [TRANSLATIONS_KEY as symbol]: enTranslations,
+    [MERGE_TAG_SYNTAX_KEY as symbol]: SYNTAX_PRESETS.liquid,
+    [MERGE_TAGS_KEY as symbol]: [],
+  };
+}
+
+describe("VideoPlayButton", () => {
+  it("renders an SVG play triangle", () => {
     const wrapper = mount(VideoPlayButton);
-    const svg = wrapper.find('svg');
+    const svg = wrapper.find("svg");
     expect(svg.exists()).toBe(true);
-    const polygon = svg.find('polygon');
-    expect(polygon.attributes('points')).toBe('5,3 19,12 5,21');
+    const polygon = svg.find("polygon");
+    expect(polygon.attributes("points")).toBe("5,3 19,12 5,21");
   });
 
-  it('does not apply the hover-transition class by default', () => {
+  it("does not apply the hover-transition class by default", () => {
     const wrapper = mount(VideoPlayButton);
-    const outer = wrapper.find('div');
-    expect(outer.classes()).not.toContain('tpl:transition-opacity');
+    const outer = wrapper.find("div");
+    expect(outer.classes()).not.toContain("tpl:transition-opacity");
   });
 
-  it('applies the hover-transition class when hoverEffect=true', () => {
+  it("applies the hover-transition class when hoverEffect=true", () => {
     const wrapper = mount(VideoPlayButton, {
       props: { hoverEffect: true },
     });
-    const outer = wrapper.find('div');
-    expect(outer.classes()).toContain('tpl:transition-opacity');
+    const outer = wrapper.find("div");
+    expect(outer.classes()).toContain("tpl:transition-opacity");
+  });
+});
+
+describe("VideoBlock alignment (regression: #111)", () => {
+  function mountVideo(align: "left" | "center" | "right", width: number | "full") {
+    const block = createVideoBlock({
+      url: "https://www.youtube.com/watch?v=8vO7dKj7CFs",
+      thumbnailUrl: "https://img.youtube.com/vi/8vO7dKj7CFs/maxresdefault.jpg",
+      width,
+      align,
+    });
+    return mount(VideoBlock, {
+      props: { block, viewport: "desktop" },
+      global: { provide: baseProvide() },
+    });
+  }
+
+  it("center alignment applies marginLeft: auto and marginRight: auto", () => {
+    const wrapper = mountVideo("center", 400);
+    const anchor = wrapper.find("a");
+    expect(anchor.exists()).toBe(true);
+    const style = (anchor.element as HTMLElement).style;
+    expect(style.marginLeft).toBe("auto");
+    expect(style.marginRight).toBe("auto");
+    expect(style.width).toBe("400px");
+  });
+
+  it("right alignment applies marginLeft: auto only", () => {
+    const wrapper = mountVideo("right", 400);
+    const anchor = wrapper.find("a");
+    const style = (anchor.element as HTMLElement).style;
+    expect(style.marginLeft).toBe("auto");
+    expect(style.marginRight).toBe("");
+  });
+
+  it("left alignment applies no auto margins", () => {
+    const wrapper = mountVideo("left", 400);
+    const anchor = wrapper.find("a");
+    const style = (anchor.element as HTMLElement).style;
+    expect(style.marginLeft).toBe("");
+    expect(style.marginRight).toBe("");
+  });
+
+  it("does not use the margin shorthand (prevents Vue's longhand-clear regression)", () => {
+    const wrapper = mountVideo("center", 400);
+    const anchor = wrapper.find("a");
+    const inline = anchor.attributes("style") ?? "";
+    expect(inline).not.toMatch(/(^|;)\s*margin\s*:/);
   });
 });


### PR DESCRIPTION
- Closes #111. Video block (and Image block — same code path, not yet reported) rendered flush-left in the editor preview when alignment was set to center with a fixed pixel width.
- Root cause: the style computed prop mixed the CSS `margin` shorthand with the `marginLeft` longhand. Vue patched `margin: "0 auto"` first (expanding to all four longhands including `margin-left: auto`), then patched `marginLeft: undefined` which cleared `margin-left` back to `0`. Resulting inline style was `margin-top: 0; margin-right: auto; margin-bottom: 0;` — left-aligned with extra space on the right.
- Fix: drop the shorthand, use only longhand `marginLeft` / `marginRight`.