### PR TITLE
Add a single `lintTemplate` entry point for quality checks

### DIFF
--- a/.changeset/lint-template-entry-point.md
+++ b/.changeset/lint-template-entry-point.md
@@ -1,0 +1,8 @@
+---
+"@templatical/quality": minor
+"@templatical/editor": patch
+---
+
+Add a single `lintTemplate(content, options?)` entry point that runs every linter — accessibility, structure, and links — and returns the merged issue list. Prefer it over calling `lintAccessibility` / `lintStructure` / `lintLinks` individually: new linter categories are picked up automatically by every consumer that funnels through it.
+
+The editor's live linter (`useTemplateLint`) now calls `lintTemplate` internally; behavior is unchanged. The individual linter exports remain available.

--- a/apps/docs/de/quality/headless-usage.md
+++ b/apps/docs/de/quality/headless-usage.md
@@ -2,27 +2,26 @@
 
 `@templatical/quality` ist ausschließlich JSON-basiert und hat keine DOM-Abhängigkeit — dieselben Linter laufen in jedem Node.js-Kontext: CI, Build-Pipelines, serverseitige Validierung, Batch-Jobs.
 
-`lintAccessibility(content, options?)`, `lintStructure(content, options?)` und `lintLinks(content, options?)` liefern alle dieselbe `LintIssue[]`-Struktur — du kannst sie unabhängig aufrufen oder Ergebnisse zusammenführen.
+`lintTemplate(content, options?)` führt jeden Linter aus — Barrierefreiheit, Struktur und Links — und liefert die zusammengeführten `LintIssue[]`. Es ist der empfohlene Einstiegspunkt: ein Aufruf, und jede künftige Linter-Kategorie ist automatisch enthalten.
+
+```ts
+import { lintTemplate } from "@templatical/quality";
+
+const issues = lintTemplate(content); // a11y-, dann structure-, dann link-Issues
+```
+
+Die einzelnen Linter-Funktionen — `lintAccessibility(content, options?)`, `lintStructure(content, options?)`, `lintLinks(content, options?)` — liefern dieselbe Struktur und bleiben exportiert, falls du nur eine Teilmenge ausführen willst. Du kannst eine Teilmenge auch über `lintTemplate` ausführen, indem du Kategorien deaktivierst: `lintTemplate(content, { structure: false, links: false })` führt nur die Barrierefreiheit aus.
 
 ## Vor dem Speichern validieren
 
 Verweigere Template-JSON, das die Linter nicht besteht, dort wo es in dein System eintritt — CMS-Save-Handler, API-Endpunkt, Ingestion-Job:
 
 ```ts
-import {
-  lintAccessibility,
-  lintLinks,
-  lintStructure,
-} from "@templatical/quality";
+import { lintTemplate } from "@templatical/quality";
 import type { TemplateContent } from "@templatical/types";
 
 export function assertValid(content: TemplateContent): void {
-  const issues = [
-    ...lintAccessibility(content),
-    ...lintStructure(content),
-    ...lintLinks(content),
-  ];
-  const errors = issues.filter((i) => i.severity === "error");
+  const errors = lintTemplate(content).filter((i) => i.severity === "error");
   if (errors.length > 0) {
     throw new Error(
       `Template scheitert an Qualitätsprüfungen:\n${errors
@@ -41,11 +40,7 @@ Wenn deine Anwendung `TemplateContent`-JSON in einer Datenbank speichert, lass d
 
 ```ts
 // scripts/lint-templates.ts
-import {
-  lintAccessibility,
-  lintLinks,
-  lintStructure,
-} from "@templatical/quality";
+import { lintTemplate } from "@templatical/quality";
 import { templates } from "../fixtures/templates";
 
 const SEVERITY_RANK = { error: 3, warning: 2, info: 1 };
@@ -53,11 +48,9 @@ const SEVERITY_RANK = { error: 3, warning: 2, info: 1 };
 let failed = 0;
 
 for (const [name, content] of Object.entries(templates)) {
-  const issues = [
-    ...lintAccessibility(content),
-    ...lintStructure(content),
-    ...lintLinks(content),
-  ].filter((i) => SEVERITY_RANK[i.severity] >= SEVERITY_RANK.warning);
+  const issues = lintTemplate(content).filter(
+    (i) => SEVERITY_RANK[i.severity] >= SEVERITY_RANK.warning,
+  );
 
   if (issues.length === 0) {
     console.log(`OK ${name}: sauber`);
@@ -81,11 +74,7 @@ Per `tsx scripts/lint-templates.ts` ausführen und in deinen CI-Workflow einbind
 Regel-IDs sind namensraum-getrennt (`a11y.*`, `structure.*`, `link.*`), also ist Gruppieren oder Filtern nach Linter ein `startsWith`-Check:
 
 ```ts
-const issues = [
-  ...lintAccessibility(content),
-  ...lintStructure(content),
-  ...lintLinks(content),
-];
+const issues = lintTemplate(content);
 const a11y = issues.filter((i) => i.ruleId.startsWith("a11y."));
 const structural = issues.filter((i) => i.ruleId.startsWith("structure."));
 const links = issues.filter((i) => i.ruleId.startsWith("link."));
@@ -136,4 +125,4 @@ for (const { url, blockId, source } of walkUrls(content)) {
 }
 ```
 
-Wenn deine Custom-Regel beim Orchestrator mitmachen soll (Schweregrad-Overrides, lokalisierte Nachrichten, das Editor-Issues-Panel), implementiere das `Rule`-Interface — `block` / `template` liefern einen `RuleHit` (`blockId`, optionale `params`, optionaler `fix`), und der Orchestrator kombiniert ihn mit `meta` und dem Nachrichtentemplate der aktiven Locale. Dasselbe `runRules`-Helper-Modul betreibt `lintAccessibility`, `lintStructure` und `lintLinks`.
+Wenn deine Custom-Regel beim Orchestrator mitmachen soll (Schweregrad-Overrides, lokalisierte Nachrichten, das Editor-Issues-Panel), implementiere das `Rule`-Interface — `block` / `template` liefern einen `RuleHit` (`blockId`, optionale `params`, optionaler `fix`), und der Orchestrator kombiniert ihn mit `meta` und dem Nachrichtentemplate der aktiven Locale. Dasselbe `runRules`-Helper-Modul betreibt `lintAccessibility`, `lintStructure` und `lintLinks`, und `lintTemplate` verteilt einfach an alle drei.

--- a/apps/docs/de/quality/index.md
+++ b/apps/docs/de/quality/index.md
@@ -12,6 +12,8 @@
 
 Alle drei Linter liefern dieselbe `LintIssue`-Struktur und teilen sich dieselbe Optionsfläche (`LintOptions`) — Konsumenten können sie also in jeder Kombination ausführen, Ergebnisse zusammenführen und beim Gruppieren nach `ruleId`-Präfix (`a11y.*`, `structure.*`, `link.*`) filtern. Die Schweregrad-Overrides und tool-spezifischen Stellschrauben jedes Linters liegen unter seinem eigenen Namensraum (`accessibility`, `structure`, `links`); setze einen davon auf `false`, um den jeweiligen Linter komplett zu deaktivieren.
 
+**Alles mit einem Aufruf ausführen.** `lintTemplate(content, options?)` ist der einzelne aggregierte Einstiegspunkt — er führt alle drei Linter aus und liefert die zusammengeführten `LintIssue[]` (zuerst Barrierefreiheit, dann Struktur, dann Links). Greife standardmäßig dazu; die einzelnen Linter-Funktionen bleiben exportiert, falls du nur eine Teilmenge ausführen willst. Um eine Kategorie zu überspringen, setze ihren Schlüssel auf `false`: `lintTemplate(content, { structure: false })`. Siehe [Headless-Nutzung](./headless-usage).
+
 ## Architektur
 
 <svg viewBox="0 0 640 280" fill="none" xmlns="http://www.w3.org/2000/svg" style="width:100%;max-width:640px;margin:1.5em auto;display:block;">
@@ -52,7 +54,7 @@ Alle drei Linter liefern dieselbe `LintIssue`-Struktur und teilen sich dieselbe 
   <text x="520" y="224" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748b" text-anchor="middle">gespeicherte Templates</text>
 </svg>
 
-Das Paket trifft keine UI-Annahmen. Das `useTemplateLint`-Composable des Editors lädt `@templatical/quality` per dynamischem Import nach, ruft jeden exportierten Linter bei (entprellten) Inhaltsänderungen auf und führt die Ergebnisse in einen einzigen Issue-Strom zusammen, der den **Issues**-Sidebar-Tab und die Per-Block-Canvas-Badges speist. `applyFix(issue)` führt jeden Patch über den bestehenden Block-Update-Pfad des Editors aus — Fixes landen so als ordentliche Undo-Einträge.
+Das Paket trifft keine UI-Annahmen. Das `useTemplateLint`-Composable des Editors lädt `@templatical/quality` per dynamischem Import nach, ruft alle Linter über den einzelnen `lintTemplate`-Aufruf bei (entprellten) Inhaltsänderungen auf und speist den zusammengeführten Issue-Strom in den **Issues**-Sidebar-Tab und die Per-Block-Canvas-Badges. `applyFix(issue)` führt jeden Patch über den bestehenden Block-Update-Pfad des Editors aus — Fixes landen so als ordentliche Undo-Einträge.
 
 ## Installation
 
@@ -118,7 +120,7 @@ init({ container: "#editor", lint: { links: false } });
 
 - [Optionen](./options) — `disabled`, `locale`, pro-Tool-Namensräume `accessibility` / `structure` / `links`.
 - [Schweregrade & Fixes](./severity-and-fixes) — Schweregrad-Modell + wie Auto-Fix-Patches im Editor landen.
-- [Headless-Nutzung](./headless-usage) — Validierung gespeicherter Templates in CI / Server-Save-Handlern.
+- [Headless-Nutzung](./headless-usage) — `lintTemplate` + Validierung gespeicherter Templates in CI / Server-Save-Handlern.
 - [Lokalen beitragen](./contributing-locales) — Regel-Nachrichten + Vague-Text-Dictionaries hinzufügen.
 - [Barrierefreiheits-Linter](./accessibility/) — was er erkennt, Regelkatalog.
 - [Struktur-Linter](./structure/) — was er erkennt, Regelkatalog.

--- a/apps/docs/de/quality/options.md
+++ b/apps/docs/de/quality/options.md
@@ -1,6 +1,6 @@
 # Optionen
 
-`lintAccessibility`, `lintStructure` und `lintLinks` akzeptieren dieselbe `LintOptions`-Struktur. Jedes Feld ist optional.
+`lintTemplate`, `lintAccessibility`, `lintStructure` und `lintLinks` akzeptieren alle dieselbe `LintOptions`-Struktur. Jedes Feld ist optional.
 
 ```ts
 interface LintOptions {
@@ -70,7 +70,7 @@ init({ locale: "de" });
 ::: warning Im Editor-Modus wird `lint.locale` ignoriert
 Im Editor-Modus wird die Linter-Locale **erzwungen** auf den `locale`-Wert aus `init({ locale })`. `lint.locale` zu setzen, hat keinen Effekt — es wird auf dem Weg überschrieben.
 
-Headless-Aufrufer (`lintAccessibility(...)` / `lintStructure(...)` / `lintLinks(...)` direkt) behalten volle Kontrolle.
+Headless-Aufrufer (`lintTemplate(...)` oder `lintAccessibility(...)` / `lintStructure(...)` / `lintLinks(...)` direkt) behalten volle Kontrolle.
 :::
 
 ::: tip Vague-Text-Dictionaries sind sprachübergreifend

--- a/apps/docs/de/quality/severity-and-fixes.md
+++ b/apps/docs/de/quality/severity-and-fixes.md
@@ -1,6 +1,6 @@
 # Schweregrade & Fixes
 
-Alle Linter teilen sich dasselbe Schweregrad-Modell und dieselbe Patch-Struktur, daher behandelt diese Seite `lintAccessibility`, `lintStructure` und `lintLinks` gemeinsam.
+Alle Linter teilen sich dasselbe Schweregrad-Modell und dieselbe Patch-Struktur, daher behandelt diese Seite `lintTemplate`, `lintAccessibility`, `lintStructure` und `lintLinks` gemeinsam.
 
 ## Schweregrad-Modell
 
@@ -43,18 +43,9 @@ Im Editor läuft `apply` über den bestehenden `editor.updateBlock` / `editor.up
 Headless-Aufrufer können einen eigenen `LintPatchContext` konstruieren und Patches programmatisch anwenden:
 
 ```ts
-import {
-  lintAccessibility,
-  lintLinks,
-  lintStructure,
-} from "@templatical/quality";
+import { lintTemplate } from "@templatical/quality";
 
-const issues = [
-  ...lintAccessibility(content),
-  ...lintStructure(content),
-  ...lintLinks(content),
-];
-const fixable = issues.filter((i) => i.fix);
+const fixable = lintTemplate(content).filter((i) => i.fix);
 
 for (const issue of fixable) {
   issue.fix!.apply({

--- a/apps/docs/quality/headless-usage.md
+++ b/apps/docs/quality/headless-usage.md
@@ -2,27 +2,26 @@
 
 `@templatical/quality` is JSON-only and has no DOM dependency, so the same linters run in any Node.js context: CI, build pipelines, server-side validation, batch jobs.
 
-`lintAccessibility(content, options?)`, `lintStructure(content, options?)`, and `lintLinks(content, options?)` all return the same `LintIssue[]` shape, so you can call them independently or merge results.
+`lintTemplate(content, options?)` runs every linter — accessibility, structure, and links — and returns the merged `LintIssue[]`. It's the recommended entry point: one call, and any future linter category is included automatically.
+
+```ts
+import { lintTemplate } from "@templatical/quality";
+
+const issues = lintTemplate(content); // a11y, then structure, then link issues
+```
+
+The per-linter functions — `lintAccessibility(content, options?)`, `lintStructure(content, options?)`, `lintLinks(content, options?)` — return the same shape and stay exported for when you want to run only a subset. You can also run a subset through `lintTemplate` by disabling categories: `lintTemplate(content, { structure: false, links: false })` runs accessibility only.
 
 ## Validate before storing
 
 Reject template JSON that fails the linter at the point it enters your system — CMS save handler, API endpoint, ingestion job:
 
 ```ts
-import {
-  lintAccessibility,
-  lintLinks,
-  lintStructure,
-} from "@templatical/quality";
+import { lintTemplate } from "@templatical/quality";
 import type { TemplateContent } from "@templatical/types";
 
 export function assertValid(content: TemplateContent): void {
-  const issues = [
-    ...lintAccessibility(content),
-    ...lintStructure(content),
-    ...lintLinks(content),
-  ];
-  const errors = issues.filter((i) => i.severity === "error");
+  const errors = lintTemplate(content).filter((i) => i.severity === "error");
   if (errors.length > 0) {
     throw new Error(
       `Template fails quality checks:\n${errors
@@ -41,11 +40,7 @@ If your application stores `TemplateContent` JSON in a database, run the linters
 
 ```ts
 // scripts/lint-templates.ts
-import {
-  lintAccessibility,
-  lintLinks,
-  lintStructure,
-} from "@templatical/quality";
+import { lintTemplate } from "@templatical/quality";
 import { templates } from "../fixtures/templates";
 
 const SEVERITY_RANK = { error: 3, warning: 2, info: 1 };
@@ -53,11 +48,9 @@ const SEVERITY_RANK = { error: 3, warning: 2, info: 1 };
 let failed = 0;
 
 for (const [name, content] of Object.entries(templates)) {
-  const issues = [
-    ...lintAccessibility(content),
-    ...lintStructure(content),
-    ...lintLinks(content),
-  ].filter((i) => SEVERITY_RANK[i.severity] >= SEVERITY_RANK.warning);
+  const issues = lintTemplate(content).filter(
+    (i) => SEVERITY_RANK[i.severity] >= SEVERITY_RANK.warning,
+  );
 
   if (issues.length === 0) {
     console.log(`OK ${name}: clean`);
@@ -81,11 +74,7 @@ Run via `tsx scripts/lint-templates.ts` and wire it into your CI workflow. The T
 Rule IDs are namespaced (`a11y.*`, `structure.*`, `link.*`), so grouping or filtering by linter is a `startsWith` check:
 
 ```ts
-const issues = [
-  ...lintAccessibility(content),
-  ...lintStructure(content),
-  ...lintLinks(content),
-];
+const issues = lintTemplate(content);
 const a11y = issues.filter((i) => i.ruleId.startsWith("a11y."));
 const structural = issues.filter((i) => i.ruleId.startsWith("structure."));
 const links = issues.filter((i) => i.ruleId.startsWith("link."));
@@ -136,4 +125,4 @@ for (const { url, blockId, source } of walkUrls(content)) {
 }
 ```
 
-If you'd like your custom rule to participate in the orchestrator alongside the built-ins (severity overrides, localized messages, the editor Issues panel), implement the `Rule` interface — `block` / `template` return a `RuleHit` (`blockId`, optional `params`, optional `fix`) and the orchestrator combines it with the rule's `meta` and the active locale's message template. The same `runRules` helper powers `lintAccessibility`, `lintStructure`, and `lintLinks`.
+If you'd like your custom rule to participate in the orchestrator alongside the built-ins (severity overrides, localized messages, the editor Issues panel), implement the `Rule` interface — `block` / `template` return a `RuleHit` (`blockId`, optional `params`, optional `fix`) and the orchestrator combines it with the rule's `meta` and the active locale's message template. The same `runRules` helper powers `lintAccessibility`, `lintStructure`, and `lintLinks`, and `lintTemplate` simply fans out to all three.

--- a/apps/docs/quality/index.md
+++ b/apps/docs/quality/index.md
@@ -12,6 +12,8 @@
 
 All three linters return the same `LintIssue` shape and share the same options surface (`LintOptions`) — so consumers can run them in any combination, merge results, and filter by `ruleId` prefix (`a11y.*`, `structure.*`, `link.*`) when grouping. Each linter's per-rule severities and tool-specific knobs live under its own namespace (`accessibility`, `structure`, `links`); set any of them to `false` to disable that linter entirely.
 
+**Run everything in one call.** `lintTemplate(content, options?)` is the single aggregate entry point — it runs all three linters and returns the merged `LintIssue[]` (accessibility, then structure, then links). Reach for it by default; the per-linter functions stay exported for when you want to run just a subset. To skip a category, set its key to `false`: `lintTemplate(content, { structure: false })`. See [Headless usage](./headless-usage).
+
 ## Architecture
 
 <svg viewBox="0 0 640 280" fill="none" xmlns="http://www.w3.org/2000/svg" style="width:100%;max-width:640px;margin:1.5em auto;display:block;">
@@ -59,7 +61,7 @@ All three linters return the same `LintIssue` shape and share the same options s
   <text x="520" y="224" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#64748b" text-anchor="middle">stored templates</text>
 </svg>
 
-The package has no opinion on UI. The editor's `useTemplateLint` composable lazy-imports `@templatical/quality`, runs every exported linter on debounced content changes, and merges results into a single issues stream that drives the **Issues** sidebar tab and the per-block canvas badges. `applyFix(issue)` runs each patch through the editor's existing block-update path so fixes land as proper undo entries.
+The package has no opinion on UI. The editor's `useTemplateLint` composable lazy-imports `@templatical/quality`, runs all linters via the single `lintTemplate` call on debounced content changes, and feeds the merged issues stream into the **Issues** sidebar tab and the per-block canvas badges. `applyFix(issue)` runs each patch through the editor's existing block-update path so fixes land as proper undo entries.
 
 ## Install
 
@@ -125,7 +127,7 @@ init({ container: "#editor", lint: { links: false } });
 
 - [Options](./options) — `disabled`, `locale`, per-tool `accessibility` / `structure` / `links` namespaces.
 - [Severity & fixes](./severity-and-fixes) — severity model + how auto-fix patches land in the editor.
-- [Headless usage](./headless-usage) — validating stored templates in CI / server save handlers.
+- [Headless usage](./headless-usage) — `lintTemplate` + validating stored templates in CI / server save handlers.
 - [Contributing locales](./contributing-locales) — adding rule messages + vague-text dictionaries.
 - [Accessibility linter](./accessibility/) — what it catches, rule catalog.
 - [Structure linter](./structure/) — what it catches, rule catalog.

--- a/apps/docs/quality/options.md
+++ b/apps/docs/quality/options.md
@@ -1,6 +1,6 @@
 # Options
 
-`lintAccessibility`, `lintStructure`, and `lintLinks` accept the same `LintOptions` shape. Every field is optional.
+`lintTemplate`, `lintAccessibility`, `lintStructure`, and `lintLinks` all accept the same `LintOptions` shape. Every field is optional.
 
 ```ts
 interface LintOptions {
@@ -70,7 +70,7 @@ init({ locale: "de" });
 ::: warning Editor mode ignores `lint.locale`
 In editor mode the linter locale is **forced** to the editor's `locale` from `init({ locale })`. Setting `lint.locale` has no effect — it's overwritten on the way through.
 
-Headless callers (`lintAccessibility(...)` / `lintStructure(...)` / `lintLinks(...)` directly) keep full control.
+Headless callers (`lintTemplate(...)` or `lintAccessibility(...)` / `lintStructure(...)` / `lintLinks(...)` directly) keep full control.
 :::
 
 ::: tip Vague-text dictionaries are cross-locale

--- a/apps/docs/quality/severity-and-fixes.md
+++ b/apps/docs/quality/severity-and-fixes.md
@@ -1,6 +1,6 @@
 # Severity & fixes
 
-Every linter shares the same severity model and patch shape, so this page covers `lintAccessibility`, `lintStructure`, and `lintLinks` together.
+Every linter shares the same severity model and patch shape, so this page covers `lintTemplate`, `lintAccessibility`, `lintStructure`, and `lintLinks` together.
 
 ## Severity model
 
@@ -43,18 +43,9 @@ In the editor, `apply` runs through the existing `editor.updateBlock` / `editor.
 Headless callers can construct their own `LintPatchContext` and apply patches programmatically:
 
 ```ts
-import {
-  lintAccessibility,
-  lintLinks,
-  lintStructure,
-} from "@templatical/quality";
+import { lintTemplate } from "@templatical/quality";
 
-const issues = [
-  ...lintAccessibility(content),
-  ...lintStructure(content),
-  ...lintLinks(content),
-];
-const fixable = issues.filter((i) => i.fix);
+const fixable = lintTemplate(content).filter((i) => i.fix);
 
 for (const issue of fixable) {
   issue.fix!.apply({

--- a/apps/playground/scripts/lint-templates.ts
+++ b/apps/playground/scripts/lint-templates.ts
@@ -1,12 +1,16 @@
 /**
- * CI guard: run @templatical/quality against every showcase template.
+ * CI guard: run every @templatical/quality linter (accessibility, structure,
+ * and links) against every showcase template via the single `lintTemplate`
+ * entry point. New linter categories are covered automatically — `lintTemplate`
+ * fans out to all registered linters, so this guard never needs editing when
+ * one is added.
  *
  * Exits non-zero if any rule above `info` severity fires. Wired into
  * `pnpm --filter @templatical/playground run lint:templates`.
  *
  * Run locally with: `pnpm --filter @templatical/playground run lint:templates`
  */
-import { lintAccessibility } from "@templatical/quality";
+import { lintTemplate } from "@templatical/quality";
 import {
   createBlackFridayTemplate,
   createEventInvitationTemplate,
@@ -32,7 +36,7 @@ const SEVERITY_RANK: Record<string, number> = { error: 3, warning: 2, info: 1 };
 let failed = 0;
 
 for (const [name, build] of TEMPLATES) {
-  const issues = lintAccessibility(build()).filter(
+  const issues = lintTemplate(build()).filter(
     (i) => SEVERITY_RANK[i.severity] >= SEVERITY_RANK.warning,
   );
   if (issues.length === 0) {
@@ -51,9 +55,9 @@ for (const [name, build] of TEMPLATES) {
 
 if (failed > 0) {
   console.error(
-    `\n${failed} template(s) failed accessibility lint. Fix the issues above or adjust the severity in templates.ts.`,
+    `\n${failed} template(s) failed quality lint. Fix the issues above or adjust the severity in templates.ts.`,
   );
   process.exit(1);
 }
 
-console.log("\nAll templates passed accessibility lint.");
+console.log("\nAll templates passed quality lint.");

--- a/packages/editor/src/composables/useTemplateLint.ts
+++ b/packages/editor/src/composables/useTemplateLint.ts
@@ -9,9 +9,7 @@ import type {
 import type {
   LintIssue,
   LintOptions,
-  lintAccessibility as LintAccessibilityFn,
-  lintStructure as LintStructureFn,
-  lintLinks as LintLinksFn,
+  lintTemplate as LintTemplateFn,
 } from "@templatical/quality";
 
 export type { LintIssue, LintOptions } from "@templatical/quality";
@@ -52,9 +50,7 @@ export interface UseTemplateLintReturn {
 }
 
 interface Loaded {
-  lintAccessibility: typeof LintAccessibilityFn;
-  lintStructure: typeof LintStructureFn;
-  lintLinks: typeof LintLinksFn;
+  lintTemplate: typeof LintTemplateFn;
 }
 
 /**
@@ -93,9 +89,7 @@ export function useTemplateLint(
       // destroy() can no longer reach.
       if (destroyed) return;
       loaded.value = {
-        lintAccessibility: mod.lintAccessibility,
-        lintStructure: mod.lintStructure,
-        lintLinks: mod.lintLinks,
+        lintTemplate: mod.lintTemplate,
       };
       ready.value = true;
       runLint();
@@ -113,16 +107,7 @@ export function useTemplateLint(
 
   function runLint(): void {
     if (!loaded.value) return;
-    const a11y = loaded.value.lintAccessibility(
-      opts.content.value,
-      opts.options,
-    );
-    const structure = loaded.value.lintStructure(
-      opts.content.value,
-      opts.options,
-    );
-    const links = loaded.value.lintLinks(opts.content.value, opts.options);
-    issues.value = [...a11y, ...structure, ...links];
+    issues.value = loaded.value.lintTemplate(opts.content.value, opts.options);
   }
 
   // Re-run when severity overrides change at runtime (rare, but useful for

--- a/packages/editor/tests/useTemplateLint.test.ts
+++ b/packages/editor/tests/useTemplateLint.test.ts
@@ -11,23 +11,21 @@ function createContent(): TemplateContent {
 }
 
 interface QualityMockHandle {
-  lintAccessibility: ReturnType<typeof vi.fn>;
-  lintStructure: ReturnType<typeof vi.fn>;
-  lintLinks: ReturnType<typeof vi.fn>;
+  lintTemplate: ReturnType<typeof vi.fn>;
   resolveImport: () => void;
   rejectImport: (err: unknown) => void;
 }
 
 /**
  * Stage a per-test mock for `@templatical/quality` whose dynamic import can
- * be deferred. Returns the spies + resolver so the test can control timing.
+ * be deferred. The composable funnels every linter through the package's
+ * single `lintTemplate` entry point, so that's the only spy we need.
+ * Returns the spy + resolver so the test can control timing.
  */
 async function setupQualityMock(): Promise<QualityMockHandle> {
   vi.resetModules();
 
-  const lintAccessibility = vi.fn(() => [] as unknown[]);
-  const lintStructure = vi.fn(() => [] as unknown[]);
-  const lintLinks = vi.fn(() => [] as unknown[]);
+  const lintTemplate = vi.fn(() => [] as unknown[]);
   let resolve!: () => void;
   let reject!: (err: unknown) => void;
   const importPromise = new Promise<void>((res, rej) => {
@@ -37,13 +35,11 @@ async function setupQualityMock(): Promise<QualityMockHandle> {
 
   vi.doMock("@templatical/quality", async () => {
     await importPromise;
-    return { lintAccessibility, lintStructure, lintLinks };
+    return { lintTemplate };
   });
 
   return {
-    lintAccessibility,
-    lintStructure,
-    lintLinks,
+    lintTemplate,
     resolveImport: resolve,
     rejectImport: reject,
   };
@@ -77,15 +73,13 @@ describe("useTemplateLint", () => {
     result.destroy();
 
     // Now resolve the import — load() will run its post-await body. The fix
-    // must short-circuit so it neither calls lintFn nor installs a watcher.
+    // must short-circuit so it neither calls lintTemplate nor installs a watcher.
     mock.resolveImport();
     // Let microtasks settle.
     await new Promise((r) => setTimeout(r, 0));
     await nextTick();
 
-    expect(mock.lintAccessibility).not.toHaveBeenCalled();
-    expect(mock.lintStructure).not.toHaveBeenCalled();
-    expect(mock.lintLinks).not.toHaveBeenCalled();
+    expect(mock.lintTemplate).not.toHaveBeenCalled();
     expect(result.ready.value).toBe(false);
 
     // Mutate content. If a leaked watcher exists, it would fire runLint after
@@ -96,12 +90,10 @@ describe("useTemplateLint", () => {
     } as TemplateContent;
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(mock.lintAccessibility).not.toHaveBeenCalled();
-    expect(mock.lintStructure).not.toHaveBeenCalled();
-    expect(mock.lintLinks).not.toHaveBeenCalled();
+    expect(mock.lintTemplate).not.toHaveBeenCalled();
   });
 
-  it("runs every linter on content changes when alive", async () => {
+  it("runs lintTemplate on content changes when alive", async () => {
     const mock = await setupQualityMock();
     const useTemplateLint = await loadComposable();
 
@@ -121,9 +113,7 @@ describe("useTemplateLint", () => {
     await new Promise((r) => setTimeout(r, 0));
     await nextTick();
 
-    expect(mock.lintAccessibility).toHaveBeenCalledTimes(1);
-    expect(mock.lintStructure).toHaveBeenCalledTimes(1);
-    expect(mock.lintLinks).toHaveBeenCalledTimes(1);
+    expect(mock.lintTemplate).toHaveBeenCalledTimes(1);
 
     content.value = {
       blocks: [{ id: "b2", type: "paragraph" }],
@@ -131,20 +121,16 @@ describe("useTemplateLint", () => {
     } as TemplateContent;
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(mock.lintAccessibility).toHaveBeenCalledTimes(2);
-    expect(mock.lintStructure).toHaveBeenCalledTimes(2);
-    expect(mock.lintLinks).toHaveBeenCalledTimes(2);
+    expect(mock.lintTemplate).toHaveBeenCalledTimes(2);
   });
 
-  it("merges issues from every linter", async () => {
+  it("surfaces the merged issues lintTemplate returns", async () => {
     const mock = await setupQualityMock();
-    mock.lintAccessibility.mockReturnValue([
+    // lintTemplate already merges accessibility + structure + links inside the
+    // quality package; the composable just surfaces whatever it returns.
+    mock.lintTemplate.mockReturnValue([
       { ruleId: "a11y.x", blockId: "b1", severity: "error", message: "a" },
-    ]);
-    mock.lintStructure.mockReturnValue([
       { ruleId: "structure.x", blockId: "b1", severity: "error", message: "b" },
-    ]);
-    mock.lintLinks.mockReturnValue([
       { ruleId: "link.x", blockId: "b1", severity: "error", message: "c" },
     ]);
     const useTemplateLint = await loadComposable();
@@ -186,9 +172,7 @@ describe("useTemplateLint", () => {
     await new Promise((r) => setTimeout(r, 0));
     await nextTick();
 
-    expect(mock.lintAccessibility).not.toHaveBeenCalled();
-    expect(mock.lintStructure).not.toHaveBeenCalled();
-    expect(mock.lintLinks).not.toHaveBeenCalled();
+    expect(mock.lintTemplate).not.toHaveBeenCalled();
   });
 
   it("does not start lint when every per-tool key is false", async () => {
@@ -207,18 +191,17 @@ describe("useTemplateLint", () => {
     await new Promise((r) => setTimeout(r, 0));
     await nextTick();
 
-    expect(mock.lintAccessibility).not.toHaveBeenCalled();
-    expect(mock.lintStructure).not.toHaveBeenCalled();
-    expect(mock.lintLinks).not.toHaveBeenCalled();
+    expect(mock.lintTemplate).not.toHaveBeenCalled();
   });
 
   it("still starts lint when only some tools are disabled", async () => {
     const mock = await setupQualityMock();
     const useTemplateLint = await loadComposable();
 
+    const options = { accessibility: false, structure: false } as const;
     useTemplateLint({
       content: ref(createContent()),
-      options: { accessibility: false, structure: false },
+      options,
       updateBlock: vi.fn(),
       updateSettings: vi.fn(),
       removeBlock: vi.fn(),
@@ -229,12 +212,14 @@ describe("useTemplateLint", () => {
     await new Promise((r) => setTimeout(r, 0));
     await nextTick();
 
-    // The composable calls every linter; the per-tool false is enforced
-    // inside the linter function itself (returns []) — but the composable
-    // does not short-circuit while at least one tool is still active.
-    expect(mock.lintAccessibility).toHaveBeenCalledTimes(1);
-    expect(mock.lintStructure).toHaveBeenCalledTimes(1);
-    expect(mock.lintLinks).toHaveBeenCalledTimes(1);
+    // The composable still calls lintTemplate while at least one tool is
+    // active; the per-tool false is enforced inside the linter functions
+    // (each returns []). Options pass through unchanged.
+    expect(mock.lintTemplate).toHaveBeenCalledTimes(1);
+    expect(mock.lintTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ blocks: expect.any(Array) }),
+      options,
+    );
   });
 });
 

--- a/packages/quality/src/index.ts
+++ b/packages/quality/src/index.ts
@@ -1,3 +1,4 @@
+export { lintTemplate } from "./lint-template";
 export { lintAccessibility, ACCESSIBILITY_RULES } from "./accessibility";
 export { lintStructure, STRUCTURE_RULES } from "./structure";
 export { lintLinks, LINK_RULES } from "./links";

--- a/packages/quality/src/lint-template.ts
+++ b/packages/quality/src/lint-template.ts
@@ -1,0 +1,34 @@
+import type { TemplateContent } from "@templatical/types";
+import type { LintIssue, LintOptions } from "./types";
+import { lintAccessibility } from "./accessibility";
+import { lintStructure } from "./structure";
+import { lintLinks } from "./links";
+import { isLintFullyDisabled } from "./util";
+
+/**
+ * Run every linter in the package — accessibility, structure, and links —
+ * against `content` and return the merged issue list.
+ *
+ * This is the single entry point callers should prefer. CI guards, the
+ * editor's live linter, and headless consumers all funnel through here, so
+ * a new linter category is picked up everywhere by registering it in this
+ * one fan-out — no consumer has to learn about the new function.
+ *
+ * Per-category options (`options.accessibility`, `options.structure`,
+ * `options.links`) and the global `options.disabled` flag are forwarded
+ * unchanged; each sub-linter already short-circuits when its category is
+ * `false`, so the per-tool calls below are cheap no-ops when disabled.
+ *
+ * Issue order is stable: accessibility first, then structure, then links.
+ */
+export function lintTemplate(
+  content: TemplateContent,
+  options: LintOptions = {},
+): LintIssue[] {
+  if (isLintFullyDisabled(options)) return [];
+  return [
+    ...lintAccessibility(content, options),
+    ...lintStructure(content, options),
+    ...lintLinks(content, options),
+  ];
+}

--- a/packages/quality/tests/lint-template.test.ts
+++ b/packages/quality/tests/lint-template.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDefaultTemplateContent,
+  createImageBlock,
+  createParagraphBlock,
+  createSectionBlock,
+  type TemplateContent,
+} from "@templatical/types";
+import {
+  lintAccessibility,
+  lintLinks,
+  lintStructure,
+  lintTemplate,
+} from "../src";
+
+/**
+ * A template that trips at least one rule from each linter:
+ *  - accessibility: image with empty alt   → a11y.img-missing-alt
+ *  - links:         javascript: anchor      → link.javascript-protocol
+ *  - structure:     section w/ empty column → structure.*
+ */
+function buildMultiIssueTemplate(): TemplateContent {
+  const content = createDefaultTemplateContent();
+  content.blocks = [
+    createImageBlock({ src: "https://example.com/x.png", alt: "" }),
+    createParagraphBlock({
+      content: '<p><a href="javascript:alert(1)">go</a></p>',
+    }),
+    createSectionBlock(),
+  ];
+  return content;
+}
+
+const namespaces = (issues: { ruleId: string }[]) =>
+  new Set(issues.map((i) => i.ruleId.split(".")[0]));
+
+// `fix` carries a freshly-built closure per linter call, so identity-compare
+// the serializable surface instead of the raw issue objects.
+const fingerprint = (issues: { ruleId: string; blockId: string | null }[]) =>
+  issues.map((i) => `${i.ruleId}@${i.blockId ?? "template"}`);
+
+describe("lintTemplate", () => {
+  it("returns the concatenation of every linter, a11y then structure then links", () => {
+    const content = buildMultiIssueTemplate();
+
+    const expected = [
+      ...lintAccessibility(content),
+      ...lintStructure(content),
+      ...lintLinks(content),
+    ];
+
+    expect(fingerprint(lintTemplate(content))).toEqual(fingerprint(expected));
+  });
+
+  it("surfaces issues from all three linter categories at once", () => {
+    const issues = lintTemplate(buildMultiIssueTemplate());
+
+    expect(namespaces(issues)).toEqual(new Set(["a11y", "structure", "link"]));
+    expect(issues.some((i) => i.ruleId === "a11y.img-missing-alt")).toBe(true);
+    expect(issues.some((i) => i.ruleId === "link.javascript-protocol")).toBe(
+      true,
+    );
+  });
+
+  it("returns [] when options.disabled is true", () => {
+    expect(lintTemplate(buildMultiIssueTemplate(), { disabled: true })).toEqual(
+      [],
+    );
+  });
+
+  it("returns [] when every per-category key is false", () => {
+    const issues = lintTemplate(buildMultiIssueTemplate(), {
+      accessibility: false,
+      structure: false,
+      links: false,
+    });
+    expect(issues).toEqual([]);
+  });
+
+  it("skips only the category turned off, keeping the rest", () => {
+    const issues = lintTemplate(buildMultiIssueTemplate(), {
+      structure: false,
+    });
+
+    expect(namespaces(issues)).toEqual(new Set(["a11y", "link"]));
+    expect(issues.some((i) => i.ruleId.startsWith("structure."))).toBe(false);
+  });
+
+  it("forwards per-category options to the underlying linter", () => {
+    const content = buildMultiIssueTemplate();
+
+    // A severity override on an accessibility rule must reach lintAccessibility.
+    const issues = lintTemplate(content, {
+      accessibility: { rules: { "a11y.img-missing-alt": "off" } },
+    });
+
+    expect(issues.some((i) => i.ruleId === "a11y.img-missing-alt")).toBe(false);
+    // Other categories are untouched.
+    expect(issues.some((i) => i.ruleId === "link.javascript-protocol")).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Add a single `lintTemplate(content, options?)` entry point that runs every linter — accessibility, structure, and links — and returns the merged issue list. Prefer it over calling `lintAccessibility` / `lintStructure` / `lintLinks` individually: new linter categories are picked up automatically by every consumer that funnels through it.

The editor's live linter (`useTemplateLint`) now calls `lintTemplate` internally; behavior is unchanged. The individual linter exports remain available.