### PR TITLE
feat: add support for custom block stylesheets in editor and renderer

### DIFF
--- a/.changeset/custom-block-stylesheet.md
+++ b/.changeset/custom-block-stylesheet.md
@@ -1,0 +1,22 @@
+---
+"@templatical/types": minor
+"@templatical/renderer": minor
+"@templatical/editor": minor
+---
+
+Add `CustomBlockDefinition.stylesheet` — definition-level CSS that emits once into `<mj-head><mj-style>` in the rendered MJML and is mirrored in the editor canvas.
+
+Custom blocks render as raw HTML inside an `mj-text` cell, which means MJML's automatic responsive behavior (column stacking, fluid images) only applies to the *outer* layout — not to the internals of a custom block. Previously a developer had no clean place to put per-definition media queries, hover states, or block-specific font declarations; ad-hoc `<style>` blocks inside the `template` ended up in the email body rather than `<mj-head>`, with no dedupe across instances.
+
+The new `stylesheet?: string` field on `CustomBlockDefinition` solves this:
+
+- The renderer collects every definition's `stylesheet` from the content tree, dedupes by `customType` *and* by trimmed content, and emits each unique stylesheet once as an additional `<mj-style>` block alongside the built-in visibility media queries.
+- The editor canvas mirrors the same CSS via a reactive `<style>` element rendered inside the editor root — in shadow-DOM mode it scopes to the shadow root; in light-DOM mode it shares the global stylesheet surface already established by `dist/style.css`.
+- The renderer adds an optional `getCustomBlockStylesheet?: (customType: string) => string | undefined | null` resolver to `RenderOptions`. The editor wires this from its block registry automatically; headless callers provide their own resolver from whatever definitions map they manage.
+- `TemplaticalEditor` (the OSS init return) gains `getCustomBlockStylesheet(customType)` for parity with `renderCustomBlock`.
+
+Class names in `stylesheet` are **not** scoped by the SDK — namespace them per definition (e.g. `.tplc-<type>-<element>`) to avoid collisions. Email-client caveats apply (Outlook desktop ignores `@media` queries, matching every other media-query-based feature in the SDK such as block visibility).
+
+Fully backward compatible: existing definitions and renderer callers that omit the new field/option produce the same MJML and editor behavior as before.
+
+Addresses #155 (raised as the follow-up to #146).

--- a/apps/docs/api/types.md
+++ b/apps/docs/api/types.md
@@ -365,8 +365,10 @@ interface CustomBlockDefinition {
   icon?: string;
   description?: string;
   fields: CustomBlockField[];
-  template: string;           // Liquid template
+  template: string;                       // Liquid template
   dataSource?: DataSourceConfig;
+  defaultStyles?: Partial<BlockStyles>;   // styles applied to new instances
+  stylesheet?: string;                    // CSS emitted once into mj-head
 }
 ```
 

--- a/apps/docs/de/api/types.md
+++ b/apps/docs/de/api/types.md
@@ -365,8 +365,10 @@ interface CustomBlockDefinition {
   icon?: string;
   description?: string;
   fields: CustomBlockField[];
-  template: string;           // Liquid-Template
+  template: string;                       // Liquid-Template
   dataSource?: DataSourceConfig;
+  defaultStyles?: Partial<BlockStyles>;   // Stile für neue Instanzen
+  stylesheet?: string;                    // CSS, einmal in mj-head emittiert
 }
 ```
 

--- a/apps/docs/de/guide/custom-blocks.md
+++ b/apps/docs/de/guide/custom-blocks.md
@@ -97,6 +97,7 @@ interface CustomBlockDefinition {
   template: string;
   dataSource?: DataSourceConfig;
   defaultStyles?: Partial<BlockStyles>;
+  stylesheet?: string;
 }
 ```
 
@@ -110,6 +111,7 @@ interface CustomBlockDefinition {
 | `template` | Ja | Liquid-Template-String für das Rendering |
 | `dataSource` | Nein | Konfiguration für das Abrufen externer Daten |
 | `defaultStyles` | Nein | Standard-Blockstile (padding, backgroundColor) — siehe [Standardstile](#standardstile) |
+| `stylesheet` | Nein | CSS auf Definitionsebene, das einmalig in den `<mj-head>` des gerenderten MJML eingefügt und im Editor-Canvas gespiegelt wird — siehe [Stylesheets](#stylesheets) |
 
 ## Feldtypen
 
@@ -274,6 +276,59 @@ Dies ist der empfohlene Weg, um benutzerdefinierte Blöcke vom Standard-Wrapper-
 
 ::: warning Bestehende Blöcke übernehmen Änderungen an `defaultStyles` nicht rückwirkend
 `defaultStyles` wird einmalig angewendet, wenn eine neue Block-Instanz aus der Palette erstellt wird. Blöcke, die bereits auf der Arbeitsfläche liegen — oder in gespeicherten Templates stecken — behalten die Stile, mit denen sie erstellt wurden. Damit eine Änderung an `defaultStyles` an einem bestehenden Block sichtbar wird, muss er gelöscht und neu aus der Palette gezogen werden. Das ist Absicht: So werden per-Instanz-Anpassungen durch Endnutzer:innen nicht stillschweigend überschrieben, wenn ein:e Entwickler:in die Definition ändert.
+:::
+
+## Stylesheets
+
+Der Renderer hüllt die Ausgabe deines `template` in eine `mj-text`-Zelle. Das bedeutet: MJMLs automatische responsive Behandlung — Spaltenstapelung, fluide Bilder, mobile-first Padding — greift auf das *äußere* Layout, aber **nicht innerhalb** des HTMLs deines Custom Blocks. Ein zweispaltiger Custom Block mit `<table>`-Layout muss z. B. selbst per Media Query für das mobile Stapeln sorgen.
+
+Verwende `stylesheet` auf der Definition für CSS, das auf alle Instanzen des Blocks angewendet werden soll: Media Queries, Hover-Zustände, blockspezifische Font-Deklarationen, Anchor-Farb-Überschreibungen. Der Renderer sammelt jedes `stylesheet` aus dem Inhaltsbaum, dedupliziert (pro `customType` und nochmals pro getrimmtem Inhalt) und gibt jedes eindeutige Stylesheet **einmal** als `<mj-style>` innerhalb von `<mj-head>` aus — unabhängig davon, wie viele Instanzen das Template enthält. Das Editor-Canvas spiegelt dasselbe CSS, sodass das authoring responsive Verhalten live in der Vorschau erscheint.
+
+```ts
+{
+  type: 'image-text',
+  name: 'Bild + Text',
+  fields: [
+    { key: 'image', type: 'image', label: 'Bild' },
+    { key: 'heading', type: 'text', label: 'Überschrift' },
+    { key: 'body', type: 'textarea', label: 'Text' },
+  ],
+  template: `
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+      <tr>
+        <td class="tplc-image-text-cell tplc-image-text-cell--media" style="width: 40%; vertical-align: top;">
+          <img src="{{ image }}" width="200" style="display: block; max-width: 100%;" />
+        </td>
+        <td class="tplc-image-text-cell tplc-image-text-cell--body" style="width: 60%; padding-left: 20px; vertical-align: top;">
+          <h3 style="margin: 0 0 8px;">{{ heading }}</h3>
+          <p style="margin: 0;">{{ body }}</p>
+        </td>
+      </tr>
+    </table>
+  `,
+  stylesheet: `
+    @media (max-width: 480px) {
+      .tplc-image-text-cell {
+        display: block !important;
+        width: 100% !important;
+        padding-left: 0 !important;
+      }
+      .tplc-image-text-cell--body {
+        padding-top: 16px !important;
+      }
+    }
+  `,
+}
+```
+
+::: tip Klassennamen mit Namespace versehen
+Das SDK scoped `stylesheet`-Selektoren nicht automatisch. Zwei Definitionen, die denselben Klassennamen verwenden, kollidieren im ausgegebenen `<mj-head>`. Versieh deine Klassen pro Definition mit einem Präfix — die Konvention `tplc-<type>-<element>` (`tplc-image-text-cell`, `tplc-product-card-button`, …) hält das CSS jeder Definition ohne Laufzeitkosten isoliert.
+:::
+
+::: warning E-Mail-Client-Einschränkungen gelten
+Wie bei jedem CSS in einer E-Mail unterliegen auch deine `stylesheet`-Regeln dem Support des jeweiligen Clients. Insbesondere **ignoriert Outlook unter Windows (2007–2021, Word-Rendering-Engine) `@media`-Queries vollständig** — dein Block behält dort sein Desktop-Layout. Das ist der erwartete Fallback: Outlook Desktop ist ein Desktop-Client, daher ist das Beibehalten der Desktop-Darstellung in der Regel das richtige Ergebnis. Mobile Clients (iOS Mail, Apple Mail, Gmail, Outlook Mobile) unterstützen Media Queries und wenden deine responsiven Regeln normal an.
+
+Setze auf breit unterstütztes CSS: `display`, `width`, `padding`, `background-color`, `border`, einfache Media Queries auf `max-width`. Vermeide `flex`, `grid`, `position`, CSS-Animationen und ähnliche fortgeschrittene Features in E-Mail-Kontexten.
 :::
 
 ## Liquid-Templates

--- a/apps/docs/guide/custom-blocks.md
+++ b/apps/docs/guide/custom-blocks.md
@@ -97,6 +97,7 @@ interface CustomBlockDefinition {
   template: string;
   dataSource?: DataSourceConfig;
   defaultStyles?: Partial<BlockStyles>;
+  stylesheet?: string;
 }
 ```
 
@@ -109,7 +110,8 @@ interface CustomBlockDefinition {
 | `fields` | Yes | Array of field definitions |
 | `template` | Yes | Liquid template string for rendering |
 | `dataSource` | No | External data fetching configuration |
-| `defaultStyles` | No | Default block styles (padding, margin, backgroundColor) — see [Default styles](#default-styles) |
+| `defaultStyles` | No | Default block styles (padding, backgroundColor) — see [Default styles](#default-styles) |
+| `stylesheet` | No | Definition-level CSS emitted once into the rendered MJML's `<mj-head>` and mirrored in the editor canvas — see [Stylesheets](#stylesheets) |
 
 ## Field types
 
@@ -274,6 +276,59 @@ This is the recommended way to opt custom blocks out of the SDK's default wrappe
 
 ::: warning Existing blocks don't retroactively pick up `defaultStyles` changes
 `defaultStyles` is applied once, when a new block instance is created from the palette. Blocks already on the canvas — or in saved templates — keep the styles they were created with. To see a `defaultStyles` change reflected on an existing block, delete it and drag a fresh instance. This is intentional: it prevents per-instance spacing tweaks made by end-users from being silently overwritten when a developer edits the definition.
+:::
+
+## Stylesheets
+
+The renderer wraps your `template` output in an `mj-text` cell, which means MJML's automatic responsive behavior — column stacking, fluid images, mobile-first padding — applies to the *outer* layout but **does not reach inside** your custom block's HTML. A two-column custom block with a `<table>` layout, for example, needs to opt into its own mobile stacking via a media query.
+
+Use `stylesheet` on the definition for CSS that should apply to all instances of the block: media queries, hover states, custom-block-specific font declarations, anchor color overrides. The renderer collects every definition's `stylesheet` from the content tree, dedupes (per `customType` and again per trimmed content), and emits each unique stylesheet **once** as `<mj-style>` inside `<mj-head>` — regardless of how many instances of the block the template contains. The editor canvas mirrors the same CSS so authored responsive behavior previews live.
+
+```ts
+{
+  type: 'image-text',
+  name: 'Image + Text',
+  fields: [
+    { key: 'image', type: 'image', label: 'Image' },
+    { key: 'heading', type: 'text', label: 'Heading' },
+    { key: 'body', type: 'textarea', label: 'Body' },
+  ],
+  template: `
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+      <tr>
+        <td class="tplc-image-text-cell tplc-image-text-cell--media" style="width: 40%; vertical-align: top;">
+          <img src="{{ image }}" width="200" style="display: block; max-width: 100%;" />
+        </td>
+        <td class="tplc-image-text-cell tplc-image-text-cell--body" style="width: 60%; padding-left: 20px; vertical-align: top;">
+          <h3 style="margin: 0 0 8px;">{{ heading }}</h3>
+          <p style="margin: 0;">{{ body }}</p>
+        </td>
+      </tr>
+    </table>
+  `,
+  stylesheet: `
+    @media (max-width: 480px) {
+      .tplc-image-text-cell {
+        display: block !important;
+        width: 100% !important;
+        padding-left: 0 !important;
+      }
+      .tplc-image-text-cell--body {
+        padding-top: 16px !important;
+      }
+    }
+  `,
+}
+```
+
+::: tip Namespace your class names
+The SDK does not scope `stylesheet` selectors automatically. Two definitions that use the same class name will collide in the emitted `<mj-head>`. Prefix your classes per definition — the `tplc-<type>-<element>` convention (`tplc-image-text-cell`, `tplc-product-card-button`, …) keeps each definition's CSS isolated without runtime work.
+:::
+
+::: warning Email client caveats apply
+Like all CSS in an email, your `stylesheet` rules are subject to per-client support. Notably, **Outlook on Windows (2007–2021, Word rendering engine) ignores `@media` queries entirely** — your block keeps its desktop layout there. That's the expected fallback: Outlook desktop is a desktop client, so retaining the desktop styling is usually the right outcome. Mobile clients (iOS Mail, Apple Mail, Gmail, Outlook mobile) support media queries and apply your responsive rules normally.
+
+Stick to widely-supported CSS for the best results: `display`, `width`, `padding`, `background-color`, `border`, simple media queries on `max-width`. Avoid `flex`, `grid`, `position`, CSS animations, and similar advanced features in email contexts.
 :::
 
 ## Liquid templates

--- a/apps/playground/e2e/tests/custom-block-stylesheet.spec.ts
+++ b/apps/playground/e2e/tests/custom-block-stylesheet.spec.ts
@@ -75,10 +75,49 @@ async function readComputedStyle(
 test.describe("Custom block stylesheet (#155)", () => {
   test.beforeEach(async ({ page }) => {
     // Suppress overlays so the editor reaches a stable state and the canvas
-    // is laid out before we sample computed styles.
+    // is laid out before we sample computed styles. Also hook
+    // `navigator.clipboard.writeText` to capture the playground's copy-button
+    // payload into a window variable — reading the OS clipboard directly
+    // via `navigator.clipboard.readText()` is unreliable in headless
+    // Chromium on Linux CI (no X11, plus the focus requirement is racy
+    // under parallel workers). The playground's copy is driven by
+    // VueUse's `useClipboard` which calls `writeText`; intercepting it
+    // here gives us the exact string the user would have copied without
+    // any OS-clipboard involvement.
     await page.addInitScript(() => {
       localStorage.setItem("tpl-playground-onboarding-dismissed", "true");
       localStorage.setItem("tpl-playground-features-dismissed", "true");
+
+      // VueUse's `useClipboard` checks `clipboard-write` permission first.
+      // In headless Chromium without `grantPermissions`, that permission is
+      // denied → useClipboard falls back to its `legacyCopy` path:
+      // creates a hidden `<textarea>`, selects its value, calls
+      // `document.execCommand("copy")`. Hooking `execCommand("copy")` is
+      // the most reliable interception point — works regardless of
+      // permission state, no OS-clipboard involvement, no permission
+      // ceremony in the test. At execCommand-call time the textarea's
+      // value is in `getSelection().toString()`.
+      (window as { __capturedClipboardWrite?: string }).__capturedClipboardWrite =
+        "";
+      const originalExec = document.execCommand.bind(document);
+      document.execCommand = function (
+        command: string,
+        ...rest: unknown[]
+      ): boolean {
+        if (command === "copy") {
+          const selected = document.getSelection()?.toString() ?? "";
+          if (selected) {
+            (
+              window as { __capturedClipboardWrite?: string }
+            ).__capturedClipboardWrite = selected;
+          }
+        }
+        // The Function.prototype.apply signature accepts the rest as an
+        // array — execCommand's optional args (showUI, value) pass through.
+        return (
+          originalExec as (cmd: string, ...args: unknown[]) => boolean
+        )(command, ...rest);
+      };
     });
   });
 
@@ -246,25 +285,35 @@ test.describe("Custom block stylesheet (#155)", () => {
     editorPage,
     page,
   }) => {
-    // Read the full MJML by going through the playground's user-facing
-    // copy button — testing the export pipeline end-to-end (editor.toMjml()
-    // → playground state → CodeMirror render → copy-to-clipboard) rather
-    // than poking at internal CodeMirror APIs. Granting clipboard-read at
-    // the context level lets `navigator.clipboard.readText()` resolve.
-    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
-
+    // Drive the export through the playground's `__tplPlaygroundGetMjml`
+    // test affordance (installed by `apps/playground/src/App.vue` after
+    // editor init). That calls `editor.toMjml()` directly — same code
+    // path the export modal uses — without depending on copy-to-clipboard,
+    // CodeMirror virtualization, or DOM inspection of the rendered MJML.
+    // Deterministic in headless Chromium CI where clipboard APIs are
+    // unreliable.
     await chooserPage.goto();
     await chooserPage.selectTemplateByName("Product Launch");
     await editorPage.waitForReady();
     await editorPage.dismissOverlays();
 
-    await editorPage.openExport();
-    const modal = page.locator(SELECTORS.exportModal);
-    await expect(modal).toBeVisible();
-    // Default tab is MJML per `playground-modals.spec.ts`.
-    await page.locator(SELECTORS.exportCopyBtn).click();
+    // Wait for the hook to be installed (editor init is async).
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            typeof (
+              window as { __tplPlaygroundGetMjml?: () => Promise<string> }
+            ).__tplPlaygroundGetMjml === "function",
+        ),
+      )
+      .toBe(true);
 
-    const mjml = await page.evaluate(() => navigator.clipboard.readText());
+    const mjml = await page.evaluate(async () =>
+      (
+        window as { __tplPlaygroundGetMjml?: () => Promise<string> }
+      ).__tplPlaygroundGetMjml!(),
+    );
     expect(mjml.length).toBeGreaterThan(100);
 
     // 1. The MJML output exists and is well-formed (sanity).

--- a/apps/playground/e2e/tests/custom-block-stylesheet.spec.ts
+++ b/apps/playground/e2e/tests/custom-block-stylesheet.spec.ts
@@ -1,0 +1,332 @@
+import { test, expect } from "../fixtures/editor.fixture";
+import { SELECTORS } from "../helpers/selectors";
+
+/**
+ * Browser-level coverage for `CustomBlockDefinition.stylesheet` (#155).
+ *
+ * Unit tests (renderer + editor composable + mount) prove the data path and
+ * DOM presence in happy-dom. This file proves what happy-dom cannot: rules
+ * actually apply in a real browser's CSS engine — shadow-root scoping,
+ * computed-style cascade through inline + class rules, pseudo-class matching
+ * (`:hover`), media-query firing on a real viewport, reactive cleanup when
+ * the last instance of a custom-block type is removed, and the full export
+ * path producing `<mj-style>` blocks in the rendered MJML.
+ *
+ * Fixture: the playground's `testimonialBlock` is a real responsive-layout
+ * demo (table-based avatar | byline that stacks to single-column at ≤480px
+ * via the new `stylesheet` field). The "Product Launch" template uses it and
+ * promotes it in the "What's in this template" features modal, so loading
+ * that template puts an instance on the canvas without any drag setup.
+ */
+
+/**
+ * Read the textContent of every `<style data-tpl-custom-block-stylesheet>`
+ * element found inside the editor root. The root auto-resolves to the
+ * shadow root when one exists, the document otherwise — same surface either
+ * way, so callers don't branch on mode.
+ */
+async function readStylesheetTextContents(
+  page: import("@playwright/test").Page,
+): Promise<string[]> {
+  return page.evaluate(() => {
+    const container = document.querySelector(
+      '[data-testid="editor-container"]',
+    );
+    const root: Document | ShadowRoot =
+      (container?.shadowRoot as ShadowRoot | null) ?? document;
+    const elements = Array.from(
+      root.querySelectorAll<HTMLStyleElement>(
+        "style[data-tpl-custom-block-stylesheet]",
+      ),
+    );
+    return elements.map((el) => el.textContent ?? "");
+  });
+}
+
+/**
+ * Read computed style for an element matched by `selector` inside the editor
+ * root. Returns `null` when the element is absent.
+ */
+async function readComputedStyle(
+  page: import("@playwright/test").Page,
+  selector: string,
+  props: readonly string[],
+): Promise<Record<string, string> | null> {
+  return page.evaluate(
+    ({ selector, props }) => {
+      const container = document.querySelector(
+        '[data-testid="editor-container"]',
+      );
+      const root: Document | ShadowRoot =
+        (container?.shadowRoot as ShadowRoot | null) ?? document;
+      const el = root.querySelector<HTMLElement>(selector);
+      if (!el) return null;
+      const cs = getComputedStyle(el);
+      const out: Record<string, string> = {};
+      for (const p of props) {
+        out[p] = cs.getPropertyValue(p) || (cs as never)[p as never] || "";
+      }
+      return out;
+    },
+    { selector, props: [...props] },
+  );
+}
+
+test.describe("Custom block stylesheet (#155)", () => {
+  test.beforeEach(async ({ page }) => {
+    // Suppress overlays so the editor reaches a stable state and the canvas
+    // is laid out before we sample computed styles.
+    await page.addInitScript(() => {
+      localStorage.setItem("tpl-playground-onboarding-dismissed", "true");
+      localStorage.setItem("tpl-playground-features-dismissed", "true");
+    });
+  });
+
+  test("emits a <style data-tpl-custom-block-stylesheet> with the definition's CSS in the editor root", async ({
+    chooserPage,
+    editorPage,
+    page,
+  }) => {
+    await chooserPage.goto();
+    await chooserPage.selectTemplateByName("Product Launch");
+    await editorPage.waitForReady();
+    await editorPage.dismissOverlays();
+
+    // Wait until the composable has emitted the stylesheet — `waitForReady`
+    // only guarantees the canvas DOM shell, not that the content has been
+    // processed.
+    await expect
+      .poll(() => readStylesheetTextContents(page).then((s) => s.length))
+      .toBe(1);
+
+    const [cssText] = await readStylesheetTextContents(page);
+    expect(cssText).toContain(".tplc-testimonial-card");
+    expect(cssText).toContain("box-shadow: rgba(0, 0, 0, 0.08)");
+    expect(cssText).toContain(".tplc-testimonial-avatar");
+    expect(cssText).toContain(".tplc-testimonial-byline");
+    expect(cssText).toContain("@media (max-width: 480px)");
+  });
+
+  test("base rule is applied by the browser's CSS engine (transition on .tplc-testimonial-card)", async ({
+    chooserPage,
+    editorPage,
+    page,
+  }) => {
+    await chooserPage.goto();
+    await chooserPage.selectTemplateByName("Product Launch");
+    await editorPage.waitForReady();
+    await editorPage.dismissOverlays();
+
+    // `transition-property: box-shadow` is declared in the stylesheet and
+    // NOT set inline in the template — a matching computed value cleanly
+    // proves the stylesheet was parsed AND the selector matched (not just
+    // that the `<style>` tag is in the DOM).
+    await expect
+      .poll(() =>
+        readComputedStyle(page, ".tplc-testimonial-card", [
+          "transition-property",
+        ]),
+      )
+      .toEqual({ "transition-property": "box-shadow" });
+  });
+
+  test(":hover applies the stylesheet's box-shadow", async ({
+    chooserPage,
+    editorPage,
+    page,
+  }) => {
+    await chooserPage.goto();
+    await chooserPage.selectTemplateByName("Product Launch");
+    await editorPage.waitForReady();
+    await editorPage.dismissOverlays();
+
+    const card = page.locator(".tplc-testimonial-card").first();
+    await card.waitFor();
+    await card.scrollIntoViewIfNeeded();
+
+    // Playwright leaves the mouse wherever the previous click landed. After
+    // dismissing overlays + clicking template cards, the cursor often ends
+    // up over the canvas — sometimes directly on the custom block — so
+    // "rest" already matches `:hover`. Move the cursor far from the canvas
+    // with intermediate interpolation steps so the browser's hit-test path
+    // crosses the card's edge and fires `mouseleave` reliably; a single
+    // direct move to (0, 0) sometimes doesn't propagate under parallel
+    // worker load (the issue we saw flake only in the full-suite run).
+    await page.mouse.move(2000, 2000, { steps: 5 });
+
+    // At rest, no box-shadow.
+    await expect
+      .poll(() =>
+        readComputedStyle(page, ".tplc-testimonial-card", ["box-shadow"]).then(
+          (v) => v?.["box-shadow"] ?? "",
+        ),
+      )
+      .toBe("none");
+
+    await card.hover();
+
+    // After hover, the stylesheet's box-shadow declaration kicks in. The
+    // 200ms transition is handled by `expect.poll`'s retry loop — no
+    // `waitForTimeout` needed.
+    await expect
+      .poll(
+        () =>
+          readComputedStyle(page, ".tplc-testimonial-card", [
+            "box-shadow",
+          ]).then((v) => v?.["box-shadow"] ?? ""),
+        { timeout: 2000 },
+      )
+      .toContain("rgba(0, 0, 0, 0.08)");
+  });
+
+  test("layout stacks on mobile viewport (@media (max-width: 480px) fires)", async ({
+    chooserPage,
+    editorPage,
+    page,
+  }) => {
+    // Narrow the browser viewport BEFORE the editor mounts so the media
+    // query is evaluated as "mobile" from the start — avoids racing the
+    // canvas's own layout transitions and the CSSOM media-query rematch.
+    // The playground header/chooser may overflow at this width; that's
+    // fine — we only care about the testimonial's computed style.
+    await page.setViewportSize({ width: 400, height: 800 });
+
+    await chooserPage.goto();
+    await chooserPage.selectTemplateByName("Product Launch");
+    await editorPage.waitForReady();
+    await editorPage.dismissOverlays();
+
+    // Both author-row TDs default to `display: table-cell`. The mobile
+    // override switches them to `display: block` with full width — the
+    // visible result is "avatar above byline, both full-width, centered".
+    await expect
+      .poll(() =>
+        readComputedStyle(page, ".tplc-testimonial-avatar", [
+          "display",
+          "text-align",
+        ]),
+      )
+      .toEqual({ display: "block", "text-align": "center" });
+
+    await expect
+      .poll(() =>
+        readComputedStyle(page, ".tplc-testimonial-byline", [
+          "display",
+          "text-align",
+        ]),
+      )
+      .toEqual({ display: "block", "text-align": "center" });
+  });
+
+  test("desktop viewport keeps the 2-column layout (no @media match)", async ({
+    chooserPage,
+    editorPage,
+    page,
+  }) => {
+    await chooserPage.goto();
+    await chooserPage.selectTemplateByName("Product Launch");
+    await editorPage.waitForReady();
+    await editorPage.dismissOverlays();
+
+    // Negative case for the mobile test above: at the default (desktop)
+    // viewport, the stylesheet's mobile rule must NOT fire. `display`
+    // stays at the table-cell default — proves the @media gate works
+    // correctly, not just that the rule exists.
+    await expect
+      .poll(() =>
+        readComputedStyle(page, ".tplc-testimonial-byline", ["display"]).then(
+          (v) => v?.["display"] ?? "",
+        ),
+      )
+      .toBe("table-cell");
+  });
+
+  test("editor.toMjml() output contains the stylesheet inside <mj-head><mj-style>", async ({
+    chooserPage,
+    editorPage,
+    page,
+  }) => {
+    // Read the full MJML by going through the playground's user-facing
+    // copy button — testing the export pipeline end-to-end (editor.toMjml()
+    // → playground state → CodeMirror render → copy-to-clipboard) rather
+    // than poking at internal CodeMirror APIs. Granting clipboard-read at
+    // the context level lets `navigator.clipboard.readText()` resolve.
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await chooserPage.goto();
+    await chooserPage.selectTemplateByName("Product Launch");
+    await editorPage.waitForReady();
+    await editorPage.dismissOverlays();
+
+    await editorPage.openExport();
+    const modal = page.locator(SELECTORS.exportModal);
+    await expect(modal).toBeVisible();
+    // Default tab is MJML per `playground-modals.spec.ts`.
+    await page.locator(SELECTORS.exportCopyBtn).click();
+
+    const mjml = await page.evaluate(() => navigator.clipboard.readText());
+    expect(mjml.length).toBeGreaterThan(100);
+
+    // 1. The MJML output exists and is well-formed (sanity).
+    expect(mjml).toContain("<mjml");
+    expect(mjml).toContain("<mj-head>");
+    expect(mjml).toContain("</mj-head>");
+
+    // 2. The testimonial's CSS rules from `stylesheet` are emitted —
+    //    proves the renderer's `getCustomBlockStylesheet` resolver was
+    //    wired through from the editor's block registry.
+    expect(mjml).toContain(".tplc-testimonial-card");
+    expect(mjml).toContain(".tplc-testimonial-avatar");
+    expect(mjml).toContain(".tplc-testimonial-byline");
+    expect(mjml).toContain("@media (max-width: 480px)");
+
+    // 3. The CSS sits inside a `<mj-style>` block, and that block sits
+    //    inside `<mj-head>` — not bare in head, not in body. The regex
+    //    bounds both wraps so a future refactor that drops either fails
+    //    this test.
+    expect(mjml).toMatch(
+      /<mj-head>[\s\S]*<mj-style>[\s\S]*\.tplc-testimonial-card[\s\S]*<\/mj-style>[\s\S]*<\/mj-head>/,
+    );
+
+    // 4. The CSS does NOT leak into mj-body (where consumer HTML lands).
+    const bodyStart = mjml.indexOf("</mj-head>");
+    const bodyEnd = mjml.indexOf("</mj-body>");
+    if (bodyStart >= 0 && bodyEnd > bodyStart) {
+      const bodySection = mjml.slice(bodyStart, bodyEnd);
+      // The class names appear in the rendered HTML inside mj-body (that's
+      // the testimonial's actual markup) but the @media RULE must not.
+      expect(bodySection).not.toContain("@media (max-width: 480px)");
+    }
+  });
+
+  test("removing the last instance clears the <style> element", async ({
+    chooserPage,
+    editorPage,
+    page,
+  }) => {
+    await chooserPage.goto();
+    await chooserPage.selectTemplateByName("Product Launch");
+    await editorPage.waitForReady();
+    await editorPage.dismissOverlays();
+
+    // Confirm the stylesheet is present to start.
+    await expect
+      .poll(() => readStylesheetTextContents(page).then((s) => s.length))
+      .toBe(1);
+
+    // Select the custom block. `[data-block-type="custom"]` is the block
+    // wrapper's stable test selector.
+    const customBlock = page.locator('[data-block-type="custom"]').first();
+    await customBlock.scrollIntoViewIfNeeded();
+    await customBlock.click();
+    await page.locator(SELECTORS.blockActions).waitFor();
+    await editorPage.deleteSelectedBlock();
+
+    // The composable is reactive: once the last instance of the custom type
+    // is gone, the stylesheet drops out of the list and the `<style>`
+    // element is removed from the DOM.
+    await expect
+      .poll(() => readStylesheetTextContents(page).then((s) => s.length))
+      .toBe(0);
+  });
+});

--- a/apps/playground/src/App.vue
+++ b/apps/playground/src/App.vue
@@ -886,6 +886,16 @@ async function initEditor(): Promise<void> {
       locale: sdkLocale.value,
       onRequestMedia: enableRequestMedia.value ? requestMedia : undefined,
     });
+    // E2E affordance: expose `editor.toMjml()` on window so Playwright tests
+    // can read the export-path output without depending on the playground's
+    // copy-to-clipboard UI (the clipboard API is unreliable in headless
+    // Chromium on Linux CI — see `apps/playground/e2e/tests/custom-block-stylesheet.spec.ts`).
+    // The playground is a dev/demo harness, not a shipped product, so a
+    // test hook here is on-mission.
+    (
+      window as { __tplPlaygroundGetMjml?: () => Promise<string> }
+    ).__tplPlaygroundGetMjml = () =>
+      editor.value?.toMjml() ?? Promise.resolve("");
   } catch (err) {
     console.error("[Playground] Editor init failed:", err);
     initError.value = format(t.value.error.initFailed, {

--- a/apps/playground/src/templates.ts
+++ b/apps/playground/src/templates.ts
@@ -202,16 +202,56 @@ export const testimonialBlock: CustomBlockDefinition = {
       default: "",
     },
   ],
-  template: `<div style="padding: 20px; background-color: #f9fafb; border-radius: 8px; border-left: 3px solid #d1d5db;">
-  <div style="font-size: 15px; color: #374151; font-style: italic; line-height: 1.6; margin-bottom: 12px;">\u201c{{ quote }}\u201d</div>
-  <div style="display: flex; align-items: center; gap: 10px;">
-    {% if avatarUrl %}<img src="{{ avatarUrl }}" width="36" height="36" style="border-radius: 50%;" />{% endif %}
-    <div>
-      <div style="font-size: 13px; font-weight: 600; color: #111827;">{{ authorName }}</div>
-      <div style="font-size: 12px; color: #6b7280;">{{ authorTitle }}</div>
-    </div>
-  </div>
+  // Author row uses a table-based 2-column layout (avatar | byline) instead
+  // of flexbox \u2014 flex is unreliable in email clients (Outlook desktop ignores
+  // it entirely). The accompanying `stylesheet` stacks the columns to a
+  // single centered column on viewports \u2264480px, which is the canonical
+  // responsive pattern for "image + text" blocks in email.
+  template: `<div class="tplc-testimonial-card" style="padding: 20px; background-color: #f9fafb; border-radius: 8px; border-left: 3px solid #d1d5db;">
+  <div style="font-size: 15px; color: #374151; font-style: italic; line-height: 1.6; margin-bottom: 16px;">\u201c{{ quote }}\u201d</div>
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+    <tr>
+      {% if avatarUrl %}<td class="tplc-testimonial-avatar" style="vertical-align: middle; padding-right: 12px; width: 48px;">
+        <img src="{{ avatarUrl }}" width="48" height="48" style="display: block; border-radius: 50%;" alt="" />
+      </td>{% endif %}
+      <td class="tplc-testimonial-byline" style="vertical-align: middle;">
+        <div style="font-size: 13px; font-weight: 600; color: #111827;">{{ authorName }}</div>
+        <div style="font-size: 12px; color: #6b7280;">{{ authorTitle }}</div>
+      </td>
+    </tr>
+  </table>
 </div>`,
+  // Showcases CustomBlockDefinition.stylesheet \u2014 the canonical responsive
+  // demo: a hover state for the canvas + a mobile media query that stacks
+  // the avatar above the byline (centered) at \u2264480px. This is exactly the
+  // pattern raised in #155: MJML's auto-responsive doesn't reach inside a
+  // custom block, and the new `stylesheet` field is the right primitive
+  // for the developer to author per-definition responsive CSS.
+  //
+  // Browser coverage: `apps/playground/e2e/tests/custom-block-stylesheet.spec.ts`.
+  stylesheet: `
+.tplc-testimonial-card {
+  transition: box-shadow 200ms ease;
+}
+.tplc-testimonial-card:hover {
+  box-shadow: rgba(0, 0, 0, 0.08) 0px 6px 16px 0px;
+}
+@media (max-width: 480px) {
+  .tplc-testimonial-avatar,
+  .tplc-testimonial-byline {
+    display: block !important;
+    width: 100% !important;
+    padding-right: 0 !important;
+    text-align: center !important;
+  }
+  .tplc-testimonial-avatar {
+    padding-bottom: 12px !important;
+  }
+  .tplc-testimonial-avatar img {
+    margin: 0 auto !important;
+  }
+}
+`,
 };
 
 export const productCardBlock: CustomBlockDefinition = {
@@ -806,7 +846,9 @@ export function createProductLaunchTemplate(): TemplateContent {
         ],
         styles: white(0, 20, 0, 20),
       }),
-      // Custom block: Testimonial
+      // Custom block: Testimonial \u2014 avatar provided so the stylesheet's
+      // responsive stacking demo (avatar \u2194 byline \u2192 stacked on mobile) has
+      // two table cells to rearrange.
       {
         ...createCustomBlock(testimonialBlock),
         fieldValues: {
@@ -814,7 +856,7 @@ export function createProductLaunchTemplate(): TemplateContent {
             "Launchpad v2 is the upgrade we didn\u2019t know we needed. Our team onboarded in minutes.",
           authorName: "Maria Santos",
           authorTitle: "VP of Engineering, NovaTech",
-          avatarUrl: "",
+          avatarUrl: "https://placehold.co/96x96/0d9488/ffffff?text=MS",
         },
         styles: white(16, 24, 16, 24),
       },
@@ -1824,6 +1866,12 @@ export const templates: TemplateOption[] = [
         icon: "custom-block",
         description:
           "The Testimonial near the bottom is a custom block with its own fields: quote, author name, title, and an optional avatar.\nTo try it: click the testimonial and check the right sidebar \u2014 you\u2019ll see custom field editors instead of the usual text toolbar. Edit any field and watch the block update instantly.\nThe Quote and Author Name fields are marked as required \u2014 they show a red asterisk and cannot be left empty. The avatar is optional and uses {% if avatarUrl %} in the Liquid template to conditionally render.\nCustom blocks use Liquid templates, so developers can add conditional logic directly in the markup.",
+      },
+      {
+        label: "Responsive Stylesheet",
+        icon: "responsive",
+        description:
+          "The testimonial uses CustomBlockDefinition.stylesheet to ship its own responsive CSS \u2014 a hover state on the card, plus a @media (max-width: 480px) rule that stacks the avatar above the byline on mobile (single centered column instead of side-by-side).\nMJML's automatic responsive behavior (column stacking, fluid images) only applies to the outer mj-section / mj-column layout, not to the HTML inside a custom block \u2014 so per-definition stylesheets are how you make a custom block's internals responsive.\nTo try it: hover the testimonial card in the canvas to see the shadow lift. The full stacked layout appears in the exported MJML when the recipient opens the email on a phone \u2014 open Export to see the .tplc-testimonial-* rules emitted inside <mj-head><mj-style>\u2026</mj-style></mj-head>.",
       },
     ],
   },

--- a/packages/editor/src/Editor.vue
+++ b/packages/editor/src/Editor.vue
@@ -10,6 +10,7 @@ import type { UseFontsReturn } from "./composables/useFonts";
 
 import { RotateCcw } from "@lucide/vue";
 import Canvas from "./components/Canvas.vue";
+import CustomBlockStylesheets from "./components/CustomBlockStylesheets.vue";
 import Sidebar from "./components/Sidebar.vue";
 import RightSidebar from "./components/RightSidebar.vue";
 import ViewportToggle from "./components/ViewportToggle.vue";
@@ -89,6 +90,8 @@ defineExpose({
   setContent: (content: TemplateContent) => editor.setContent(content),
   setTheme: (theme: UiTheme) => editor.setUiTheme(theme),
   renderCustomBlock: core.registry.renderCustomBlock,
+  getCustomBlockStylesheet: (customType: string) =>
+    core.registry.getDefinition(customType)?.stylesheet,
 });
 </script>
 
@@ -100,6 +103,9 @@ defineExpose({
     :data-tpl-theme="core.resolvedTheme.value"
     :style="core.themeStyles.value"
   >
+    <!-- Reactive `<style>` tags for custom-block definition stylesheets in
+         use. Sits at the top so its rules apply to the canvas below. -->
+    <CustomBlockStylesheets />
     <!-- Header — absolute, full width, above everything -->
     <header
       class="tpl-header tpl:absolute tpl:top-0 tpl:right-0 tpl:left-0 tpl:z-50 tpl:grid tpl:h-14 tpl:grid-cols-[1fr_auto_1fr] tpl:items-center tpl:px-4 tpl:shadow-[var(--tpl-shadow-md)] tpl:border-b tpl:border-[var(--tpl-border)]"

--- a/packages/editor/src/cloud/CloudEditor.vue
+++ b/packages/editor/src/cloud/CloudEditor.vue
@@ -18,6 +18,7 @@ import CloudPanels from "./components/CloudPanels.vue";
 import EditorFooter from "../components/EditorFooter.vue";
 
 import Canvas from "../components/Canvas.vue";
+import CustomBlockStylesheets from "../components/CustomBlockStylesheets.vue";
 import Sidebar from "../components/Sidebar.vue";
 import RightSidebar from "../components/RightSidebar.vue";
 import CloudLoadingOverlay from "./components/CloudLoadingOverlay.vue";
@@ -195,6 +196,9 @@ defineExpose({
     :data-tpl-theme="core.resolvedTheme.value"
     :style="core.themeStyles.value"
   >
+    <!-- Reactive `<style>` tags for custom-block definition stylesheets in
+         use. Sits at the top so its rules apply to the canvas below. -->
+    <CustomBlockStylesheets />
     <!-- Loading overlay -->
     <Transition
       enter-active-class="tpl:transition-opacity tpl:duration-200"

--- a/packages/editor/src/components/CustomBlockStylesheets.vue
+++ b/packages/editor/src/components/CustomBlockStylesheets.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { inject, type ComputedRef } from "vue";
+import { CUSTOM_BLOCK_STYLESHEETS_KEY } from "../keys";
+
+/**
+ * Renders one `<style>` tag per unique custom-block definition stylesheet
+ * currently in use by the editor's content. Mounted near the top of the
+ * editor's root template (both OSS `Editor.vue` and `CloudEditor.vue`) so the
+ * rules sit early in the document order and apply to the canvas.
+ *
+ * In shadow-DOM mode (`shadowDom: true`, default) the styles scope to the
+ * editor's shadow root. In light-DOM mode they leak globally, matching the
+ * existing behavior of the editor's published `dist/style.css` in that mode
+ * — no new global-leak vector.
+ *
+ * `v-html` on a `<style>` element sets its `innerHTML` (i.e., the raw CSS
+ * text) without escaping; safe because the source is the consumer-authored
+ * `CustomBlockDefinition.stylesheet` string they passed to `init()`. We don't
+ * sanitize it — same trust model as `template`.
+ */
+const stylesheets = inject<ComputedRef<string[]> | null>(
+  CUSTOM_BLOCK_STYLESHEETS_KEY,
+  null,
+);
+</script>
+
+<template>
+  <template v-if="stylesheets">
+    <style
+      v-for="(css, i) in stylesheets"
+      :key="i"
+      data-tpl-custom-block-stylesheet
+      v-html="css"
+    ></style>
+  </template>
+</template>

--- a/packages/editor/src/components/CustomBlockStylesheets.vue
+++ b/packages/editor/src/components/CustomBlockStylesheets.vue
@@ -1,5 +1,5 @@
-<script setup lang="ts">
-import { inject, type ComputedRef } from "vue";
+<script lang="ts">
+import { defineComponent, h, inject, type ComputedRef } from "vue";
 import { CUSTOM_BLOCK_STYLESHEETS_KEY } from "../keys";
 
 /**
@@ -13,24 +13,32 @@ import { CUSTOM_BLOCK_STYLESHEETS_KEY } from "../keys";
  * existing behavior of the editor's published `dist/style.css` in that mode
  * — no new global-leak vector.
  *
- * `v-html` on a `<style>` element sets its `innerHTML` (i.e., the raw CSS
- * text) without escaping; safe because the source is the consumer-authored
- * `CustomBlockDefinition.stylesheet` string they passed to `init()`. We don't
- * sanitize it — same trust model as `template`.
+ * Why a render function instead of `<template>`: Vue's template compiler
+ * treats `<style>` inside `<template>` as a side-effect tag and refuses to
+ * emit it in strict client-render compilation paths (notably the one used
+ * by `vue-tsc` and Vitest's Vue plugin). The render function below
+ * bypasses the template compiler entirely and produces the same DOM at
+ * runtime — and `innerHTML` on a `<style>` element sets the CSS rules
+ * directly, no escape/parse pass between authoring and the cssom.
  */
-const stylesheets = inject<ComputedRef<string[]> | null>(
-  CUSTOM_BLOCK_STYLESHEETS_KEY,
-  null,
-);
-</script>
+export default defineComponent({
+  name: "CustomBlockStylesheets",
+  setup() {
+    const stylesheets = inject<ComputedRef<string[]> | null>(
+      CUSTOM_BLOCK_STYLESHEETS_KEY,
+      null,
+    );
 
-<template>
-  <template v-if="stylesheets">
-    <style
-      v-for="(css, i) in stylesheets"
-      :key="i"
-      data-tpl-custom-block-stylesheet
-      v-html="css"
-    ></style>
-  </template>
-</template>
+    return () => {
+      if (!stylesheets) return null;
+      return stylesheets.value.map((css, i) =>
+        h("style", {
+          key: i,
+          "data-tpl-custom-block-stylesheet": "",
+          innerHTML: css,
+        }),
+      );
+    };
+  },
+});
+</script>

--- a/packages/editor/src/composables/useCustomBlockStylesheets.ts
+++ b/packages/editor/src/composables/useCustomBlockStylesheets.ts
@@ -1,0 +1,75 @@
+import { computed, type ComputedRef, type Ref } from "vue";
+import type { Block, TemplateContent } from "@templatical/types";
+import { isCustomBlock } from "@templatical/types";
+import type { UseBlockRegistryReturn } from "./useBlockRegistry";
+
+/**
+ * Derive the reactive set of custom-block `stylesheet` strings currently in
+ * use by the editor's content. Two layers of dedupe:
+ *
+ *  1. By `customType` — each definition's stylesheet is resolved once even if
+ *     dozens of instances of that type exist in the template.
+ *  2. By trimmed CSS content — two definitions that ship the same stylesheet
+ *     string (unlikely but possible) emit it only once. Matches the renderer's
+ *     `collectCustomBlockStylesheets` behavior so the editor preview and the
+ *     exported MJML reflect the same rule set.
+ *
+ * Whitespace-only and missing stylesheets are filtered out. The result is a
+ * `ComputedRef<string[]>` in insertion order (i.e., the order custom-block
+ * types first appear in the content tree, depth-first through sections).
+ *
+ * Consumers render one `<style>` element per entry inside the editor's mount
+ * root so the rules apply to the canvas. In shadow-DOM mode they scope to the
+ * shadow root; in light-DOM mode they share the global stylesheet surface
+ * already established by the published editor CSS — no new leak.
+ */
+export function useCustomBlockStylesheets(
+  content: Ref<TemplateContent>,
+  registry: UseBlockRegistryReturn,
+): ComputedRef<string[]> {
+  return computed(() => {
+    const customTypes = collectUniqueCustomTypes(content.value.blocks);
+    if (customTypes.size === 0) {
+      return [];
+    }
+
+    const seenContent = new Set<string>();
+    const out: string[] = [];
+
+    for (const customType of customTypes) {
+      const css = registry.getDefinition(customType)?.stylesheet;
+      if (!css) continue;
+
+      const trimmed = css.trim();
+      if (trimmed === "" || seenContent.has(trimmed)) continue;
+
+      seenContent.add(trimmed);
+      out.push(trimmed);
+    }
+
+    return out;
+  });
+}
+
+function collectUniqueCustomTypes(blocks: Block[]): Set<string> {
+  const types = new Set<string>();
+  walk(blocks, types);
+  return types;
+}
+
+function walk(blocks: Block[], out: Set<string>): void {
+  for (const block of blocks) {
+    if (isCustomBlock(block)) {
+      out.add(block.customType);
+      continue;
+    }
+    if (block.type === "section") {
+      // SectionBlock has `children: Block[][]` (one array per column).
+      const children = (block as unknown as { children?: Block[][] }).children;
+      if (!children) continue;
+      for (const column of children) {
+        walk(column, out);
+      }
+    }
+  }
+}

--- a/packages/editor/src/composables/useEditorCore.ts
+++ b/packages/editor/src/composables/useEditorCore.ts
@@ -53,6 +53,7 @@ import {
   BLOCK_DEFAULTS_KEY,
   BLOCK_REGISTRY_KEY,
   CUSTOM_BLOCK_DEFINITIONS_KEY,
+  CUSTOM_BLOCK_STYLESHEETS_KEY,
   MERGE_TAGS_KEY,
   MERGE_TAG_SYNTAX_KEY,
   MERGE_TAG_AUTOCOMPLETE_KEY,
@@ -86,6 +87,7 @@ import {
   useBlockRegistry,
   type UseBlockRegistryReturn,
 } from "./useBlockRegistry";
+import { useCustomBlockStylesheets } from "./useCustomBlockStylesheets";
 import { registerBuiltInBlocks } from "../utils/registerBuiltInBlocks";
 import { handleEditorKeydown } from "../utils/keyboardShortcuts";
 
@@ -409,6 +411,14 @@ export function useEditorCore(
   provide(BLOCK_DEFAULTS_KEY, config.blockDefaults);
   provide(BLOCK_REGISTRY_KEY, registry);
   provide(CUSTOM_BLOCK_DEFINITIONS_KEY, config.customBlocks ?? []);
+  // Reactive deduped list of custom-block stylesheets currently in use. The
+  // `<CustomBlockStylesheets>` component reads this and renders `<style>` tags
+  // into the editor root so authored CSS previews live in the canvas. The
+  // renderer's `getCustomBlockStylesheet` resolver covers the export path.
+  provide(
+    CUSTOM_BLOCK_STYLESHEETS_KEY,
+    useCustomBlockStylesheets(editor.content, registry),
+  );
 
   const mergeTagSyntax = resolveSyntax(config.mergeTags?.syntax);
   provide(MERGE_TAGS_KEY, config.mergeTags?.tags ?? []);

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -131,6 +131,14 @@ export interface TemplaticalEditor extends TemplaticalEditorBase {
    * `renderCustomBlock` option from outside the editor instance).
    */
   renderCustomBlock(block: CustomBlock): Promise<string>;
+  /**
+   * Look up the definition-level `stylesheet` for a registered custom block
+   * type. Returns the raw CSS string, or `undefined` when the type is unknown
+   * or the definition has no stylesheet. Exposed for headless callers that
+   * want to drive `@templatical/renderer`'s `getCustomBlockStylesheet` option
+   * from outside the editor instance.
+   */
+  getCustomBlockStylesheet(customType: string): string | undefined;
 }
 
 /**
@@ -405,6 +413,15 @@ export async function init(
         return Promise.reject(new Error("[Templatical] Editor not ready"));
       }
       return editorRef.value.renderCustomBlock(block);
+    },
+    getCustomBlockStylesheet(customType: string) {
+      // Pre-mount: registry is empty, so no definition has a stylesheet to
+      // resolve. Returning undefined here matches the "unknown type" branch
+      // and keeps the renderer's `getCustomBlockStylesheet` resolver total.
+      if (!editorRef.value) {
+        return undefined;
+      }
+      return editorRef.value.getCustomBlockStylesheet(customType);
     },
     toMjml: () => toMjmlForInstance(instance),
   };

--- a/packages/editor/src/keys.ts
+++ b/packages/editor/src/keys.ts
@@ -63,6 +63,9 @@ export const CUSTOM_BLOCK_DEFINITIONS_KEY: InjectionKey<
   CustomBlockDefinition[]
 > = Symbol("customBlockDefinitions");
 
+export const CUSTOM_BLOCK_STYLESHEETS_KEY: InjectionKey<ComputedRef<string[]>> =
+  Symbol("customBlockStylesheets");
+
 export const MERGE_TAGS_KEY: InjectionKey<MergeTag[]> = Symbol("mergeTags");
 
 export const MERGE_TAG_SYNTAX_KEY: InjectionKey<SyntaxPreset> =

--- a/packages/editor/src/utils/toMjml.ts
+++ b/packages/editor/src/utils/toMjml.ts
@@ -8,6 +8,15 @@ import type { CustomBlock, TemplateContent } from "@templatical/types";
 export interface ToMjmlSource {
   getContent(): TemplateContent;
   renderCustomBlock(block: CustomBlock): Promise<string>;
+  /**
+   * Optional. Look up the definition-level CSS for a custom block type.
+   * Returns `undefined` when the definition is unknown or has no
+   * `stylesheet`. Wired to the renderer's `getCustomBlockStylesheet` option
+   * so authored responsive/hover/font CSS lands in `<mj-head>` deduped per
+   * definition. Sources that omit it produce the same MJML as before this
+   * field existed — backward compatible.
+   */
+  getCustomBlockStylesheet?: (customType: string) => string | undefined;
 }
 
 /**
@@ -35,7 +44,17 @@ export async function toMjmlForInstance(
       "[Templatical] toMjml() requires the @templatical/renderer package. Please install it.",
     );
   }
+  const stylesheetResolver = instance.getCustomBlockStylesheet;
   return renderer.renderToMjml(instance.getContent(), {
     renderCustomBlock: instance.renderCustomBlock,
+    // Only pass through when the source actually provides a resolver, so
+    // callers that don't care about stylesheets see the same options shape
+    // (and the same MJML output) as before this field existed.
+    ...(stylesheetResolver
+      ? {
+          getCustomBlockStylesheet: (customType: string) =>
+            stylesheetResolver(customType),
+        }
+      : {}),
   });
 }

--- a/packages/editor/tests/customBlockStylesheets.test.ts
+++ b/packages/editor/tests/customBlockStylesheets.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { defineComponent, h, ref } from "vue";
+import {
+  createCustomBlock,
+  createDefaultTemplateContent,
+  createParagraphBlock,
+  createSectionBlock,
+  type CustomBlockDefinition,
+  type TemplateContent,
+} from "@templatical/types";
+import { useBlockRegistry } from "../src/composables/useBlockRegistry";
+import { useCustomBlockStylesheets } from "../src/composables/useCustomBlockStylesheets";
+
+/**
+ * Composable that drives the editor's `<CustomBlockStylesheets>` mirror.
+ * Mirrors the renderer's `collectCustomBlockStylesheets` contract: dedupe by
+ * customType *and* by trimmed content, skip empty/missing, walk into sections.
+ */
+
+const STACK_CSS = `
+@media (max-width: 480px) {
+  .tplc-image-text { display: block !important; }
+}
+`;
+const HOVER_CSS = `.tplc-card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.1); }`;
+
+function makeRegistry() {
+  const registry = useBlockRegistry();
+  return registry;
+}
+
+function registerDef(
+  registry: ReturnType<typeof useBlockRegistry>,
+  type: string,
+  stylesheet?: string,
+) {
+  const def: CustomBlockDefinition = {
+    type,
+    name: type,
+    fields: [],
+    template: `<div class="tplc-${type}">x</div>`,
+    ...(stylesheet === undefined ? {} : { stylesheet }),
+  };
+  registry.registerCustom(def, defineComponent({ render: () => h("div") }));
+  return def;
+}
+
+describe("useCustomBlockStylesheets", () => {
+  it("returns empty when no custom blocks are present", () => {
+    const registry = makeRegistry();
+    registerDef(registry, "image-text", STACK_CSS);
+    const content = ref<TemplateContent>(createDefaultTemplateContent());
+
+    const sheets = useCustomBlockStylesheets(content, registry);
+    expect(sheets.value).toEqual([]);
+  });
+
+  it("returns the stylesheet for a present customType", () => {
+    const registry = makeRegistry();
+    const def = registerDef(registry, "image-text", STACK_CSS);
+
+    const tpl = createDefaultTemplateContent();
+    tpl.blocks = [createCustomBlock(def)];
+    const content = ref(tpl);
+
+    const sheets = useCustomBlockStylesheets(content, registry);
+    expect(sheets.value).toHaveLength(1);
+    expect(sheets.value[0]).toContain(".tplc-image-text");
+  });
+
+  it("dedupes across multiple instances of the same customType", () => {
+    const registry = makeRegistry();
+    const def = registerDef(registry, "image-text", STACK_CSS);
+
+    const tpl = createDefaultTemplateContent();
+    tpl.blocks = [
+      createCustomBlock(def),
+      createCustomBlock(def),
+      createCustomBlock(def),
+    ];
+    const content = ref(tpl);
+
+    const sheets = useCustomBlockStylesheets(content, registry);
+    expect(sheets.value).toHaveLength(1);
+  });
+
+  it("dedupes by trimmed content when two definitions share CSS", () => {
+    const registry = makeRegistry();
+    const a = registerDef(registry, "a", STACK_CSS);
+    const b = registerDef(registry, "b", STACK_CSS);
+
+    const tpl = createDefaultTemplateContent();
+    tpl.blocks = [createCustomBlock(a), createCustomBlock(b)];
+    const content = ref(tpl);
+
+    const sheets = useCustomBlockStylesheets(content, registry);
+    expect(sheets.value).toHaveLength(1);
+  });
+
+  it("emits both stylesheets when two definitions ship different CSS", () => {
+    const registry = makeRegistry();
+    const a = registerDef(registry, "a", STACK_CSS);
+    const b = registerDef(registry, "b", HOVER_CSS);
+
+    const tpl = createDefaultTemplateContent();
+    tpl.blocks = [createCustomBlock(a), createCustomBlock(b)];
+    const content = ref(tpl);
+
+    const sheets = useCustomBlockStylesheets(content, registry);
+    expect(sheets.value).toHaveLength(2);
+    expect(sheets.value.some((s) => s.includes(".tplc-image-text"))).toBe(true);
+    expect(sheets.value.some((s) => s.includes(".tplc-card:hover"))).toBe(true);
+  });
+
+  it("skips definitions with no stylesheet field", () => {
+    const registry = makeRegistry();
+    const def = registerDef(registry, "no-styles"); // no stylesheet
+
+    const tpl = createDefaultTemplateContent();
+    tpl.blocks = [createCustomBlock(def)];
+    const content = ref(tpl);
+
+    const sheets = useCustomBlockStylesheets(content, registry);
+    expect(sheets.value).toEqual([]);
+  });
+
+  it("skips whitespace-only stylesheets", () => {
+    const registry = makeRegistry();
+    const def = registerDef(registry, "blank", "  \n\t  ");
+
+    const tpl = createDefaultTemplateContent();
+    tpl.blocks = [createCustomBlock(def)];
+    const content = ref(tpl);
+
+    const sheets = useCustomBlockStylesheets(content, registry);
+    expect(sheets.value).toEqual([]);
+  });
+
+  it("walks into sections to collect nested custom-block types", () => {
+    const registry = makeRegistry();
+    const def = registerDef(registry, "image-text", STACK_CSS);
+
+    const tpl = createDefaultTemplateContent();
+    tpl.blocks = [
+      createSectionBlock({
+        columns: "2",
+        children: [[createCustomBlock(def)], [createParagraphBlock()]],
+      }),
+    ];
+    const content = ref(tpl);
+
+    const sheets = useCustomBlockStylesheets(content, registry);
+    expect(sheets.value).toHaveLength(1);
+    expect(sheets.value[0]).toContain(".tplc-image-text");
+  });
+
+  it("updates reactively when a custom block is added", () => {
+    const registry = makeRegistry();
+    const def = registerDef(registry, "image-text", STACK_CSS);
+
+    const content = ref(createDefaultTemplateContent());
+    const sheets = useCustomBlockStylesheets(content, registry);
+    expect(sheets.value).toEqual([]);
+
+    content.value = {
+      ...content.value,
+      blocks: [createCustomBlock(def)],
+    };
+    expect(sheets.value).toHaveLength(1);
+  });
+
+  it("updates reactively when the last instance of a customType is removed", () => {
+    const registry = makeRegistry();
+    const def = registerDef(registry, "image-text", STACK_CSS);
+
+    const tpl = createDefaultTemplateContent();
+    tpl.blocks = [createCustomBlock(def)];
+    const content = ref(tpl);
+
+    const sheets = useCustomBlockStylesheets(content, registry);
+    expect(sheets.value).toHaveLength(1);
+
+    content.value = { ...content.value, blocks: [] };
+    expect(sheets.value).toEqual([]);
+  });
+});

--- a/packages/editor/tests/customBlockStylesheetsMount.test.ts
+++ b/packages/editor/tests/customBlockStylesheetsMount.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { computed, defineComponent, h, nextTick, ref } from "vue";
+import { mount } from "@vue/test-utils";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  createCustomBlock,
+  createDefaultTemplateContent,
+  type CustomBlockDefinition,
+} from "@templatical/types";
+import CustomBlockStylesheets from "../src/components/CustomBlockStylesheets.vue";
+import { useBlockRegistry } from "../src/composables/useBlockRegistry";
+import { useCustomBlockStylesheets } from "../src/composables/useCustomBlockStylesheets";
+import { CUSTOM_BLOCK_STYLESHEETS_KEY } from "../src/keys";
+
+/**
+ * Bridge tests between `useCustomBlockStylesheets` (composable) and the
+ * actual DOM. The composable's correctness is unit-tested elsewhere; this
+ * file proves the data flows through the inject layer and into rendered
+ * `<style>` elements that consumers see in the canvas — the bug class
+ * unit tests of either side in isolation cannot catch.
+ */
+
+function dummyComponent() {
+  return defineComponent({ render: () => h("div") });
+}
+
+function registerDef(
+  registry: ReturnType<typeof useBlockRegistry>,
+  def: CustomBlockDefinition,
+) {
+  registry.registerCustom(def, dummyComponent());
+  return def;
+}
+
+describe("CustomBlockStylesheets mount contract", () => {
+  it("renders one <style data-tpl-custom-block-stylesheet> per injected entry", () => {
+    const stylesheets = computed(() => [
+      ".tplc-a { color: red; }",
+      "@media (max-width: 480px) { .tplc-b { display: block; } }",
+      ".tplc-c:hover { opacity: 0.8; }",
+    ]);
+
+    const wrapper = mount(CustomBlockStylesheets, {
+      global: {
+        provide: { [CUSTOM_BLOCK_STYLESHEETS_KEY as symbol]: stylesheets },
+      },
+    });
+
+    const tags = wrapper.findAll("style[data-tpl-custom-block-stylesheet]");
+    expect(tags).toHaveLength(3);
+    // innerHTML, not textContent — `v-html` must set innerHTML on a `<style>`
+    // element so the browser parses the rules; textContent would render the
+    // CSS as a text node and fail at runtime.
+    expect(tags[0].element.innerHTML).toContain(".tplc-a { color: red; }");
+    expect(tags[1].element.innerHTML).toContain("@media (max-width: 480px)");
+    expect(tags[1].element.innerHTML).toContain(".tplc-b");
+    expect(tags[2].element.innerHTML).toContain(".tplc-c:hover");
+  });
+
+  it("renders nothing when no parent provides the inject key", () => {
+    const wrapper = mount(CustomBlockStylesheets);
+    expect(wrapper.find("style").exists()).toBe(false);
+  });
+
+  it("renders nothing when the injected list is empty", () => {
+    const stylesheets = computed<string[]>(() => []);
+    const wrapper = mount(CustomBlockStylesheets, {
+      global: {
+        provide: { [CUSTOM_BLOCK_STYLESHEETS_KEY as symbol]: stylesheets },
+      },
+    });
+    expect(wrapper.find("style").exists()).toBe(false);
+  });
+
+  it("re-renders the <style> set when the injected list changes", async () => {
+    const list = ref<string[]>([]);
+    const stylesheets = computed(() => list.value);
+
+    const wrapper = mount(CustomBlockStylesheets, {
+      global: {
+        provide: { [CUSTOM_BLOCK_STYLESHEETS_KEY as symbol]: stylesheets },
+      },
+    });
+    expect(wrapper.findAll("style").length).toBe(0);
+
+    list.value = [".tplc-late { padding: 8px; }"];
+    await nextTick();
+    expect(wrapper.findAll("style").length).toBe(1);
+    expect(wrapper.find("style").element.innerHTML).toContain(
+      ".tplc-late { padding: 8px; }",
+    );
+
+    list.value = [];
+    await nextTick();
+    expect(wrapper.findAll("style").length).toBe(0);
+  });
+});
+
+describe("End-to-end: registry → composable → DOM <style> tag", () => {
+  it("emits a <style> tag in the canvas when a custom block with a stylesheet is added", async () => {
+    const registry = useBlockRegistry();
+    const def = registerDef(registry, {
+      type: "image-text",
+      name: "Image+Text",
+      fields: [],
+      template: "<div>x</div>",
+      stylesheet: ".tplc-image-text-cell { display: block !important; }",
+    });
+
+    const content = ref(createDefaultTemplateContent());
+    const stylesheets = useCustomBlockStylesheets(content, registry);
+
+    const wrapper = mount(CustomBlockStylesheets, {
+      global: {
+        provide: { [CUSTOM_BLOCK_STYLESHEETS_KEY as symbol]: stylesheets },
+      },
+    });
+
+    // Empty template → no stylesheet emitted.
+    expect(wrapper.findAll("style").length).toBe(0);
+
+    // Add an instance of the registered type → stylesheet appears in DOM.
+    content.value = {
+      ...content.value,
+      blocks: [createCustomBlock(def)],
+    };
+    await nextTick();
+
+    const tags = wrapper.findAll("style[data-tpl-custom-block-stylesheet]");
+    expect(tags).toHaveLength(1);
+    expect(tags[0].element.innerHTML).toContain(
+      ".tplc-image-text-cell { display: block !important; }",
+    );
+
+    // Remove the block → stylesheet disappears.
+    content.value = { ...content.value, blocks: [] };
+    await nextTick();
+    expect(wrapper.findAll("style").length).toBe(0);
+  });
+});
+
+describe("Block registry — stylesheet lookup path", () => {
+  // The editor's `defineExpose.getCustomBlockStylesheet` and the
+  // `TemplaticalEditor` instance literal both delegate to
+  // `registry.getDefinition(customType)?.stylesheet`. These cases lock the
+  // three branches of that lookup; the source-pattern assertion below pins
+  // the wiring so a future refactor of the expose line surfaces here.
+  it("returns the registered definition's stylesheet for known types", () => {
+    const registry = useBlockRegistry();
+    registerDef(registry, {
+      type: "hero",
+      name: "Hero",
+      fields: [],
+      template: "<div>h</div>",
+      stylesheet: ".tplc-hero { padding: 32px; }",
+    });
+    expect(registry.getDefinition("hero")?.stylesheet).toBe(
+      ".tplc-hero { padding: 32px; }",
+    );
+  });
+
+  it("returns undefined for unknown customTypes", () => {
+    const registry = useBlockRegistry();
+    expect(registry.getDefinition("never-registered")?.stylesheet).toBe(
+      undefined,
+    );
+  });
+
+  it("returns undefined for definitions without a stylesheet field", () => {
+    const registry = useBlockRegistry();
+    registerDef(registry, {
+      type: "plain",
+      name: "Plain",
+      fields: [],
+      template: "<div>p</div>",
+    });
+    expect(registry.getDefinition("plain")?.stylesheet).toBe(undefined);
+  });
+});
+
+describe("Editor.vue — getCustomBlockStylesheet expose wiring (source pattern)", () => {
+  // Editor.vue is heavy to mount (needs config, fontsManager, translations,
+  // etc.). Mounting it for one expose line isn't worth the rig. Instead we
+  // pin the exact line via source inspection — same pattern as
+  // `block-chrome-structure.test.ts`. Refactoring this expose is fine; the
+  // test fails until the new wiring is locked in here too. That paper trail
+  // is the point.
+  const editorSrc = readFileSync(
+    join(import.meta.dirname, "..", "src", "Editor.vue"),
+    "utf8",
+  );
+
+  it("Editor.vue exposes getCustomBlockStylesheet routing through registry.getDefinition().stylesheet", () => {
+    expect(editorSrc).toMatch(
+      /getCustomBlockStylesheet:\s*\(customType:\s*string\)\s*=>\s*[\s\S]*?core\.registry\.getDefinition\(customType\)\?\.stylesheet/,
+    );
+  });
+});

--- a/packages/editor/tests/toMjml.test.ts
+++ b/packages/editor/tests/toMjml.test.ts
@@ -151,6 +151,50 @@ describe("toMjmlForInstance", () => {
     expect(renderToMjml).toHaveBeenCalledTimes(2);
   });
 
+  it("wires getCustomBlockStylesheet through to the renderer when the source provides it", async () => {
+    const renderToMjml = vi.fn().mockResolvedValue("<mjml/>");
+    vi.doMock("@templatical/renderer", () => ({ renderToMjml }));
+
+    const { toMjmlForInstance } = await import("../src/utils/toMjml");
+
+    const getCustomBlockStylesheet = vi.fn(
+      (t: string) => (t === "event" ? ".tplc-event { color: red; }" : undefined),
+    );
+    const content = makeContent([createCustomBlock(definition)]);
+
+    await toMjmlForInstance({
+      getContent: () => content,
+      renderCustomBlock: vi.fn(async () => ""),
+      getCustomBlockStylesheet,
+    });
+
+    // The renderer received a stylesheet resolver and calling it with
+    // "event" returns the source's CSS — proving the wiring is end-to-end,
+    // not just a shape match.
+    const optionsArg = renderToMjml.mock.calls[0][1];
+    expect(typeof optionsArg.getCustomBlockStylesheet).toBe("function");
+    expect(optionsArg.getCustomBlockStylesheet("event")).toBe(
+      ".tplc-event { color: red; }",
+    );
+    expect(optionsArg.getCustomBlockStylesheet("unknown")).toBe(undefined);
+  });
+
+  it("omits getCustomBlockStylesheet from renderer options when the source doesn't provide one", async () => {
+    const renderToMjml = vi.fn().mockResolvedValue("<mjml/>");
+    vi.doMock("@templatical/renderer", () => ({ renderToMjml }));
+
+    const { toMjmlForInstance } = await import("../src/utils/toMjml");
+
+    await toMjmlForInstance({
+      getContent: () => makeContent([]),
+      renderCustomBlock: vi.fn(async () => ""),
+      // No getCustomBlockStylesheet
+    });
+
+    const optionsArg = renderToMjml.mock.calls[0][1];
+    expect(optionsArg).not.toHaveProperty("getCustomBlockStylesheet");
+  });
+
   it("does not call renderCustomBlock itself — that's the renderer's job", async () => {
     const renderCustomBlock = vi.fn(async () => "<p/>");
     vi.doMock("@templatical/renderer", () => ({

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -29,6 +29,21 @@ export interface RenderOptions {
    */
   renderCustomBlock?: (block: CustomBlock) => Promise<string>;
   /**
+   * Resolves the definition-level CSS for a custom block type. Called once
+   * per unique `customType` present in the content tree (not per instance).
+   * The non-empty results are deduped by content and emitted as additional
+   * `<mj-style>` blocks inside `<mj-head>` alongside the built-in visibility
+   * media queries.
+   *
+   * Editor consumers: pass a function that reads
+   * `blockRegistry.getDefinition(customType)?.stylesheet`.
+   *
+   * Headless consumers: provide your own resolver, typically from the same
+   * definitions map used by `renderCustomBlock`. Return `undefined` or `null`
+   * for definitions without a stylesheet — those are skipped.
+   */
+  getCustomBlockStylesheet?: (customType: string) => string | undefined | null;
+  /**
    * Base URL (no trailing slash) for the social icon PNG assets. Resolved to
    * `${baseUrl}/${style}/${platform}.png` per icon. Defaults to the
    * version-pinned unpkg mirror of this package. Override to self-host
@@ -65,6 +80,11 @@ export async function renderToMjml(
   const customBlockHtml = await resolveCustomBlocks(
     content,
     options?.renderCustomBlock,
+  );
+
+  const customBlockStylesheets = collectCustomBlockStylesheets(
+    content,
+    options?.getCustomBlockStylesheet,
   );
 
   const renderContext = new RenderContext(
@@ -109,7 +129,7 @@ export async function renderToMjml(
       @media only screen and (min-width: 481px) {
         .tpl-hide-desktop { display: none !important; mso-hide: all !important; }
       }
-    </mj-style>
+    </mj-style>${renderCustomBlockStylesheets(customBlockStylesheets)}
   </mj-head>
   <mj-body width="${renderContext.containerWidth}px" background-color="${backgroundColor}">
 ${bodyContent}
@@ -265,6 +285,70 @@ function collectCustomBlocks(blocks: Block[], out: CustomBlock[]): void {
       }
     }
   }
+}
+
+/**
+ * Walk the content tree, find every unique `customType`, ask the consumer's
+ * resolver for that definition's stylesheet, and return the non-empty,
+ * content-deduped set in insertion order.
+ *
+ * Content-level dedupe (not just by customType) means two definitions that
+ * happen to ship the same stylesheet string emit it only once — cheap and
+ * matches the "one rule, emitted once" mental model. Whitespace-only and
+ * empty stylesheets are skipped.
+ */
+function collectCustomBlockStylesheets(
+  content: TemplateContent,
+  resolver: RenderOptions["getCustomBlockStylesheet"],
+): string[] {
+  if (!resolver) {
+    return [];
+  }
+
+  const customBlocks: CustomBlock[] = [];
+  collectCustomBlocks(content.blocks, customBlocks);
+
+  if (customBlocks.length === 0) {
+    return [];
+  }
+
+  const seenTypes = new Set<string>();
+  const seenContent = new Set<string>();
+  const stylesheets: string[] = [];
+
+  for (const block of customBlocks) {
+    if (seenTypes.has(block.customType)) {
+      continue;
+    }
+    seenTypes.add(block.customType);
+
+    const css = resolver(block.customType);
+    if (!css) {
+      continue;
+    }
+
+    const trimmed = css.trim();
+    if (trimmed === "" || seenContent.has(trimmed)) {
+      continue;
+    }
+    seenContent.add(trimmed);
+    stylesheets.push(trimmed);
+  }
+
+  return stylesheets;
+}
+
+function renderCustomBlockStylesheets(stylesheets: string[]): string {
+  if (stylesheets.length === 0) {
+    return "";
+  }
+
+  // One `<mj-style>` per unique stylesheet so per-definition CSS can be
+  // independently inspected in the rendered MJML, and authors can grep their
+  // contribution without disentangling a merged blob.
+  return stylesheets
+    .map((css) => `\n    <mj-style>\n${css}\n    </mj-style>`)
+    .join("");
 }
 
 // Re-export utilities for consumers

--- a/packages/renderer/tests/custom-block-stylesheet.test.ts
+++ b/packages/renderer/tests/custom-block-stylesheet.test.ts
@@ -179,6 +179,47 @@ describe("renderer — custom block stylesheets", () => {
     expect(mjml).not.toContain(".tplc-image-text");
   });
 
+  it("wraps the stylesheet in <mj-style> inside <mj-head>, preserving CSS verbatim", async () => {
+    const def = definition("image-text", STACK_CSS);
+    const content = contentWithCustomBlocks(createCustomBlock(def));
+
+    const mjml = await renderToMjml(content, {
+      renderCustomBlock: async () => "<div>x</div>",
+      getCustomBlockStylesheet: (t) =>
+        t === "image-text" ? STACK_CSS : null,
+    });
+
+    // 1. The CSS body sits between an opening <mj-style> and a closing
+    //    </mj-style> — not bare text in head, not concatenated into the
+    //    visibility block, not in body. Non-greedy `[\s\S]*?` allows the
+    //    `@media` wrapper around our target class, but the regex still
+    //    pins the bounding mj-style tags on both sides so a future refactor
+    //    that drops either tag fails this test.
+    expect(mjml).toMatch(
+      /<mj-style>[\s\S]*?\.tplc-image-text \{ display: block !important; \}[\s\S]*?<\/mj-style>/,
+    );
+
+    // 2. That entire <mj-style>…</mj-style> pair sits inside <mj-head>…
+    //    </mj-head> — explicit head-bounded regex, no "is the index lower
+    //    than X" proxy.
+    expect(mjml).toMatch(
+      /<mj-head>[\s\S]*<mj-style>[\s\S]*\.tplc-image-text[\s\S]*<\/mj-style>[\s\S]*<\/mj-head>/,
+    );
+
+    // 3. The CSS content is preserved verbatim — newlines and the @media
+    //    wrap are intact (the renderer must not strip or reflow the CSS).
+    expect(mjml).toContain("@media (max-width: 480px)");
+    expect(mjml).toContain(".tplc-image-text { display: block !important; }");
+
+    // 4. Custom stylesheet does NOT leak into mj-body (the only place
+    //    consumer HTML lands). Walk forward from `</mj-head>` to
+    //    `</mj-body>` and confirm the CSS string is absent from that span.
+    const bodyStart = mjml.indexOf("</mj-head>");
+    const bodyEnd = mjml.indexOf("</mj-body>");
+    const bodySection = mjml.slice(bodyStart, bodyEnd);
+    expect(bodySection).not.toContain(".tplc-image-text {");
+  });
+
   it("collects custom-block types nested inside sections", async () => {
     const def = definition("image-text", STACK_CSS);
     const inSection = createSectionBlock({

--- a/packages/renderer/tests/custom-block-stylesheet.test.ts
+++ b/packages/renderer/tests/custom-block-stylesheet.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCustomBlock,
+  createDefaultTemplateContent,
+  createSectionBlock,
+  type CustomBlock,
+  type CustomBlockDefinition,
+} from "@templatical/types";
+import { renderToMjml } from "../src";
+
+/**
+ * `getCustomBlockStylesheet` option: collect per-definition CSS from the
+ * content tree, dedupe, emit as `<mj-style>` inside `<mj-head>` alongside the
+ * built-in visibility media-query block.
+ */
+
+const STACK_CSS = `
+@media (max-width: 480px) {
+  .tplc-image-text { display: block !important; }
+}
+`;
+
+const HOVER_CSS = `
+.tplc-product-card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
+`;
+
+function definition(
+  type: string,
+  stylesheet?: string,
+): CustomBlockDefinition {
+  return {
+    type,
+    name: type,
+    fields: [],
+    template: `<div class="tplc-${type}">{{ text }}</div>`,
+    ...(stylesheet === undefined ? {} : { stylesheet }),
+  };
+}
+
+function contentWithCustomBlocks(...blocks: CustomBlock[]) {
+  const content = createDefaultTemplateContent();
+  content.blocks = blocks;
+  return content;
+}
+
+describe("renderer — custom block stylesheets", () => {
+  it("emits a definition's stylesheet inside an additional mj-style block in mj-head", async () => {
+    const def = definition("image-text", STACK_CSS);
+    const content = contentWithCustomBlocks(createCustomBlock(def));
+
+    const mjml = await renderToMjml(content, {
+      renderCustomBlock: async () => "<div>x</div>",
+      getCustomBlockStylesheet: (t) => (t === "image-text" ? STACK_CSS : null),
+    });
+
+    expect(mjml).toContain(".tplc-image-text { display: block !important; }");
+    // Built-in visibility block stays as the first mj-style; the new one is
+    // appended — both present, in this order.
+    const headSection = mjml.slice(0, mjml.indexOf("</mj-head>"));
+    const visibilityIdx = headSection.indexOf("tpl-hide-mobile");
+    const customIdx = headSection.indexOf("tplc-image-text");
+    expect(visibilityIdx).toBeGreaterThan(0);
+    expect(customIdx).toBeGreaterThan(visibilityIdx);
+  });
+
+  it("dedupes across multiple instances of the same customType", async () => {
+    const def = definition("image-text", STACK_CSS);
+    const content = contentWithCustomBlocks(
+      createCustomBlock(def),
+      createCustomBlock(def),
+      createCustomBlock(def),
+    );
+
+    const resolver = vi.fn(
+      (t: string) => (t === "image-text" ? STACK_CSS : null),
+    );
+
+    const mjml = await renderToMjml(content, {
+      renderCustomBlock: async () => "<div>x</div>",
+      getCustomBlockStylesheet: resolver,
+    });
+
+    // Resolver called once per UNIQUE customType, not once per instance.
+    expect(resolver).toHaveBeenCalledTimes(1);
+    // Stylesheet rendered exactly once in the output.
+    const occurrences = mjml.match(/\.tplc-image-text/g) ?? [];
+    expect(occurrences.length).toBe(1);
+  });
+
+  it("dedupes by content when two definitions ship identical stylesheets", async () => {
+    const defA = definition("a", STACK_CSS);
+    const defB = definition("b", STACK_CSS);
+    const content = contentWithCustomBlocks(
+      createCustomBlock(defA),
+      createCustomBlock(defB),
+    );
+
+    const mjml = await renderToMjml(content, {
+      renderCustomBlock: async () => "<div>x</div>",
+      getCustomBlockStylesheet: (t) =>
+        t === "a" || t === "b" ? STACK_CSS : null,
+    });
+
+    const occurrences = mjml.match(/\.tplc-image-text/g) ?? [];
+    expect(occurrences.length).toBe(1);
+  });
+
+  it("emits both stylesheets when two definitions ship different CSS", async () => {
+    const defA = definition("a", STACK_CSS);
+    const defB = definition("b", HOVER_CSS);
+    const content = contentWithCustomBlocks(
+      createCustomBlock(defA),
+      createCustomBlock(defB),
+    );
+
+    const mjml = await renderToMjml(content, {
+      renderCustomBlock: async () => "<div>x</div>",
+      getCustomBlockStylesheet: (t) =>
+        t === "a" ? STACK_CSS : t === "b" ? HOVER_CSS : null,
+    });
+
+    expect(mjml).toContain(".tplc-image-text");
+    expect(mjml).toContain(".tplc-product-card:hover");
+  });
+
+  it("skips definitions whose stylesheet is whitespace-only", async () => {
+    const def = definition("blank");
+    const content = contentWithCustomBlocks(createCustomBlock(def));
+
+    const mjml = await renderToMjml(content, {
+      renderCustomBlock: async () => "<div>x</div>",
+      getCustomBlockStylesheet: () => "   \n\t  ",
+    });
+
+    // Only the built-in visibility mj-style block should be present.
+    const mjStyleBlocks = mjml.match(/<mj-style>/g) ?? [];
+    expect(mjStyleBlocks.length).toBe(1);
+  });
+
+  it("skips definitions where the resolver returns undefined or null", async () => {
+    const def = definition("no-styles");
+    const content = contentWithCustomBlocks(createCustomBlock(def));
+
+    const mjmlUndef = await renderToMjml(content, {
+      renderCustomBlock: async () => "<div>x</div>",
+      getCustomBlockStylesheet: () => undefined,
+    });
+    const mjmlNull = await renderToMjml(content, {
+      renderCustomBlock: async () => "<div>x</div>",
+      getCustomBlockStylesheet: () => null,
+    });
+
+    expect((mjmlUndef.match(/<mj-style>/g) ?? []).length).toBe(1);
+    expect((mjmlNull.match(/<mj-style>/g) ?? []).length).toBe(1);
+  });
+
+  it("does not call the resolver when the template has no custom blocks", async () => {
+    const content = createDefaultTemplateContent();
+    const resolver = vi.fn(() => STACK_CSS);
+
+    await renderToMjml(content, {
+      getCustomBlockStylesheet: resolver,
+    });
+
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it("works without the option (backward compatible)", async () => {
+    const def = definition("image-text", STACK_CSS);
+    const content = contentWithCustomBlocks(createCustomBlock(def));
+
+    const mjml = await renderToMjml(content, {
+      renderCustomBlock: async () => "<div>x</div>",
+      // No getCustomBlockStylesheet — should not crash, and emit only the
+      // built-in visibility mj-style block.
+    });
+
+    expect((mjml.match(/<mj-style>/g) ?? []).length).toBe(1);
+    expect(mjml).not.toContain(".tplc-image-text");
+  });
+
+  it("collects custom-block types nested inside sections", async () => {
+    const def = definition("image-text", STACK_CSS);
+    const inSection = createSectionBlock({
+      columns: "2",
+      children: [[createCustomBlock(def)], []],
+    });
+    const content = createDefaultTemplateContent();
+    content.blocks = [inSection];
+
+    const mjml = await renderToMjml(content, {
+      renderCustomBlock: async () => "<div>x</div>",
+      getCustomBlockStylesheet: (t) =>
+        t === "image-text" ? STACK_CSS : null,
+    });
+
+    expect(mjml).toContain(".tplc-image-text");
+  });
+});

--- a/packages/types/src/custom-blocks.ts
+++ b/packages/types/src/custom-blocks.ts
@@ -102,6 +102,26 @@ export interface CustomBlockDefinition {
    * }
    */
   defaultStyles?: Partial<BlockStyles>;
+  /**
+   * Optional CSS rules attached to this custom block definition. Emitted once
+   * (deduped across instances) into `<mj-head><mj-style>…</mj-style></mj-head>`
+   * in the rendered MJML, and adopted into the editor canvas (shadow root or
+   * light-DOM mount) so authored responsive/hover/font behavior previews
+   * inside the editor.
+   *
+   * Use this for media queries, hover states, or any CSS that should apply
+   * once per definition rather than per block instance. Class names are not
+   * scoped by the SDK — namespace them yourself (e.g. `.tplc-<type>-<el>`) to
+   * avoid collisions with other definitions or built-in editor styles.
+   *
+   * @example
+   * stylesheet: `
+   *   @media (max-width: 480px) {
+   *     .tplc-image-text-cell { display: block !important; width: 100% !important; }
+   *   }
+   * `
+   */
+  stylesheet?: string;
 }
 
 export interface DataSourceFetchContext {


### PR DESCRIPTION
Add `CustomBlockDefinition.stylesheet` — definition-level CSS that emits once into `<mj-head><mj-style>` in the rendered MJML and is mirrored in the editor canvas.

Custom blocks render as raw HTML inside an `mj-text` cell, which means MJML's automatic responsive behavior (column stacking, fluid images) only applies to the *outer* layout — not to the internals of a custom block. Previously a developer had no clean place to put per-definition media queries, hover states, or block-specific font declarations; ad-hoc `<style>` blocks inside the `template` ended up in the email body rather than `<mj-head>`, with no dedupe across instances.

The new `stylesheet?: string` field on `CustomBlockDefinition` solves this:

- The renderer collects every definition's `stylesheet` from the content tree, dedupes by `customType` *and* by trimmed content, and emits each unique stylesheet once as an additional `<mj-style>` block alongside the built-in visibility media queries.
- The editor canvas mirrors the same CSS via a reactive `<style>` element rendered inside the editor root — in shadow-DOM mode it scopes to the shadow root; in light-DOM mode it shares the global stylesheet surface already established by `dist/style.css`.
- The renderer adds an optional `getCustomBlockStylesheet?: (customType: string) => string | undefined | null` resolver to `RenderOptions`. The editor wires this from its block registry automatically; headless callers provide their own resolver from whatever definitions map they manage.
- `TemplaticalEditor` (the OSS init return) gains `getCustomBlockStylesheet(customType)` for parity with `renderCustomBlock`.

Class names in `stylesheet` are **not** scoped by the SDK — namespace them per definition (e.g. `.tplc-<type>-<element>`) to avoid collisions. Email-client caveats apply (Outlook desktop ignores `@media` queries, matching every other media-query-based feature in the SDK such as block visibility).

Fully backward compatible: existing definitions and renderer callers that omit the new field/option produce the same MJML and editor behavior as before.

Closes #155 (raised as the follow-up to #146).