### PR TITLE
refactor: remove margin from BlockStyles and update related components

### DIFF
--- a/.changeset/custom-block-default-styles.md
+++ b/.changeset/custom-block-default-styles.md
@@ -5,7 +5,7 @@
 
 Custom blocks can now declare default block styles in their definition, and the renderer honors `block.styles.padding` on custom and HTML blocks.
 
-**New `defaultStyles` on `CustomBlockDefinition`.** Custom block authors can now declare default `padding`, `margin`, and `backgroundColor` alongside `template` and `fields`. The value is a `Partial<BlockStyles>` deep-merged over the base defaults — specify only the fields you want to override. Controls both the editor canvas wrapper and the rendered MJML/email output.
+**New `defaultStyles` on `CustomBlockDefinition`.** Custom block authors can now declare default `padding` and `backgroundColor` alongside `template` and `fields`. The value is a `Partial<BlockStyles>` deep-merged over the base defaults — specify only the fields you want to override. Controls both the editor canvas wrapper and the rendered MJML/email output.
 
 ```ts
 customBlocks: [

--- a/.changeset/remove-block-margin.md
+++ b/.changeset/remove-block-margin.md
@@ -1,0 +1,17 @@
+---
+"@templatical/types": minor
+"@templatical/editor": minor
+"@templatical/import-beefree": minor
+"@templatical/import-unlayer": minor
+"@templatical/import-html": minor
+---
+
+Remove `margin` from `BlockStyles`.
+
+`margin` was a canvas-only style: it surfaced in the block settings panel and applied to the editor wrapper, but the renderer never read it, so it was dropped from the exported email — a WYSIWYG mismatch. Email spacing is expressed via `padding` (the renderer honors it on every block), so `margin` added a second, unreliable spacing control with no email output.
+
+- `BlockStyles.margin` is removed from the type and from `createDefaultStyles()`.
+- The Margin inputs are removed from the block settings panel, and the editor canvas no longer applies a wrapper margin.
+- The BeeFree, Unlayer, and HTML importers no longer emit a `margin` field on converted blocks.
+
+Use `padding` for block spacing. Persisted templates that still carry a `margin` key load fine — the extra field is ignored.

--- a/apps/docs/de/guide/custom-blocks.md
+++ b/apps/docs/de/guide/custom-blocks.md
@@ -109,7 +109,7 @@ interface CustomBlockDefinition {
 | `fields` | Ja | Array von Felddefinitionen |
 | `template` | Ja | Liquid-Template-String für das Rendering |
 | `dataSource` | Nein | Konfiguration für das Abrufen externer Daten |
-| `defaultStyles` | Nein | Standard-Blockstile (padding, margin, backgroundColor) — siehe [Standardstile](#standardstile) |
+| `defaultStyles` | Nein | Standard-Blockstile (padding, backgroundColor) — siehe [Standardstile](#standardstile) |
 
 ## Feldtypen
 
@@ -254,7 +254,7 @@ Eine wiederholbare Gruppe von Unterfeldern. Benutzer können Einträge innerhalb
 
 ## Standardstile
 
-Mit `defaultStyles` lassen sich die voreingestellten Werte für `padding`, `margin` und `backgroundColor` direkt in der Block-Definition festlegen. Der Wert ist ein `Partial<BlockStyles>` — nur die Felder angeben, die überschrieben werden sollen; alles andere fällt auf die eingebauten Standardwerte zurück (`10px` Padding rundherum, kein Margin, kein Hintergrund).
+Mit `defaultStyles` lassen sich die voreingestellten Werte für `padding` und `backgroundColor` direkt in der Block-Definition festlegen. Der Wert ist ein `Partial<BlockStyles>` — nur die Felder angeben, die überschrieben werden sollen; alles andere fällt auf die eingebauten Standardwerte zurück (`10px` Padding rundherum, kein Hintergrund).
 
 ```ts
 {
@@ -264,12 +264,11 @@ Mit `defaultStyles` lassen sich die voreingestellten Werte für `padding`, `marg
   template: '<table>…</table>',
   defaultStyles: {
     padding: { top: 0, right: 0, bottom: 0, left: 0 },
-    margin: { top: 0, right: 0, bottom: 0, left: 0 },
   },
 }
 ```
 
-`defaultStyles` greift, sobald ein:e Nutzer:in den Block aus der Palette auf die Arbeitsfläche zieht. Padding, Margin und Hintergrund lassen sich pro Block-Instanz weiterhin in den Block-Einstellungen anpassen — `defaultStyles` legt nur den Startzustand jeder neuen Instanz fest.
+`defaultStyles` greift, sobald ein:e Nutzer:in den Block aus der Palette auf die Arbeitsfläche zieht. Padding und Hintergrund lassen sich pro Block-Instanz weiterhin in den Block-Einstellungen anpassen — `defaultStyles` legt nur den Startzustand jeder neuen Instanz fest.
 
 Dies ist der empfohlene Weg, um benutzerdefinierte Blöcke vom Standard-Wrapper-Padding des SDK auszunehmen, wenn das Liquid-Template seinen Innenraum bereits selbst verwaltet (z. B. Hero-Sektionen, Produktkarten oder alles, was als vollständiges Tabellen-HTML verfasst ist).
 

--- a/apps/docs/de/guide/sections-and-columns.md
+++ b/apps/docs/de/guide/sections-and-columns.md
@@ -123,6 +123,5 @@ const section = createSectionBlock({ columns: '1' });
 section.styles = {
   backgroundColor: '#f8fafc',
   padding: { top: 32, right: 24, bottom: 32, left: 24 },
-  margin: { top: 0, right: 0, bottom: 0, left: 0 },
 };
 ```

--- a/apps/docs/de/guide/styling.md
+++ b/apps/docs/de/guide/styling.md
@@ -9,12 +9,11 @@ Jeder Block in Templatical trägt eine Eigenschaft `styles` für Layout und Ersc
 
 ## BlockStyles
 
-Die Schnittstelle `BlockStyles` steuert Padding, Margin und Hintergrund.
+Die Schnittstelle `BlockStyles` steuert Padding und Hintergrund.
 
 ```ts
 interface BlockStyles {
   padding: SpacingValue;
-  margin: SpacingValue;
   backgroundColor?: string;
 }
 ```
@@ -28,14 +27,13 @@ const block = createParagraphBlock({
 
 block.styles = {
   padding: { top: 16, right: 24, bottom: 16, left: 24 },
-  margin: { top: 0, right: 0, bottom: 0, left: 0 },
   backgroundColor: '#f0f9ff',
 };
 ```
 
 ## SpacingValue
 
-Padding und Margin verwenden den Typ `SpacingValue` mit vier Richtungswerten in Pixeln.
+Padding verwendet den Typ `SpacingValue` mit vier Richtungswerten in Pixeln.
 
 ```ts
 interface SpacingValue {
@@ -51,7 +49,6 @@ Alle vier Eigenschaften sind erforderlich. Verwenden Sie `0` für Seiten, die ke
 ```ts
 block.styles = {
   padding: { top: 0, right: 16, bottom: 0, left: 16 },
-  margin: { top: 8, right: 0, bottom: 8, left: 0 },
 };
 ```
 

--- a/apps/docs/guide/custom-blocks.md
+++ b/apps/docs/guide/custom-blocks.md
@@ -254,7 +254,7 @@ A repeatable group of sub-fields. Users can add or remove items within the confi
 
 ## Default styles
 
-Use `defaultStyles` to declare the block's default `padding`, `margin`, and `backgroundColor` alongside the rest of the definition. The value is a `Partial<BlockStyles>` — specify only the fields you want to override; everything else falls back to the built-in defaults (`10px` padding all around, zero margin, no background).
+Use `defaultStyles` to declare the block's default `padding` and `backgroundColor` alongside the rest of the definition. The value is a `Partial<BlockStyles>` — specify only the fields you want to override; everything else falls back to the built-in defaults (`10px` padding all around, no background).
 
 ```ts
 {
@@ -264,12 +264,11 @@ Use `defaultStyles` to declare the block's default `padding`, `margin`, and `bac
   template: '<table>…</table>',
   defaultStyles: {
     padding: { top: 0, right: 0, bottom: 0, left: 0 },
-    margin: { top: 0, right: 0, bottom: 0, left: 0 },
   },
 }
 ```
 
-`defaultStyles` applies the moment a user drags the block from the palette onto the canvas. Users can still adjust padding/margin/background per block instance through the block settings — `defaultStyles` only controls where each new instance starts.
+`defaultStyles` applies the moment a user drags the block from the palette onto the canvas. Users can still adjust padding/background per block instance through the block settings — `defaultStyles` only controls where each new instance starts.
 
 This is the recommended way to opt custom blocks out of the SDK's default wrapper padding when the block's Liquid template already manages its own spacing (e.g. hero sections, product cards, or anything authored as full table HTML).
 

--- a/apps/docs/guide/sections-and-columns.md
+++ b/apps/docs/guide/sections-and-columns.md
@@ -123,6 +123,5 @@ const section = createSectionBlock({ columns: '1' });
 section.styles = {
   backgroundColor: '#f8fafc',
   padding: { top: 32, right: 24, bottom: 32, left: 24 },
-  margin: { top: 0, right: 0, bottom: 0, left: 0 },
 };
 ```

--- a/apps/docs/guide/styling.md
+++ b/apps/docs/guide/styling.md
@@ -9,12 +9,11 @@ Every block in Templatical carries a `styles` property for layout and appearance
 
 ## BlockStyles
 
-The `BlockStyles` interface controls padding, margin, and background.
+The `BlockStyles` interface controls padding and background.
 
 ```ts
 interface BlockStyles {
   padding: SpacingValue;
-  margin: SpacingValue;
   backgroundColor?: string;
 }
 ```
@@ -28,14 +27,13 @@ const block = createParagraphBlock({
 
 block.styles = {
   padding: { top: 16, right: 24, bottom: 16, left: 24 },
-  margin: { top: 0, right: 0, bottom: 0, left: 0 },
   backgroundColor: '#f0f9ff',
 };
 ```
 
 ## SpacingValue
 
-Padding and margin use the `SpacingValue` type with four directional values in pixels.
+Padding uses the `SpacingValue` type with four directional values in pixels.
 
 ```ts
 interface SpacingValue {
@@ -51,7 +49,6 @@ All four properties are required. Use `0` for sides that need no spacing:
 ```ts
 block.styles = {
   padding: { top: 0, right: 16, bottom: 0, left: 16 },
-  margin: { top: 8, right: 0, bottom: 8, left: 0 },
 };
 ```
 

--- a/apps/playground/src/templates.ts
+++ b/apps/playground/src/templates.ts
@@ -21,7 +21,6 @@ import {
 
 const pad = (top: number, right: number, bottom: number, left: number) => ({
   padding: { top, right, bottom, left },
-  margin: { top: 0, right: 0, bottom: 0, left: 0 },
 });
 
 const white = (top = 0, right = 0, bottom = 0, left = 0) => ({

--- a/packages/core/tests/block-actions.test.ts
+++ b/packages/core/tests/block-actions.test.ts
@@ -422,7 +422,6 @@ describe('useBlockActions with blockDefaults', () => {
         if (block.type === 'paragraph') {
             expect(block.styles.padding.top).toBe(30);
             expect(block.styles.padding.right).toBe(10);
-            expect(block.styles.margin.top).toBe(0);
         }
     });
 });

--- a/packages/editor/src/components/blocks/BlockWrapper.vue
+++ b/packages/editor/src/components/blocks/BlockWrapper.vue
@@ -134,13 +134,9 @@ const blockCommentCount = computed(
   () => caps.comments?.getBlockCount(props.block.id) ?? 0,
 );
 
-// Split the block style: margin stays on `.tpl-block` (so the block's flow
-// spacing in the canvas is unaffected), while padding + backgroundColor
-// move onto `.tpl-block-content`. Filter-based dark-mode preview targets
-// `.tpl-block-content` so the bg inverts together with its content.
-const wrapperStyle = computed(() => ({
-  margin: getBlockWrapperStyle(props.block).margin,
-}));
+// padding + backgroundColor live on `.tpl-block-content` (not `.tpl-block`).
+// Filter-based dark-mode preview targets `.tpl-block-content` so the bg
+// inverts together with its content.
 const contentStyle = computed(() => {
   const full = getBlockWrapperStyle(props.block);
   return { padding: full.padding, backgroundColor: full.backgroundColor };
@@ -180,7 +176,6 @@ function handleConditionToggle(): void {
       'tpl-block--idle': !isSelected,
       'tpl-block--lifted': isLifted,
     }"
-    :style="wrapperStyle"
     :data-block-id="block.id"
     :data-block-type="block.type"
     @click="handleClick"

--- a/packages/editor/src/components/toolbar/CommonBlockSettings.vue
+++ b/packages/editor/src/components/toolbar/CommonBlockSettings.vue
@@ -148,13 +148,6 @@ function toggleVisibility(key: VisibilityKey): void {
         :model-value="block.styles.padding"
         @update:model-value="updateStyle('padding', $event)"
       />
-      <div class="tpl:mt-4">
-        <SpacingControl
-          :label="t.blockSettings.margin"
-          :model-value="block.styles.margin"
-          @update:model-value="updateStyle('margin', $event)"
-        />
-      </div>
     </CollapsibleSection>
 
     <CollapsibleSection

--- a/packages/editor/src/i18n/locales/de.ts
+++ b/packages/editor/src/i18n/locales/de.ts
@@ -389,7 +389,6 @@ const de: typeof en = {
   blockSettings: {
     spacing: "Abstände",
     padding: "Innenabstand",
-    margin: "Außenabstand",
     background: "Hintergrund",
     color: "Farbe",
     display: "Anzeige",

--- a/packages/editor/src/i18n/locales/en.ts
+++ b/packages/editor/src/i18n/locales/en.ts
@@ -382,7 +382,6 @@ export default {
   blockSettings: {
     spacing: "Spacing",
     padding: "Padding",
-    margin: "Margin",
     background: "Background",
     color: "Color",
     display: "Display",

--- a/packages/editor/src/i18n/locales/pt-BR.ts
+++ b/packages/editor/src/i18n/locales/pt-BR.ts
@@ -386,7 +386,6 @@ const ptBR: typeof en = {
   blockSettings: {
     spacing: "Espaçamento",
     padding: "Preenchimento",
-    margin: "Margem",
     background: "Plano de Fundo",
     color: "Cor",
     display: "Exibição",

--- a/packages/editor/src/utils/blockComponentResolver.ts
+++ b/packages/editor/src/utils/blockComponentResolver.ts
@@ -25,10 +25,9 @@ export function resolveBlockComponent(
  * Computes inline styles for a block wrapper from its styles config.
  */
 export function getBlockWrapperStyle(block: Block): Record<string, string> {
-  const { padding, margin, backgroundColor } = block.styles;
+  const { padding, backgroundColor } = block.styles;
   return {
     padding: `${padding.top}px ${padding.right}px ${padding.bottom}px ${padding.left}px`,
-    margin: `${margin.top}px ${margin.right}px ${margin.bottom}px ${margin.left}px`,
     backgroundColor: backgroundColor || "transparent",
   };
 }

--- a/packages/editor/tests/block-chrome-structure.test.ts
+++ b/packages/editor/tests/block-chrome-structure.test.ts
@@ -37,16 +37,16 @@ describe("block chrome structure", () => {
     );
   });
 
-  it("padding + backgroundColor live on `.tpl-block-content`, not `.tpl-block`", () => {
+  it("padding + backgroundColor live on `.tpl-block-content`; `.tpl-block` carries no inline spacing", () => {
     // Block bg has to sit INSIDE the filter region — moving it back onto
     // `.tpl-block` makes the dark-preview filter invert text-only, leaving
     // inverted (white) text on an un-inverted (white) section bg = invisible.
     expect(blockWrapper).toMatch(
       /contentStyle\s*=\s*computed\(\(\)\s*=>\s*\{[\s\S]*padding[\s\S]*backgroundColor/,
     );
-    expect(blockWrapper).toMatch(
-      /wrapperStyle\s*=\s*computed\(\(\)\s*=>\s*\(\{\s*margin:/,
-    );
+    // `.tpl-block` carries no inline style; spacing lives only on the content
+    // layer. Guards against reintroducing a wrapper-level spacing style.
+    expect(blockWrapper).not.toMatch(/wrapperStyle/);
   });
 
   it("Canvas renders `.tpl-canvas-bg` sibling with conditional invert filter", () => {

--- a/packages/editor/tests/blockComponentResolver.test.ts
+++ b/packages/editor/tests/blockComponentResolver.test.ts
@@ -76,17 +76,16 @@ describe("resolveBlockComponent", () => {
 });
 
 describe("getBlockWrapperStyle", () => {
-  it("computes padding, margin, and background from block styles", () => {
+  it("computes padding and background from block styles", () => {
     const block = createTitleBlock();
     block.styles = {
       padding: { top: 10, right: 20, bottom: 30, left: 40 },
-      margin: { top: 5, right: 10, bottom: 15, left: 20 },
       backgroundColor: "#ff0000",
     };
 
     const style = getBlockWrapperStyle(block);
     expect(style.padding).toBe("10px 20px 30px 40px");
-    expect(style.margin).toBe("5px 10px 15px 20px");
+    expect(style.margin).toBeUndefined();
     expect(style.backgroundColor).toBe("#ff0000");
   });
 
@@ -94,7 +93,6 @@ describe("getBlockWrapperStyle", () => {
     const block = createTitleBlock();
     block.styles = {
       padding: { top: 0, right: 0, bottom: 0, left: 0 },
-      margin: { top: 0, right: 0, bottom: 0, left: 0 },
       backgroundColor: "",
     };
 
@@ -102,16 +100,15 @@ describe("getBlockWrapperStyle", () => {
     expect(style.backgroundColor).toBe("transparent");
   });
 
-  it("handles zero padding and margin", () => {
+  it("handles zero padding", () => {
     const block = createTitleBlock();
     block.styles = {
       padding: { top: 0, right: 0, bottom: 0, left: 0 },
-      margin: { top: 0, right: 0, bottom: 0, left: 0 },
       backgroundColor: "#fff",
     };
 
     const style = getBlockWrapperStyle(block);
     expect(style.padding).toBe("0px 0px 0px 0px");
-    expect(style.margin).toBe("0px 0px 0px 0px");
+    expect(style.backgroundColor).toBe("#fff");
   });
 });

--- a/packages/editor/tests/e2e-consumer/aggressive-host.spec.ts
+++ b/packages/editor/tests/e2e-consumer/aggressive-host.spec.ts
@@ -155,7 +155,6 @@ test.describe("aggressive host CSS — issue #70 proof-of-fix gate", () => {
             content: "<p>shadow-protected text</p>",
             styles: {
               padding: { top: 10, right: 10, bottom: 10, left: 10 },
-              margin: { top: 0, right: 0, bottom: 0, left: 0 },
             },
           },
         ],
@@ -202,7 +201,6 @@ test.describe("aggressive host CSS — issue #70 proof-of-fix gate", () => {
             content: "<p>shadow-protected heading</p>",
             styles: {
               padding: { top: 10, right: 10, bottom: 10, left: 10 },
-              margin: { top: 0, right: 0, bottom: 0, left: 0 },
             },
           },
         ],

--- a/packages/editor/tests/e2e-consumer/smoke.spec.ts
+++ b/packages/editor/tests/e2e-consumer/smoke.spec.ts
@@ -134,7 +134,6 @@ test("editor.toMjml() includes custom blocks in the output", async ({ page }) =>
       fieldValues: { title: "Annual Gala 2026" },
       styles: {
         padding: { top: 10, right: 10, bottom: 10, left: 10 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     };
 

--- a/packages/editor/tests/preRenderCustomBlocks.test.ts
+++ b/packages/editor/tests/preRenderCustomBlocks.test.ts
@@ -17,7 +17,6 @@ function createCustom(customType: string, id = 'c1'): CustomBlock {
     fieldValues: {},
     styles: {
       padding: { top: 0, right: 0, bottom: 0, left: 0 },
-      margin: { top: 0, right: 0, bottom: 0, left: 0 },
     },
   } as CustomBlock;
 }

--- a/packages/import-beefree/src/block-mapper.ts
+++ b/packages/import-beefree/src/block-mapper.ts
@@ -20,7 +20,6 @@ import type {
   MenuItemData,
   TableRowData,
   TableCellData,
-  SpacingValue,
 } from "@templatical/types";
 import type {
   BeeFreeeModule,
@@ -123,16 +122,11 @@ function stripTagsPlain(text: string): string {
   return out;
 }
 
-function defaultMargin(): SpacingValue {
-  return { top: 0, right: 0, bottom: 0, left: 0 };
-}
-
 function makeStyles(descriptor: BeeFreeeModuleDescriptor): Block["styles"] {
   const padding = extractPadding(descriptor.style);
   const bg = parseColor(descriptor.style?.["background-color"]);
   return {
     padding,
-    margin: defaultMargin(),
     ...(bg ? { backgroundColor: bg } : {}),
   };
 }

--- a/packages/import-beefree/src/converter.ts
+++ b/packages/import-beefree/src/converter.ts
@@ -111,7 +111,6 @@ function processRow(
     children,
     styles: {
       padding: { top: 0, right: 0, bottom: 0, left: 0 },
-      margin: { top: 0, right: 0, bottom: 0, left: 0 },
       ...(rowBg ? { backgroundColor: rowBg } : {}),
     },
   });

--- a/packages/import-html/src/block-mapper.ts
+++ b/packages/import-html/src/block-mapper.ts
@@ -25,10 +25,6 @@ import {
 const HEADING_TAGS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
 const TEXT_TAGS = new Set(["p", "span", "div"]);
 
-function emptyMargin(): SpacingValue {
-  return { top: 0, right: 0, bottom: 0, left: 0 };
-}
-
 function emptyPadding(): SpacingValue {
   return { top: 0, right: 0, bottom: 0, left: 0 };
 }
@@ -87,7 +83,6 @@ function convertHeading($el: Cheerio<Element>): Block {
     fontFamily: parseFontFamily(styles["font-family"]) || undefined,
     styles: {
       padding: readPaddingFromStyles(styles),
-      margin: emptyMargin(),
     },
   });
 }
@@ -133,7 +128,6 @@ function convertParagraph($el: Cheerio<Element>): Block {
     content: result,
     styles: {
       padding: readPaddingFromStyles(styles),
-      margin: emptyMargin(),
     },
   });
 }
@@ -156,7 +150,6 @@ function convertImage($el: Cheerio<Element>): Block {
     align: parseAlignment(styles["text-align"], "center"),
     styles: {
       padding: readPaddingFromStyles(styles),
-      margin: emptyMargin(),
     },
   });
 }
@@ -205,7 +198,6 @@ function convertButton($el: Cheerio<Element>): Block {
     buttonPadding: readPaddingFromStyles(styles),
     styles: {
       padding: emptyPadding(),
-      margin: emptyMargin(),
     },
   });
 }
@@ -228,7 +220,6 @@ function convertDivider($el: Cheerio<Element>): Block {
     width: 100,
     styles: {
       padding: readPaddingFromStyles(styles),
-      margin: emptyMargin(),
     },
   });
 }
@@ -249,7 +240,6 @@ function convertSpacer($el: Cheerio<Element>): Block {
     height,
     styles: {
       padding: emptyPadding(),
-      margin: emptyMargin(),
     },
   });
 }
@@ -270,7 +260,6 @@ export function convertHtmlFallback(
     content,
     styles: {
       padding: readPaddingFromStyles(styles),
-      margin: emptyMargin(),
     },
   });
 }

--- a/packages/import-html/src/converter.ts
+++ b/packages/import-html/src/converter.ts
@@ -17,10 +17,6 @@ import {
 } from "./style-parser";
 import type { ImportReport, ImportReportEntry, ImportResult } from "./types";
 
-function emptyMargin() {
-  return { top: 0, right: 0, bottom: 0, left: 0 };
-}
-
 function emptyPadding() {
   return { top: 0, right: 0, bottom: 0, left: 0 };
 }
@@ -78,7 +74,6 @@ function wrapInSection(blocks: Block[]): Block {
     children: [blocks],
     styles: {
       padding: emptyPadding(),
-      margin: emptyMargin(),
     },
   });
 }

--- a/packages/import-html/src/section-builder.ts
+++ b/packages/import-html/src/section-builder.ts
@@ -21,10 +21,6 @@ import {
 } from "./style-parser";
 import type { ImportReportEntry } from "./types";
 
-function emptyMargin() {
-  return { top: 0, right: 0, bottom: 0, left: 0 };
-}
-
 function emptyPadding() {
   return { top: 0, right: 0, bottom: 0, left: 0 };
 }
@@ -59,7 +55,6 @@ function buildCellButton(
     buttonPadding: readPaddingFromStyles(merged),
     styles: {
       padding: emptyPadding(),
-      margin: emptyMargin(),
     },
   });
 }
@@ -75,7 +70,6 @@ function buildSpacerFromCell($cell: Cheerio<Element>): Block {
     height,
     styles: {
       padding: emptyPadding(),
-      margin: emptyMargin(),
     },
   });
 }
@@ -281,7 +275,6 @@ export function processTable(
         children: columnsBlocks,
         styles: {
           padding,
-          margin: emptyMargin(),
           ...(bgColor ? { backgroundColor: bgColor } : {}),
         },
       }),

--- a/packages/import-unlayer/src/block-mapper.ts
+++ b/packages/import-unlayer/src/block-mapper.ts
@@ -17,7 +17,6 @@ import type {
   SocialPlatform,
   SocialIcon,
   MenuItemData,
-  SpacingValue,
 } from "@templatical/types";
 import type {
   UnlayerContent,
@@ -102,15 +101,10 @@ function toLineStyle(
   return fallback;
 }
 
-function defaultMargin(): SpacingValue {
-  return { top: 0, right: 0, bottom: 0, left: 0 };
-}
-
 function makeStyles(values: UnlayerContentValues): Block["styles"] {
   const padding = parsePaddingShorthand(values.containerPadding);
   return {
     padding,
-    margin: defaultMargin(),
   };
 }
 

--- a/packages/import-unlayer/src/converter.ts
+++ b/packages/import-unlayer/src/converter.ts
@@ -97,7 +97,6 @@ function processRow(
     children,
     styles: {
       padding,
-      margin: { top: 0, right: 0, bottom: 0, left: 0 },
       ...(rowBg ? { backgroundColor: rowBg } : {}),
     },
   });

--- a/packages/quality/tests/accessibility/text-rules.test.ts
+++ b/packages/quality/tests/accessibility/text-rules.test.ts
@@ -114,7 +114,6 @@ describe("a11y.text-low-contrast", () => {
       styles: {
         backgroundColor: "#000000",
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     });
     const content = createDefaultTemplateContent();

--- a/packages/quality/tests/walk.test.ts
+++ b/packages/quality/tests/walk.test.ts
@@ -57,7 +57,6 @@ describe("walkBlocks", () => {
       styles: {
         backgroundColor: "#112233",
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
       children: [[inner]],
     });
@@ -92,7 +91,6 @@ describe("walkBlocks", () => {
       styles: {
         backgroundColor: "#000000",
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     });
     content.blocks = [inner];

--- a/packages/renderer/tests/mjml-fidelity.test.ts
+++ b/packages/renderer/tests/mjml-fidelity.test.ts
@@ -177,7 +177,6 @@ describe("custom block backgroundColor reaches HTML", () => {
       styles: {
         backgroundColor: "#fffbeb",
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     };
     const context = new RenderContext(
@@ -204,7 +203,6 @@ describe("html block backgroundColor reaches HTML", () => {
       content: "<div>hello</div>",
       styles: {
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
         backgroundColor: "#fffbeb",
       },
     });
@@ -262,7 +260,6 @@ describe("button with openInNewTab=true emits rel=noopener", () => {
       openInNewTab: true,
       styles: {
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     };
     const mjml = renderBlock(block as any, ctx);
@@ -297,7 +294,6 @@ describe("menu items with openInNewTab=true emit rel=noopener", () => {
       textAlign: "left",
       styles: {
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     };
     const mjml = renderBlock(block as any, ctx);
@@ -345,7 +341,6 @@ describe("button color attrs are escaped", () => {
       openInNewTab: false,
       styles: {
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     };
     const mjml = renderBlock(block as any, ctx);
@@ -378,7 +373,6 @@ describe("button with empty URL", () => {
       openInNewTab: false,
       styles: {
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     };
     const mjml = renderBlock(block as any, ctx);
@@ -394,7 +388,6 @@ describe("spacer ignores block.styles.padding (matches canvas)", () => {
       styles: {
         backgroundColor: "",
         padding: { top: 10, right: 0, bottom: 10, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     } as Parameters<typeof createSpacerBlock>[0]);
 

--- a/packages/renderer/tests/render-to-mjml.test.ts
+++ b/packages/renderer/tests/render-to-mjml.test.ts
@@ -92,7 +92,7 @@ describe('renderToMjml', () => {
     const content = createDefaultTemplateContent();
     content.blocks = [
       createParagraphBlock({ content: '<p>Keep</p>' }),
-      { id: '1', type: 'html' as const, content: '<div>Remove</div>', styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } } },
+      { id: '1', type: 'html' as const, content: '<div>Remove</div>', styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 } } },
     ];
     const mjml = await renderToMjml(content, { allowHtmlBlocks: false });
     expect(mjml).toContain('Keep');

--- a/packages/renderer/tests/renderers.test.ts
+++ b/packages/renderer/tests/renderers.test.ts
@@ -128,7 +128,6 @@ describe('renderBlock', () => {
       content: '<div>x</div>',
       styles: {
         padding: { top: 5, right: 10, bottom: 15, left: 20 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
       },
     });
     const result = renderBlock(block, ctx);
@@ -140,7 +139,6 @@ describe('renderBlock', () => {
       content: '<div>x</div>',
       styles: {
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
         backgroundColor: '#fafafa',
       },
     });
@@ -244,7 +242,7 @@ describe('renderBlock', () => {
     const block = {
       id: '1',
       type: 'nonexistent' as never,
-      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 } },
     } as Block;
     const result = renderBlock(block, ctx);
     expect(result).toBe('');
@@ -257,7 +255,7 @@ describe('renderBlock', () => {
       customType: 'product-card',
       fieldValues: {},
       renderedHtml: '<div>Custom Content</div>',
-      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 } },
     };
     const result = renderBlock(block, ctx);
     expect(result).toContain('<mj-text');
@@ -270,7 +268,7 @@ describe('renderBlock', () => {
       type: 'custom',
       customType: 'product-card',
       fieldValues: {},
-      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 } },
     };
     const result = renderBlock(block, ctx);
     expect(result).toBe('');
@@ -283,7 +281,7 @@ describe('renderBlock', () => {
       customType: 'product-card',
       fieldValues: {},
       renderedHtml: '',
-      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 } },
     };
     const result = renderBlock(block, ctx);
     expect(result).toBe('');
@@ -297,7 +295,7 @@ describe('renderBlock', () => {
       fieldValues: {},
       renderedHtml: '<div>Content</div>',
       visibility: { desktop: false, mobile: false },
-      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 } },
     };
     const result = renderBlock(block, ctx);
     expect(result).toBe('');
@@ -311,7 +309,7 @@ describe('renderBlock', () => {
       fieldValues: {},
       renderedHtml: '<div>Content</div>',
       visibility: { desktop: false, mobile: true },
-      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 } },
     };
     const result = renderBlock(block, ctx);
     expect(result).toContain('css-class="tpl-hide-desktop"');
@@ -324,7 +322,7 @@ describe('renderBlock', () => {
       customType: 'product-card',
       fieldValues: {},
       renderedHtml: '<div>Content</div>',
-      styles: { padding: { top: 5, right: 10, bottom: 15, left: 20 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+      styles: { padding: { top: 5, right: 10, bottom: 15, left: 20 } },
     };
     const result = renderBlock(block, ctx);
     expect(result).toContain('padding="5px 10px 15px 20px"');
@@ -337,7 +335,7 @@ describe('renderBlock', () => {
       customType: 'product-card',
       fieldValues: {},
       renderedHtml: '<div>Content</div>',
-      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+      styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 } },
     };
     const result = renderBlock(block, ctx);
     expect(result).toContain('padding="0px 0px 0px 0px"');
@@ -352,7 +350,6 @@ describe('renderBlock', () => {
       renderedHtml: '<div>Content</div>',
       styles: {
         padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
         backgroundColor: '#fafafa',
       },
     };

--- a/packages/types/src/blocks.ts
+++ b/packages/types/src/blocks.ts
@@ -7,7 +7,6 @@ export interface SpacingValue {
 
 export interface BlockStyles {
   padding: SpacingValue;
-  margin: SpacingValue;
   backgroundColor?: string;
 }
 

--- a/packages/types/src/factory.ts
+++ b/packages/types/src/factory.ts
@@ -58,7 +58,6 @@ function createDefaultSpacing(value = 0): SpacingValue {
 function createDefaultStyles(padding = 10): BlockStyles {
   return {
     padding: createDefaultSpacing(padding),
-    margin: createDefaultSpacing(0),
   };
 }
 

--- a/packages/types/tests/defaults.test.ts
+++ b/packages/types/tests/defaults.test.ts
@@ -51,7 +51,7 @@ describe("deepMergeDefaults", () => {
 
   it("deep merges nested objects", () => {
     const base = {
-      styles: { padding: { top: 10, right: 10, bottom: 10, left: 10 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+      styles: { padding: { top: 10, right: 10, bottom: 10, left: 10 }, backgroundColor: "#fff" },
     };
     const result = deepMergeDefaults(base, {
       styles: { padding: { top: 20 } },
@@ -60,7 +60,8 @@ describe("deepMergeDefaults", () => {
     expect(result.styles.padding.right).toBe(10);
     expect(result.styles.padding.bottom).toBe(10);
     expect(result.styles.padding.left).toBe(10);
-    expect(result.styles.margin.top).toBe(0);
+    // sibling key the patch didn't touch survives the deep merge
+    expect(result.styles.backgroundColor).toBe("#fff");
   });
 
   it("replaces arrays instead of merging", () => {

--- a/packages/types/tests/factory.test.ts
+++ b/packages/types/tests/factory.test.ts
@@ -368,7 +368,6 @@ describe('createCustomBlock with defaultStyles', () => {
         };
         const block = createCustomBlock(definition);
         expect(block.styles.padding).toEqual({ top: 10, right: 10, bottom: 10, left: 10 });
-        expect(block.styles.margin).toEqual({ top: 0, right: 0, bottom: 0, left: 0 });
         expect(block.styles.backgroundColor).toBeUndefined();
     });
 
@@ -384,8 +383,8 @@ describe('createCustomBlock with defaultStyles', () => {
         };
         const block = createCustomBlock(definition);
         expect(block.styles.padding).toEqual({ top: 0, right: 0, bottom: 0, left: 0 });
-        // margin and backgroundColor remain at base
-        expect(block.styles.margin).toEqual({ top: 0, right: 0, bottom: 0, left: 0 });
+        // backgroundColor remains at base (undefined)
+        expect(block.styles.backgroundColor).toBeUndefined();
     });
 
     it('overrides only specified BlockStyles keys (partial merge)', () => {
@@ -401,22 +400,6 @@ describe('createCustomBlock with defaultStyles', () => {
         const block = createCustomBlock(definition);
         expect(block.styles.backgroundColor).toBe('#fafafa');
         // padding stays at base 10
-        expect(block.styles.padding).toEqual({ top: 10, right: 10, bottom: 10, left: 10 });
-    });
-
-    it('overrides margin independently of padding', () => {
-        const definition: CustomBlockDefinition = {
-            type: 'm-only',
-            name: 'Margin Only',
-            fields: [],
-            template: '<div></div>',
-            defaultStyles: {
-                margin: { top: 8, right: 0, bottom: 8, left: 0 },
-            },
-        };
-        const block = createCustomBlock(definition);
-        expect(block.styles.margin).toEqual({ top: 8, right: 0, bottom: 8, left: 0 });
-        // padding untouched
         expect(block.styles.padding).toEqual({ top: 10, right: 10, bottom: 10, left: 10 });
     });
 
@@ -492,7 +475,6 @@ describe('createBlock with blockDefaults', () => {
             expect(block.textColor).toBe('#ffffff');
             expect(block.styles.padding.top).toBe(20);
             expect(block.styles.padding.right).toBe(10);
-            expect(block.styles.margin.top).toBe(0);
         }
     });
 
@@ -659,12 +641,12 @@ describe('createBlock with blockDefaults', () => {
 });
 
 describe('factory deep merge vs shallow spread', () => {
-    it('deep merges styles.padding without losing styles.margin', () => {
+    it('deep merges styles.padding', () => {
         const block = createTitleBlock({
             styles: { padding: { top: 20, right: 20, bottom: 20, left: 20 } },
         } as any);
         expect(block.styles.padding.top).toBe(20);
-        expect(block.styles.margin.top).toBe(0);
+        expect(block.styles.padding.bottom).toBe(20);
     });
 
     it('deep merges partial padding preserving other padding values', () => {

--- a/packages/types/tests/guards.test.ts
+++ b/packages/types/tests/guards.test.ts
@@ -106,7 +106,7 @@ describe('type guards', () => {
             type: 'custom' as const,
             customType: 'test',
             fieldValues: {},
-            styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+            styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 } },
         };
         expect(isCustomBlock(block)).toBe(true);
         expect(isTitle(block)).toBe(false);

--- a/packages/types/tests/template.test.ts
+++ b/packages/types/tests/template.test.ts
@@ -41,7 +41,7 @@ describe('createDefaultTemplateContent', () => {
             color: '#000',
             textAlign: 'left',
             fontWeight: 'normal',
-            styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 }, margin: { top: 0, right: 0, bottom: 0, left: 0 } },
+            styles: { padding: { top: 0, right: 0, bottom: 0, left: 0 } },
         } as any);
         expect(content2.blocks).toEqual([]);
     });


### PR DESCRIPTION
Remove `margin` from `BlockStyles`.

`margin` was a canvas-only style: it surfaced in the block settings panel and applied to the editor wrapper, but the renderer never read it, so it was dropped from the exported email — a WYSIWYG mismatch. Email spacing is expressed via `padding` (the renderer honors it on every block), so `margin` added a second, unreliable spacing control with no email output.

- `BlockStyles.margin` is removed from the type and from `createDefaultStyles()`.
- The Margin inputs are removed from the block settings panel, and the editor canvas no longer applies a wrapper margin.
- The BeeFree, Unlayer, and HTML importers no longer emit a `margin` field on converted blocks.

Use `padding` for block spacing. Persisted templates that still carry a `margin` key load fine — the extra field is ignored.

Closes #151.