### PR TITLE
refactor: remove tablet viewport support - model to desktop and mobile only

### DIFF
--- a/.changeset/drop-tablet-viewport.md
+++ b/.changeset/drop-tablet-viewport.md
@@ -1,0 +1,11 @@
+---
+"@templatical/types": minor
+"@templatical/editor": minor
+"@templatical/renderer": minor
+---
+
+Collapse the responsive model to Desktop + Mobile, dropping the `tablet` tier.
+
+`ViewportSize` is now `"desktop" | "mobile"` and `BlockVisibility` drops its `tablet` field. The editor's viewport toggle no longer offers a Tablet preview, and the renderer emits a single 480px breakpoint (`tpl-hide-mobile` ≤480px, `tpl-hide-desktop` ≥481px) instead of three bands. A "tablet" breakpoint isn't a meaningful concept for email (bodies are ~600px wide; a tablet viewport renders at full desktop width), and the useful responsive split is binary — mobile vs. not-mobile, matching MJML's model.
+
+**Migration:** saved templates carrying `visibility.tablet` keep parsing — the extra key is ignored at runtime. A block previously hidden only on tablet (`tablet: false` with `desktop`/`mobile` true) will now show on 481–768px devices, because there's no longer a `tpl-hide-tablet` class. No data migration is required; re-saving a block normalizes its visibility object to the new shape.

--- a/apps/docs/api/types.md
+++ b/apps/docs/api/types.md
@@ -110,7 +110,6 @@ Controls on which viewports a block is visible.
 ```ts
 interface BlockVisibility {
   desktop: boolean;
-  tablet: boolean;
   mobile: boolean;
 }
 ```
@@ -423,7 +422,7 @@ interface CustomFont {
 ### ViewportSize
 
 ```ts
-type ViewportSize = 'desktop' | 'tablet' | 'mobile';
+type ViewportSize = 'desktop' | 'mobile';
 ```
 
 ## Factory Functions

--- a/apps/docs/de/api/types.md
+++ b/apps/docs/de/api/types.md
@@ -110,7 +110,6 @@ Steuert, auf welchen Viewports ein Block sichtbar ist.
 ```ts
 interface BlockVisibility {
   desktop: boolean;
-  tablet: boolean;
   mobile: boolean;
 }
 ```
@@ -423,7 +422,7 @@ interface CustomFont {
 ### ViewportSize
 
 ```ts
-type ViewportSize = 'desktop' | 'tablet' | 'mobile';
+type ViewportSize = 'desktop' | 'mobile';
 ```
 
 ## Factory-Funktionen

--- a/apps/docs/de/guide/sections-and-columns.md
+++ b/apps/docs/de/guide/sections-and-columns.md
@@ -107,7 +107,6 @@ const block = createParagraphBlock({
 
 block.visibility = {
   desktop: true,
-  tablet: true,
   mobile: false,
 };
 ```

--- a/apps/docs/de/guide/styling.md
+++ b/apps/docs/de/guide/styling.md
@@ -62,18 +62,16 @@ Die Eigenschaft `visibility` auf jedem Block steuert, ob er bei jedem Breakpoint
 ```ts
 interface BlockVisibility {
   desktop: boolean;
-  tablet: boolean;
   mobile: boolean;
 }
 ```
 
-Alle drei sind standardmäßig `true`. Setzen Sie einen Breakpoint auf `false`, um den Block bei dieser Größe auszublenden:
+Beide sind standardmäßig `true`. Setzen Sie einen Breakpoint auf `false`, um den Block bei dieser Größe auszublenden:
 
 ```ts
 // Nur auf dem Desktop anzeigen
 block.visibility = {
   desktop: true,
-  tablet: false,
   mobile: false,
 };
 ```

--- a/apps/docs/guide/sections-and-columns.md
+++ b/apps/docs/guide/sections-and-columns.md
@@ -107,7 +107,6 @@ const block = createParagraphBlock({
 
 block.visibility = {
   desktop: true,
-  tablet: true,
   mobile: false,
 };
 ```

--- a/apps/docs/guide/styling.md
+++ b/apps/docs/guide/styling.md
@@ -62,18 +62,16 @@ The `visibility` property on any block controls whether it renders at each break
 ```ts
 interface BlockVisibility {
   desktop: boolean;
-  tablet: boolean;
   mobile: boolean;
 }
 ```
 
-All three default to `true`. Set a breakpoint to `false` to hide the block at that size:
+Both default to `true`. Set a breakpoint to `false` to hide the block at that size:
 
 ```ts
 // Show only on desktop
 block.visibility = {
   desktop: true,
-  tablet: false,
   mobile: false,
 };
 ```

--- a/apps/playground/e2e/helpers/selectors.ts
+++ b/apps/playground/e2e/helpers/selectors.ts
@@ -55,7 +55,6 @@ export const SELECTORS = {
   // Viewport & toggles
   viewportGroup: '[role="radiogroup"][aria-label="Viewport"]',
   viewportDesktop: '[role="radio"][aria-label="Desktop"]',
-  viewportTablet: '[role="radio"][aria-label="Tablet"]',
   viewportMobile: '[role="radio"][aria-label="Mobile"]',
   darkModeToggle: ".tpl-dark-mode-toggle",
   previewToggle: ".tpl-preview-toggle",

--- a/apps/playground/e2e/pages/editor.page.ts
+++ b/apps/playground/e2e/pages/editor.page.ts
@@ -800,13 +800,11 @@ export class EditorPage {
 
   // --- Viewport & toggles ---
 
-  async switchViewport(name: "Desktop" | "Tablet" | "Mobile"): Promise<void> {
+  async switchViewport(name: "Desktop" | "Mobile"): Promise<void> {
     const selector =
       name === "Desktop"
         ? SELECTORS.viewportDesktop
-        : name === "Tablet"
-          ? SELECTORS.viewportTablet
-          : SELECTORS.viewportMobile;
+        : SELECTORS.viewportMobile;
     // Arm a transitionend listener before the click so we catch the exact
     // settled frame. Canvas.vue animates `width` with a 300ms spring-bounce
     // curve — polling for "width changed" fires mid-flight and returns an

--- a/apps/playground/e2e/tests/editor-canvas.spec.ts
+++ b/apps/playground/e2e/tests/editor-canvas.spec.ts
@@ -24,14 +24,14 @@ test.describe("Editor canvas", () => {
     expect(count).toBeGreaterThan(0);
   });
 
-  test("viewport toggle shows 3 options", async ({
+  test("viewport toggle shows 2 options", async ({
     editorReady,
     page,
   }) => {
     const group = page.locator(SELECTORS.viewportGroup);
     await expect(group).toBeVisible();
     const radios = page.locator('[role="radio"]');
-    expect(await radios.count()).toBe(3);
+    expect(await radios.count()).toBe(2);
   });
 
   test("desktop viewport is default", async ({ editorReady, page }) => {
@@ -50,18 +50,6 @@ test.describe("Editor canvas", () => {
     const mobileWidth = await editorPage.getCanvasWrapperWidth();
     expect(mobileWidth).toBeLessThan(desktopWidth);
     expect(mobileWidth).toBeLessThanOrEqual(400);
-  });
-
-  test("tablet viewport sets intermediate width", async ({
-    editorReady: { editorPage },
-    page,
-  }) => {
-    await editorPage.switchViewport("Mobile");
-    const mobileWidth = await editorPage.getCanvasWrapperWidth();
-    await editorPage.switchViewport("Tablet");
-    const tabletWidth = await editorPage.getCanvasWrapperWidth();
-    // Tablet should be wider than mobile
-    expect(tabletWidth).toBeGreaterThan(mobileWidth);
   });
 
   test("desktop viewport restores width", async ({

--- a/apps/playground/src/templates.ts
+++ b/apps/playground/src/templates.ts
@@ -1581,7 +1581,7 @@ export function createPasswordResetTemplate(): TemplateContent {
         content:
           '<p><span style="font-size: 13px; color: #6b7280"><strong>Security Tips</strong></span></p><p><span style="font-size: 13px; color: #6b7280">\u2022 Never share your password with anyone<br/>\u2022 Use a unique password for each service<br/>\u2022 Enable two-factor authentication for extra protection<br/>\u2022 Check that the URL starts with https://vaultkey.com before entering credentials</span></p>',
         styles: white(16, 40, 16, 40),
-        visibility: { desktop: true, tablet: true, mobile: false },
+        visibility: { desktop: true, mobile: false },
       }),
 
       // ── Responsive: Mobile-only short security note ──
@@ -1589,7 +1589,7 @@ export function createPasswordResetTemplate(): TemplateContent {
         content:
           '<p style="text-align: center"><span style="font-size: 13px; color: #6b7280">\ud83d\udd12 Protect your account: never share this link and enable two-factor authentication.</span></p>',
         styles: white(16, 32, 16, 32),
-        visibility: { desktop: false, tablet: false, mobile: true },
+        visibility: { desktop: false, mobile: true },
       }),
 
       createParagraphBlock({
@@ -1948,7 +1948,7 @@ export const templates: TemplateOption[] = [
         label: "Responsive Visibility",
         icon: "responsive",
         description:
-          "This template has two versions of security tips that swap based on device size.\nDesktop/tablet: a detailed list with 4 bullet points. Mobile: a condensed single-line note.\nTo try it: select either block and open Settings \u2192 Display to see the visibility toggles for desktop, tablet, and mobile.\nThen switch the viewport preview in the top toolbar between Desktop and Mobile to watch the blocks swap live on the canvas.",
+          "This template has two versions of security tips that swap based on device size.\nDesktop: a detailed list with 4 bullet points. Mobile: a condensed single-line note.\nTo try it: select either block and open Settings \u2192 Display to see the visibility toggles for desktop and mobile.\nThen switch the viewport preview in the top toolbar between Desktop and Mobile to watch the blocks swap live on the canvas.",
       },
       {
         label: "Merge Tags",

--- a/packages/editor/src/components/Canvas.vue
+++ b/packages/editor/src/components/Canvas.vue
@@ -103,8 +103,6 @@ const viewportWidth = computed(() => {
   switch (props.viewport) {
     case "mobile":
       return 375;
-    case "tablet":
-      return 768;
     default:
       return props.content.settings.width;
   }

--- a/packages/editor/src/components/ViewportToggle.vue
+++ b/packages/editor/src/components/ViewportToggle.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from "../composables/useI18n";
 import type { ViewportSize } from "@templatical/types";
-import { Monitor, Smartphone, Tablet } from "@lucide/vue";
+import { Monitor, Smartphone } from "@lucide/vue";
 import { computed } from "vue";
 
 const props = defineProps<{
@@ -16,7 +16,6 @@ const { t } = useI18n();
 
 const viewports = computed(() => [
   { value: "desktop" as ViewportSize, label: t.viewport.desktop },
-  { value: "tablet" as ViewportSize, label: t.viewport.tablet },
   { value: "mobile" as ViewportSize, label: t.viewport.mobile },
 ]);
 
@@ -67,11 +66,6 @@ const pillOffset = computed(() => {
       @click="emit('change', vp.value)"
     >
       <Monitor v-if="vp.value === 'desktop'" :size="18" :stroke-width="1.5" />
-      <Tablet
-        v-else-if="vp.value === 'tablet'"
-        :size="18"
-        :stroke-width="1.5"
-      />
       <Smartphone v-else :size="18" :stroke-width="1.5" />
       <span>{{ vp.label }}</span>
     </button>

--- a/packages/editor/src/components/blocks/BlockWrapper.vue
+++ b/packages/editor/src/components/blocks/BlockWrapper.vue
@@ -116,7 +116,6 @@ const hiddenLabel = computed(() => {
   }
   const labels: Record<string, string> = {
     desktop: t.viewport.desktop,
-    tablet: t.viewport.tablet,
     mobile: t.viewport.mobile,
   };
   return labels[props.viewport] ?? props.viewport;

--- a/packages/editor/src/components/toolbar/CommonBlockSettings.vue
+++ b/packages/editor/src/components/toolbar/CommonBlockSettings.vue
@@ -9,7 +9,7 @@ import {
   DEFAULT_BG_COLOR,
 } from "../../constants/styleConstants";
 import type { Block, DisplayCondition } from "@templatical/types";
-import { Monitor, Smartphone, Tablet } from "@lucide/vue";
+import { Monitor, Smartphone } from "@lucide/vue";
 import { computed, inject, reactive, ref, watch, type Component } from "vue";
 import {
   DISPLAY_CONDITIONS_KEY,
@@ -17,7 +17,7 @@ import {
 } from "../../keys";
 
 type SectionKey = "spacing" | "bg" | "display" | "css" | "condition";
-type VisibilityKey = "desktop" | "tablet" | "mobile";
+type VisibilityKey = "desktop" | "mobile";
 
 const props = defineProps<{
   block: Block;
@@ -41,10 +41,9 @@ const customAfter = ref("");
 const VISIBILITY_ITEMS: {
   key: VisibilityKey;
   icon: Component;
-  labelKey: "showOnDesktop" | "showOnTablet" | "showOnMobile";
+  labelKey: "showOnDesktop" | "showOnMobile";
 }[] = [
   { key: "desktop", icon: Monitor, labelKey: "showOnDesktop" },
-  { key: "tablet", icon: Tablet, labelKey: "showOnTablet" },
   { key: "mobile", icon: Smartphone, labelKey: "showOnMobile" },
 ];
 
@@ -129,7 +128,6 @@ function isVisible(key: VisibilityKey): boolean {
 function toggleVisibility(key: VisibilityKey): void {
   const next: Record<VisibilityKey, boolean> = {
     desktop: isVisible("desktop"),
-    tablet: isVisible("tablet"),
     mobile: isVisible("mobile"),
   };
   next[key] = !next[key];

--- a/packages/editor/src/i18n/locales/de.ts
+++ b/packages/editor/src/i18n/locales/de.ts
@@ -19,7 +19,6 @@ const de: typeof en = {
   viewport: {
     label: "Ansichtsgröße",
     desktop: "Desktop",
-    tablet: "Tablet",
     mobile: "Mobil",
   },
 
@@ -395,7 +394,6 @@ const de: typeof en = {
     color: "Farbe",
     display: "Anzeige",
     showOnDesktop: "Auf Desktop anzeigen",
-    showOnTablet: "Auf Tablet anzeigen",
     showOnMobile: "Auf Mobilgerät anzeigen",
     hiddenOnDevice: "Ausgeblendet auf {device}",
     customCss: "Benutzerdefiniertes CSS",

--- a/packages/editor/src/i18n/locales/en.ts
+++ b/packages/editor/src/i18n/locales/en.ts
@@ -16,7 +16,6 @@ export default {
   viewport: {
     label: "Viewport",
     desktop: "Desktop",
-    tablet: "Tablet",
     mobile: "Mobile",
   },
 
@@ -388,7 +387,6 @@ export default {
     color: "Color",
     display: "Display",
     showOnDesktop: "Show on desktop",
-    showOnTablet: "Show on tablet",
     showOnMobile: "Show on mobile",
     hiddenOnDevice: "Hidden on {device}",
     customCss: "Custom CSS",

--- a/packages/editor/src/i18n/locales/pt-BR.ts
+++ b/packages/editor/src/i18n/locales/pt-BR.ts
@@ -18,7 +18,6 @@ const ptBR: typeof en = {
   viewport: {
     label: "Viewport",
     desktop: "Desktop",
-    tablet: "Tablet",
     mobile: "Mobile",
   },
 
@@ -392,7 +391,6 @@ const ptBR: typeof en = {
     color: "Cor",
     display: "Exibição",
     showOnDesktop: "Mostrar no desktop",
-    showOnTablet: "Mostrar no tablet",
     showOnMobile: "Mostrar no mobile",
     hiddenOnDevice: "Oculto em {device}",
     customCss: "CSS Personalizado",

--- a/packages/editor/tests/blockWrapperVisibility.test.ts
+++ b/packages/editor/tests/blockWrapperVisibility.test.ts
@@ -18,7 +18,6 @@ import { mountEditor } from "./helpers/mount";
 
 const HIDDEN_ON_MOBILE: BlockVisibility = {
   desktop: true,
-  tablet: true,
   mobile: false,
 };
 

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -106,10 +106,7 @@ export async function renderToMjml(
       @media only screen and (max-width: 480px) {
         .tpl-hide-mobile { display: none !important; mso-hide: all !important; }
       }
-      @media only screen and (min-width: 481px) and (max-width: 768px) {
-        .tpl-hide-tablet { display: none !important; mso-hide: all !important; }
-      }
-      @media only screen and (min-width: 769px) {
+      @media only screen and (min-width: 481px) {
         .tpl-hide-desktop { display: none !important; mso-hide: all !important; }
       }
     </mj-style>

--- a/packages/renderer/src/visibility.ts
+++ b/packages/renderer/src/visibility.ts
@@ -10,12 +10,12 @@ export function isHiddenOnAll(block: Block): boolean {
     return false;
   }
 
-  return !visibility.desktop && !visibility.tablet && !visibility.mobile;
+  return !visibility.desktop && !visibility.mobile;
 }
 
 /**
  * Get the MJML css-class attribute string for visibility hiding.
- * Returns a string like ` css-class="tpl-hide-desktop tpl-hide-tablet"` or empty string.
+ * Returns a string like ` css-class="tpl-hide-desktop"` or empty string.
  */
 export function getCssClassAttr(block: Block): string {
   const classes = getCssClasses(block);
@@ -41,10 +41,6 @@ export function getCssClasses(block: Block): string {
 
   if (!visibility.desktop) {
     classes.push("tpl-hide-desktop");
-  }
-
-  if (!visibility.tablet) {
-    classes.push("tpl-hide-tablet");
   }
 
   if (!visibility.mobile) {

--- a/packages/renderer/tests/menu.test.ts
+++ b/packages/renderer/tests/menu.test.ts
@@ -108,7 +108,7 @@ describe('renderMenu', () => {
       items: [
         { id: '1', text: 'Hidden', url: '/', openInNewTab: false, bold: false, underline: false },
       ],
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     const result = renderBlock(block, ctx);
     expect(result).toBe('');

--- a/packages/renderer/tests/render-helpers.test.ts
+++ b/packages/renderer/tests/render-helpers.test.ts
@@ -122,7 +122,7 @@ describe('renderToMjml helpers', () => {
     const content = createDefaultTemplateContent();
     const result = await renderToMjml(content);
     expect(result).toContain('.tpl-hide-mobile');
-    expect(result).toContain('.tpl-hide-tablet');
     expect(result).toContain('.tpl-hide-desktop');
+    expect(result).not.toContain('.tpl-hide-tablet');
   });
 });

--- a/packages/renderer/tests/render-to-mjml.test.ts
+++ b/packages/renderer/tests/render-to-mjml.test.ts
@@ -66,8 +66,8 @@ describe('renderToMjml', () => {
     const content = createDefaultTemplateContent();
     const mjml = await renderToMjml(content);
     expect(mjml).toContain('tpl-hide-mobile');
-    expect(mjml).toContain('tpl-hide-tablet');
     expect(mjml).toContain('tpl-hide-desktop');
+    expect(mjml).not.toContain('tpl-hide-tablet');
   });
 
   it('wraps blocks with display conditions', async () => {
@@ -185,7 +185,7 @@ describe('renderToMjml', () => {
       }),
       createParagraphBlock({
         content: '<p>Hidden</p>',
-        visibility: { desktop: false, tablet: false, mobile: false },
+        visibility: { desktop: false, mobile: false },
       }),
     ];
     const mjml = await renderToMjml(content);

--- a/packages/renderer/tests/renderers.test.ts
+++ b/packages/renderer/tests/renderers.test.ts
@@ -197,7 +197,7 @@ describe('renderBlock', () => {
 
   it('returns empty for blocks hidden on all viewports', () => {
     const block = createParagraphBlock({
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     const result = renderBlock(block, ctx);
     expect(result).toBe('');
@@ -205,10 +205,10 @@ describe('renderBlock', () => {
 
   it('adds visibility css classes', () => {
     const block = createParagraphBlock({
-      visibility: { desktop: true, tablet: false, mobile: true },
+      visibility: { desktop: false, mobile: true },
     });
     const result = renderBlock(block, ctx);
-    expect(result).toContain('css-class="tpl-hide-tablet"');
+    expect(result).toContain('css-class="tpl-hide-desktop"');
   });
 
   it('renders section with columns', () => {
@@ -296,7 +296,7 @@ describe('renderBlock', () => {
       customType: 'product-card',
       fieldValues: {},
       renderedHtml: '<div>Content</div>',
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
       styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
     };
     const result = renderBlock(block, ctx);
@@ -310,11 +310,11 @@ describe('renderBlock', () => {
       customType: 'product-card',
       fieldValues: {},
       renderedHtml: '<div>Content</div>',
-      visibility: { desktop: true, tablet: false, mobile: true },
+      visibility: { desktop: false, mobile: true },
       styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
     };
     const result = renderBlock(block, ctx);
-    expect(result).toContain('css-class="tpl-hide-tablet"');
+    expect(result).toContain('css-class="tpl-hide-desktop"');
   });
 
   it('emits explicit padding on custom block mj-text from block.styles.padding', () => {
@@ -390,35 +390,35 @@ describe('renderBlock', () => {
   it('returns empty for title block hidden on all viewports', () => {
     const block = createTitleBlock({
       content: '<p>Hidden</p>',
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     expect(renderBlock(block, ctx)).toBe('');
   });
 
   it('returns empty for button block hidden on all viewports', () => {
     const block = createButtonBlock({
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     expect(renderBlock(block, ctx)).toBe('');
   });
 
   it('returns empty for image block hidden on all viewports', () => {
     const block = createImageBlock({
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     expect(renderBlock(block, ctx)).toBe('');
   });
 
   it('returns empty for spacer block hidden on all viewports', () => {
     const block = createSpacerBlock({
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     expect(renderBlock(block, ctx)).toBe('');
   });
 
   it('returns empty for divider block hidden on all viewports', () => {
     const block = createDividerBlock({
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     expect(renderBlock(block, ctx)).toBe('');
   });
@@ -426,7 +426,7 @@ describe('renderBlock', () => {
   it('returns empty for html block hidden on all viewports', () => {
     const block = createHtmlBlock({
       content: '<div>Hidden</div>',
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     expect(renderBlock(block, ctx)).toBe('');
   });
@@ -435,7 +435,7 @@ describe('renderBlock', () => {
     const child = createParagraphBlock({ content: '<p>Hidden</p>' });
     const block = createSectionBlock({
       children: [[child]],
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     expect(renderBlock(block, ctx)).toBe('');
   });

--- a/packages/renderer/tests/social.test.ts
+++ b/packages/renderer/tests/social.test.ts
@@ -12,7 +12,7 @@ describe("renderSocialIcons", () => {
   it("returns empty string for hidden block", () => {
     const block = createSocialIconsBlock({
       icons: [{ platform: "facebook", url: "https://facebook.com" }],
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     const result = renderBlock(block, ctx);
     expect(result).toBe("");

--- a/packages/renderer/tests/table.test.ts
+++ b/packages/renderer/tests/table.test.ts
@@ -140,7 +140,7 @@ describe('renderTable', () => {
 
   it('returns empty for hidden block', () => {
     const block = createTableBlock({
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     const result = renderBlock(block, ctx);
     expect(result).toBe('');

--- a/packages/renderer/tests/video.test.ts
+++ b/packages/renderer/tests/video.test.ts
@@ -83,7 +83,7 @@ describe('renderVideo', () => {
   it('returns empty for hidden block', () => {
     const block = createVideoBlock({
       url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     const result = renderBlock(block, ctx);
     expect(result).toBe('');

--- a/packages/renderer/tests/visibility.test.ts
+++ b/packages/renderer/tests/visibility.test.ts
@@ -10,14 +10,14 @@ describe('isHiddenOnAll', () => {
 
   it('returns true when hidden on all viewports', () => {
     const block = createParagraphBlock({
-      visibility: { desktop: false, tablet: false, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     expect(isHiddenOnAll(block)).toBe(true);
   });
 
   it('returns false when visible on at least one viewport', () => {
     const block = createParagraphBlock({
-      visibility: { desktop: true, tablet: false, mobile: false },
+      visibility: { desktop: true, mobile: false },
     });
     expect(isHiddenOnAll(block)).toBe(false);
   });
@@ -31,18 +31,9 @@ describe('getCssClasses', () => {
 
   it('returns hide classes for hidden viewports', () => {
     const block = createParagraphBlock({
-      visibility: { desktop: false, tablet: true, mobile: false },
+      visibility: { desktop: false, mobile: false },
     });
     expect(getCssClasses(block)).toBe('tpl-hide-desktop tpl-hide-mobile');
-  });
-
-  it('returns all hide classes when all hidden', () => {
-    const block = createParagraphBlock({
-      visibility: { desktop: false, tablet: false, mobile: false },
-    });
-    expect(getCssClasses(block)).toBe(
-      'tpl-hide-desktop tpl-hide-tablet tpl-hide-mobile',
-    );
   });
 });
 
@@ -52,11 +43,18 @@ describe('getCssClassAttr', () => {
     expect(getCssClassAttr(block)).toBe('');
   });
 
-  it('returns css-class attribute string', () => {
+  it('returns css-class attribute string for desktop-hidden block', () => {
     const block = createParagraphBlock({
-      visibility: { desktop: true, tablet: false, mobile: true },
+      visibility: { desktop: false, mobile: true },
     });
-    expect(getCssClassAttr(block)).toBe(' css-class="tpl-hide-tablet"');
+    expect(getCssClassAttr(block)).toBe(' css-class="tpl-hide-desktop"');
+  });
+
+  it('returns css-class attribute string for mobile-hidden block', () => {
+    const block = createParagraphBlock({
+      visibility: { desktop: true, mobile: false },
+    });
+    expect(getCssClassAttr(block)).toBe(' css-class="tpl-hide-mobile"');
   });
 });
 
@@ -80,7 +78,7 @@ describe('visibility with null/undefined', () => {
 
   it('returns empty string when all viewports visible', () => {
     const block = createParagraphBlock({
-      visibility: { desktop: true, tablet: true, mobile: true },
+      visibility: { desktop: true, mobile: true },
     });
     expect(getCssClasses(block)).toBe('');
     expect(getCssClassAttr(block)).toBe('');
@@ -88,14 +86,14 @@ describe('visibility with null/undefined', () => {
 
   it('returns only desktop hide class', () => {
     const block = createParagraphBlock({
-      visibility: { desktop: false, tablet: true, mobile: true },
+      visibility: { desktop: false, mobile: true },
     });
     expect(getCssClasses(block)).toBe('tpl-hide-desktop');
   });
 
   it('returns only mobile hide class', () => {
     const block = createParagraphBlock({
-      visibility: { desktop: true, tablet: true, mobile: false },
+      visibility: { desktop: true, mobile: false },
     });
     expect(getCssClasses(block)).toBe('tpl-hide-mobile');
   });

--- a/packages/types/src/blocks.ts
+++ b/packages/types/src/blocks.ts
@@ -13,7 +13,6 @@ export interface BlockStyles {
 
 export interface BlockVisibility {
   desktop: boolean;
-  tablet: boolean;
   mobile: boolean;
 }
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -1,6 +1,6 @@
 import type { SyntaxPreset, SyntaxPresetName } from "./merge-tags";
 
-export type ViewportSize = "desktop" | "tablet" | "mobile";
+export type ViewportSize = "desktop" | "mobile";
 
 export type UiTheme = "light" | "dark" | "auto";
 


### PR DESCRIPTION
Collapse the responsive model to Desktop + Mobile, dropping the `tablet` tier.

`ViewportSize` is now `"desktop" | "mobile"` and `BlockVisibility` drops its `tablet` field. The editor's viewport toggle no longer offers a Tablet preview, and the renderer emits a single 480px breakpoint (`tpl-hide-mobile` ≤480px, `tpl-hide-desktop` ≥481px) instead of three bands. A "tablet" breakpoint isn't a meaningful concept for email (bodies are ~600px wide; a tablet viewport renders at full desktop width), and the useful responsive split is binary — mobile vs. not-mobile, matching MJML's model.

**Migration:** saved templates carrying `visibility.tablet` keep parsing — the extra key is ignored at runtime. A block previously hidden only on tablet (`tablet: false` with `desktop`/`mobile` true) will now show on 481–768px devices, because there's no longer a `tpl-hide-tablet` class. No data migration is required; re-saving a block normalizes its visibility object to the new shape.

Closes #152.