### PR TITLE
fix: test coverage hardening

### DIFF
--- a/.changeset/test-coverage-hardening.md
+++ b/.changeset/test-coverage-hardening.md
@@ -1,0 +1,10 @@
+---
+"@templatical/import-beefree": patch
+"@templatical/editor": patch
+---
+
+Close meaningful test-coverage gaps and fix a BeeFree import bug
+
+- `@templatical/import-beefree`: stop emitting a redundant `font-weight: 400` span (now matches `@templatical/import-unlayer`).
+- `@templatical/editor`: export the merge-tag suggestion `render` factory so the popup lifecycle is unit-testable (behavior unchanged).
+- Added regression tests across editor, import, and media-library packages, and started measuring Vue SFCs in coverage.

--- a/packages/editor/src/extensions/MergeTagSuggestion.ts
+++ b/packages/editor/src/extensions/MergeTagSuggestion.ts
@@ -83,6 +83,283 @@ export function handleSuggestionKeyDown(
   return false;
 }
 
+/**
+ * Builds the `@tiptap/suggestion` `render` factory for the merge-tag popup.
+ * The returned handler object owns the popup lifecycle: mount, ARIA wiring,
+ * positioning, scroll listeners, and cleanup. Exported as a standalone
+ * function so that lifecycle can be unit-tested with mocked `SuggestionProps`
+ * instead of a full ProseMirror editor.
+ */
+export function createMergeTagSuggestionRenderer(
+  emptyText: string,
+  popoverRootRef?: Ref<HTMLElement | null> | null,
+): NonNullable<SuggestionOptions<MergeTag>["render"]> {
+  return () => {
+    let app: App | null = null;
+    let container: HTMLElement | null = null;
+    let editableEl: HTMLElement | null = null;
+    const itemsRef = ref<MergeTag[]>([]);
+    const selectedIndex = ref(0);
+    let currentCommand: ((item: MergeTag) => void) | null = null;
+    const listId = `tpl-merge-tag-suggestion-${++POPUP_ID_SEQ}`;
+    let latestClientRect: (() => DOMRect | null) | null = null;
+    let scrollTargets: Array<EventTarget> = [];
+    let pendingRaf: number | null = null;
+
+    function reposition(): void {
+      position(latestClientRect?.() ?? null);
+    }
+
+    /**
+     * Reposition immediately and on the next animation frame.
+     * After a keystroke triggers the suggestion, TipTap may run its
+     * own `scrollIntoView` to keep the caret visible. That scroll
+     * lands AFTER the current task's `position()` call but BEFORE
+     * the browser's next paint, so we re-measure on rAF to catch
+     * the post-scroll caret rect. Without this, the popup pins to
+     * the pre-scroll caret position and ends up offset on slower
+     * runners.
+     */
+    function repositionAfterPaint(): void {
+      reposition();
+      if (pendingRaf !== null) cancelAnimationFrame(pendingRaf);
+      pendingRaf = requestAnimationFrame(() => {
+        pendingRaf = null;
+        reposition();
+      });
+    }
+
+    function collectScrollAncestors(el: HTMLElement | null): HTMLElement[] {
+      // Walk up the DOM finding scrollable ancestors. ProseMirror's
+      // scrollIntoView fires on whichever ancestor scrolls — listening
+      // to all of them ensures we reposition regardless of which one
+      // moves.
+      const result: HTMLElement[] = [];
+      let node: HTMLElement | null = el?.parentElement ?? null;
+      while (
+        node &&
+        // shadow-ok: ancestor walk terminator; not a mount target
+        node !== document.body &&
+        node !== document.documentElement
+      ) {
+        const style = window.getComputedStyle(node);
+        const overflow = style.overflow + style.overflowX + style.overflowY;
+        if (/(auto|scroll|overlay)/.test(overflow)) {
+          result.push(node);
+        }
+        node = node.parentElement;
+      }
+      return result;
+    }
+
+    function attachScrollListeners(viewDom: HTMLElement | null): void {
+      scrollTargets = [window, ...collectScrollAncestors(viewDom)];
+      for (const target of scrollTargets) {
+        target.addEventListener("scroll", reposition, {
+          passive: true,
+          capture: true,
+        });
+      }
+      window.addEventListener("resize", reposition, { passive: true });
+    }
+
+    function detachScrollListeners(): void {
+      for (const target of scrollTargets) {
+        target.removeEventListener("scroll", reposition, {
+          capture: true,
+        } as EventListenerOptions);
+      }
+      window.removeEventListener("resize", reposition);
+      scrollTargets = [];
+    }
+
+    function position(rect: DOMRect | null): void {
+      if (!container || !rect) return;
+      // If the caret has scrolled out of the viewport, freeze the
+      // popup at its last on-screen position. Following the caret
+      // off-screen produces an invisible popup the user can't reach,
+      // and lets pathological scroll loops drag the popup further
+      // each tick.
+      if (rect.bottom < 0 || rect.top > window.innerHeight) return;
+      container.style.position = "fixed";
+      container.style.left = `${rect.left}px`;
+      container.style.zIndex = "9999";
+      // Place below caret first; offsetHeight is sync-readable after
+      // the Vue app has mounted (or after onUpdate's reactive flush).
+      container.style.top = `${rect.bottom}px`;
+      const popupHeight = container.offsetHeight;
+      if (popupHeight === 0) return;
+      const spaceBelow = window.innerHeight - rect.bottom;
+      if (spaceBelow < popupHeight) {
+        // Not enough room below — flip above. Clamp to 0 so the
+        // popup never positions off the top of the viewport.
+        const flippedTop = Math.max(0, rect.top - popupHeight);
+        container.style.top = `${flippedTop}px`;
+      }
+    }
+
+    function applyThemeContext(
+      target: HTMLElement,
+      editorEl: HTMLElement | null | undefined,
+    ): void {
+      // When the popup mounts to document.body its `position: fixed`
+      // resolves against the viewport — any transform/filter on a
+      // consumer-page ancestor (route transitions, reveal animations,
+      // dark canvas inversion) creates a containing block and moves
+      // fixed descendants with it. Body ancestors don't transform.
+      //
+      // When mounting inside the editor's popover root, the popup is a
+      // descendant of the `.tpl[data-tpl-theme]` root so CSS vars + font
+      // would inherit — but the snapshot below is still emitted inline
+      // because inline declarations win and the cost is negligible. This
+      // keeps a single behavior across both mount paths.
+      //
+      // CSS vars (--tpl-bg-elevated, --tpl-border, etc.) are scoped to
+      // `.tpl` and `.tpl[data-tpl-theme="dark"]` in the editor's
+      // stylesheet, so the popup wouldn't inherit them at body root.
+      // Adding `class="tpl"` would also pull base rules (min-height,
+      // flex, full-page bg) we don't want on a popup. Instead, snapshot
+      // every --tpl-* custom property from the editor's theme root and
+      // re-emit them inline on the popup wrapper.
+      const themeRoot = editorEl?.closest<HTMLElement>("[data-tpl-theme]");
+      if (!themeRoot) return;
+      const themeValue = themeRoot.getAttribute("data-tpl-theme");
+      if (themeValue) target.setAttribute("data-tpl-theme", themeValue);
+      const computed = window.getComputedStyle(themeRoot);
+      for (let i = 0; i < computed.length; i++) {
+        const prop = computed[i];
+        if (prop.startsWith("--tpl-")) {
+          target.style.setProperty(prop, computed.getPropertyValue(prop));
+        }
+      }
+      // The popup no longer inherits font from the editor wrapper, so
+      // its content would render in the page's default font and end up
+      // at a different height — which changes the flip-above decision
+      // and shifts the popup off the caret. Copy typography too.
+      target.style.fontFamily = computed.fontFamily;
+      target.style.fontSize = computed.fontSize;
+      target.style.lineHeight = computed.lineHeight;
+    }
+
+    function setEditableAria(active: boolean): void {
+      if (!editableEl) return;
+      if (active) {
+        editableEl.setAttribute("role", "combobox");
+        editableEl.setAttribute("aria-haspopup", "listbox");
+        editableEl.setAttribute("aria-expanded", "true");
+        editableEl.setAttribute("aria-controls", listId);
+      } else {
+        editableEl.removeAttribute("aria-expanded");
+        editableEl.removeAttribute("aria-controls");
+        editableEl.removeAttribute("aria-activedescendant");
+        editableEl.removeAttribute("aria-haspopup");
+        editableEl.removeAttribute("role");
+      }
+    }
+
+    function setActiveDescendant(): void {
+      if (!editableEl) return;
+      if (itemsRef.value.length === 0) {
+        editableEl.removeAttribute("aria-activedescendant");
+        return;
+      }
+      editableEl.setAttribute(
+        "aria-activedescendant",
+        `${listId}-opt-${selectedIndex.value}`,
+      );
+    }
+
+    function select(item: MergeTag): void {
+      currentCommand?.(item);
+    }
+
+    return {
+      onStart: (props: SuggestionProps<MergeTag>) => {
+        itemsRef.value = props.items;
+        selectedIndex.value = 0;
+        currentCommand = (item) => props.command(item);
+
+        container = document.createElement("div");
+        container.setAttribute("data-testid", "merge-tag-suggestion-popup");
+        // Use view.dom (ProseMirror contenteditable, actually
+        // attached to the DOM) rather than options.element, which may
+        // be a detached div when no `element` is passed to the editor
+        // constructor (as is the case with @tiptap/vue-3 EditorContent).
+        const viewDom = props.editor.view?.dom as HTMLElement | undefined;
+        editableEl = viewDom ?? null;
+        applyThemeContext(container, viewDom ?? null);
+        // Prefer the editor's popover root (shadow-aware) when wired by
+        // the consumer. Falls back to document.body for headless callers
+        // that don't pass `popoverRoot` to configure().
+        // shadow-ok: fallback when popoverRoot wasn't provided (e.g., headless caller); editor mounts pass the shadow-aware root
+        const mountTarget = popoverRootRef?.value ?? document.body;
+        mountTarget.appendChild(container);
+
+        app = createApp({
+          render() {
+            return h(MergeTagSuggestionList, {
+              items: itemsRef.value,
+              selectedIndex: selectedIndex.value,
+              emptyText,
+              listId,
+              onSelect: (item: MergeTag) => select(item),
+              onHover: (index: number) => {
+                selectedIndex.value = index;
+                setActiveDescendant();
+              },
+            });
+          },
+        });
+        app.mount(container);
+        setEditableAria(true);
+        setActiveDescendant();
+        latestClientRect = props.clientRect ?? null;
+        repositionAfterPaint();
+        attachScrollListeners(viewDom ?? null);
+      },
+      onUpdate: (props: SuggestionProps<MergeTag>) => {
+        itemsRef.value = props.items;
+        // Reset selection when item set changes (query changed).
+        if (selectedIndex.value >= props.items.length) {
+          selectedIndex.value = 0;
+        }
+        currentCommand = (item) => props.command(item);
+        setActiveDescendant();
+        latestClientRect = props.clientRect ?? null;
+        repositionAfterPaint();
+      },
+      onKeyDown: (props: SuggestionKeyDownProps): boolean => {
+        if (props.event.key === "Escape") {
+          return true;
+        }
+        const handled = handleSuggestionKeyDown(
+          props.event,
+          itemsRef.value,
+          selectedIndex,
+          select,
+        );
+        if (handled) setActiveDescendant();
+        return handled;
+      },
+      onExit: () => {
+        if (pendingRaf !== null) {
+          cancelAnimationFrame(pendingRaf);
+          pendingRaf = null;
+        }
+        detachScrollListeners();
+        setEditableAria(false);
+        app?.unmount();
+        container?.remove();
+        app = null;
+        container = null;
+        editableEl = null;
+        currentCommand = null;
+        latestClientRect = null;
+      },
+    };
+  };
+}
+
 export const MergeTagSuggestion = Extension.create<MergeTagSuggestionOptions>({
   name: "mergeTagSuggestion",
 
@@ -130,270 +407,7 @@ export const MergeTagSuggestion = Extension.create<MergeTagSuggestionOptions>({
           })
           .run();
       },
-      render: () => {
-        let app: App | null = null;
-        let container: HTMLElement | null = null;
-        let editableEl: HTMLElement | null = null;
-        const itemsRef = ref<MergeTag[]>([]);
-        const selectedIndex = ref(0);
-        let currentCommand: ((item: MergeTag) => void) | null = null;
-        const listId = `tpl-merge-tag-suggestion-${++POPUP_ID_SEQ}`;
-        let latestClientRect: (() => DOMRect | null) | null = null;
-        let scrollTargets: Array<EventTarget> = [];
-        let pendingRaf: number | null = null;
-
-        function reposition(): void {
-          position(latestClientRect?.() ?? null);
-        }
-
-        /**
-         * Reposition immediately and on the next animation frame.
-         * After a keystroke triggers the suggestion, TipTap may run its
-         * own `scrollIntoView` to keep the caret visible. That scroll
-         * lands AFTER the current task's `position()` call but BEFORE
-         * the browser's next paint, so we re-measure on rAF to catch
-         * the post-scroll caret rect. Without this, the popup pins to
-         * the pre-scroll caret position and ends up offset on slower
-         * runners.
-         */
-        function repositionAfterPaint(): void {
-          reposition();
-          if (pendingRaf !== null) cancelAnimationFrame(pendingRaf);
-          pendingRaf = requestAnimationFrame(() => {
-            pendingRaf = null;
-            reposition();
-          });
-        }
-
-        function collectScrollAncestors(el: HTMLElement | null): HTMLElement[] {
-          // Walk up the DOM finding scrollable ancestors. ProseMirror's
-          // scrollIntoView fires on whichever ancestor scrolls — listening
-          // to all of them ensures we reposition regardless of which one
-          // moves.
-          const result: HTMLElement[] = [];
-          let node: HTMLElement | null = el?.parentElement ?? null;
-          while (
-            node &&
-            // shadow-ok: ancestor walk terminator; not a mount target
-            node !== document.body &&
-            node !== document.documentElement
-          ) {
-            const style = window.getComputedStyle(node);
-            const overflow = style.overflow + style.overflowX + style.overflowY;
-            if (/(auto|scroll|overlay)/.test(overflow)) {
-              result.push(node);
-            }
-            node = node.parentElement;
-          }
-          return result;
-        }
-
-        function attachScrollListeners(viewDom: HTMLElement | null): void {
-          scrollTargets = [window, ...collectScrollAncestors(viewDom)];
-          for (const target of scrollTargets) {
-            target.addEventListener("scroll", reposition, {
-              passive: true,
-              capture: true,
-            });
-          }
-          window.addEventListener("resize", reposition, { passive: true });
-        }
-
-        function detachScrollListeners(): void {
-          for (const target of scrollTargets) {
-            target.removeEventListener("scroll", reposition, {
-              capture: true,
-            } as EventListenerOptions);
-          }
-          window.removeEventListener("resize", reposition);
-          scrollTargets = [];
-        }
-
-        function position(rect: DOMRect | null): void {
-          if (!container || !rect) return;
-          // If the caret has scrolled out of the viewport, freeze the
-          // popup at its last on-screen position. Following the caret
-          // off-screen produces an invisible popup the user can't reach,
-          // and lets pathological scroll loops drag the popup further
-          // each tick.
-          if (rect.bottom < 0 || rect.top > window.innerHeight) return;
-          container.style.position = "fixed";
-          container.style.left = `${rect.left}px`;
-          container.style.zIndex = "9999";
-          // Place below caret first; offsetHeight is sync-readable after
-          // the Vue app has mounted (or after onUpdate's reactive flush).
-          container.style.top = `${rect.bottom}px`;
-          const popupHeight = container.offsetHeight;
-          if (popupHeight === 0) return;
-          const spaceBelow = window.innerHeight - rect.bottom;
-          if (spaceBelow < popupHeight) {
-            // Not enough room below — flip above. Clamp to 0 so the
-            // popup never positions off the top of the viewport.
-            const flippedTop = Math.max(0, rect.top - popupHeight);
-            container.style.top = `${flippedTop}px`;
-          }
-        }
-
-        function applyThemeContext(
-          target: HTMLElement,
-          editorEl: HTMLElement | null | undefined,
-        ): void {
-          // When the popup mounts to document.body its `position: fixed`
-          // resolves against the viewport — any transform/filter on a
-          // consumer-page ancestor (route transitions, reveal animations,
-          // dark canvas inversion) creates a containing block and moves
-          // fixed descendants with it. Body ancestors don't transform.
-          //
-          // When mounting inside the editor's popover root, the popup is a
-          // descendant of the `.tpl[data-tpl-theme]` root so CSS vars + font
-          // would inherit — but the snapshot below is still emitted inline
-          // because inline declarations win and the cost is negligible. This
-          // keeps a single behavior across both mount paths.
-          //
-          // CSS vars (--tpl-bg-elevated, --tpl-border, etc.) are scoped to
-          // `.tpl` and `.tpl[data-tpl-theme="dark"]` in the editor's
-          // stylesheet, so the popup wouldn't inherit them at body root.
-          // Adding `class="tpl"` would also pull base rules (min-height,
-          // flex, full-page bg) we don't want on a popup. Instead, snapshot
-          // every --tpl-* custom property from the editor's theme root and
-          // re-emit them inline on the popup wrapper.
-          const themeRoot = editorEl?.closest<HTMLElement>("[data-tpl-theme]");
-          if (!themeRoot) return;
-          const themeValue = themeRoot.getAttribute("data-tpl-theme");
-          if (themeValue) target.setAttribute("data-tpl-theme", themeValue);
-          const computed = window.getComputedStyle(themeRoot);
-          for (let i = 0; i < computed.length; i++) {
-            const prop = computed[i];
-            if (prop.startsWith("--tpl-")) {
-              target.style.setProperty(prop, computed.getPropertyValue(prop));
-            }
-          }
-          // The popup no longer inherits font from the editor wrapper, so
-          // its content would render in the page's default font and end up
-          // at a different height — which changes the flip-above decision
-          // and shifts the popup off the caret. Copy typography too.
-          target.style.fontFamily = computed.fontFamily;
-          target.style.fontSize = computed.fontSize;
-          target.style.lineHeight = computed.lineHeight;
-        }
-
-        function setEditableAria(active: boolean): void {
-          if (!editableEl) return;
-          if (active) {
-            editableEl.setAttribute("role", "combobox");
-            editableEl.setAttribute("aria-haspopup", "listbox");
-            editableEl.setAttribute("aria-expanded", "true");
-            editableEl.setAttribute("aria-controls", listId);
-          } else {
-            editableEl.removeAttribute("aria-expanded");
-            editableEl.removeAttribute("aria-controls");
-            editableEl.removeAttribute("aria-activedescendant");
-            editableEl.removeAttribute("aria-haspopup");
-            editableEl.removeAttribute("role");
-          }
-        }
-
-        function setActiveDescendant(): void {
-          if (!editableEl) return;
-          if (itemsRef.value.length === 0) {
-            editableEl.removeAttribute("aria-activedescendant");
-            return;
-          }
-          editableEl.setAttribute(
-            "aria-activedescendant",
-            `${listId}-opt-${selectedIndex.value}`,
-          );
-        }
-
-        function select(item: MergeTag): void {
-          currentCommand?.(item);
-        }
-
-        return {
-          onStart: (props: SuggestionProps<MergeTag>) => {
-            itemsRef.value = props.items;
-            selectedIndex.value = 0;
-            currentCommand = (item) => props.command(item);
-
-            container = document.createElement("div");
-            container.setAttribute("data-testid", "merge-tag-suggestion-popup");
-            // Use view.dom (ProseMirror contenteditable, actually
-            // attached to the DOM) rather than options.element, which may
-            // be a detached div when no `element` is passed to the editor
-            // constructor (as is the case with @tiptap/vue-3 EditorContent).
-            const viewDom = props.editor.view?.dom as HTMLElement | undefined;
-            editableEl = viewDom ?? null;
-            applyThemeContext(container, viewDom ?? null);
-            // Prefer the editor's popover root (shadow-aware) when wired by
-            // the consumer. Falls back to document.body for headless callers
-            // that don't pass `popoverRoot` to configure().
-            // shadow-ok: fallback when popoverRoot wasn't provided (e.g., headless caller); editor mounts pass the shadow-aware root
-            const mountTarget = popoverRootRef?.value ?? document.body;
-            mountTarget.appendChild(container);
-
-            app = createApp({
-              render() {
-                return h(MergeTagSuggestionList, {
-                  items: itemsRef.value,
-                  selectedIndex: selectedIndex.value,
-                  emptyText,
-                  listId,
-                  onSelect: (item: MergeTag) => select(item),
-                  onHover: (index: number) => {
-                    selectedIndex.value = index;
-                    setActiveDescendant();
-                  },
-                });
-              },
-            });
-            app.mount(container);
-            setEditableAria(true);
-            setActiveDescendant();
-            latestClientRect = props.clientRect ?? null;
-            repositionAfterPaint();
-            attachScrollListeners(viewDom ?? null);
-          },
-          onUpdate: (props: SuggestionProps<MergeTag>) => {
-            itemsRef.value = props.items;
-            // Reset selection when item set changes (query changed).
-            if (selectedIndex.value >= props.items.length) {
-              selectedIndex.value = 0;
-            }
-            currentCommand = (item) => props.command(item);
-            setActiveDescendant();
-            latestClientRect = props.clientRect ?? null;
-            repositionAfterPaint();
-          },
-          onKeyDown: (props: SuggestionKeyDownProps): boolean => {
-            if (props.event.key === "Escape") {
-              return true;
-            }
-            const handled = handleSuggestionKeyDown(
-              props.event,
-              itemsRef.value,
-              selectedIndex,
-              select,
-            );
-            if (handled) setActiveDescendant();
-            return handled;
-          },
-          onExit: () => {
-            if (pendingRaf !== null) {
-              cancelAnimationFrame(pendingRaf);
-              pendingRaf = null;
-            }
-            detachScrollListeners();
-            setEditableAria(false);
-            app?.unmount();
-            container?.remove();
-            app = null;
-            container = null;
-            editableEl = null;
-            currentCommand = null;
-            latestClientRect = null;
-          },
-        };
-      },
+      render: createMergeTagSuggestionRenderer(emptyText, popoverRootRef),
     };
 
     return [

--- a/packages/editor/tests/extensionCommandsAndRules.test.ts
+++ b/packages/editor/tests/extensionCommandsAndRules.test.ts
@@ -1,0 +1,283 @@
+import "./dom-stubs";
+
+import { describe, expect, it, vi } from "vitest";
+import { SYNTAX_PRESETS } from "@templatical/types";
+
+// Mock .vue node-view imports (matches mergeTagNode.test.ts) so importing the
+// node extensions doesn't pull in SFCs the test doesn't need.
+vi.mock("../src/extensions/MergeTagNodeView.vue", () => ({ default: {} }));
+vi.mock("../src/extensions/LogicMergeTagNodeView.vue", () => ({ default: {} }));
+
+import { FontSize } from "../src/extensions/FontSize";
+import { LetterSpacing } from "../src/extensions/LetterSpacing";
+import { LineHeight } from "../src/extensions/LineHeight";
+import { MergeTagNode } from "../src/extensions/MergeTagNode";
+import { LogicMergeTagNode } from "../src/extensions/LogicMergeTagNode";
+
+// The existing textStyleExtensions.test.ts covers the global-attribute
+// parse/render. This file covers the COMMANDS and the merge-tag INPUT/PASTE
+// rule handlers — the actual transaction-composing logic — by invoking the
+// command creators / rule handlers directly with mocked TipTap primitives
+// (no full ProseMirror editor, per the package's test conventions).
+
+/** A chained-command mock where every step returns the same object. */
+function chainMock(runReturn = true) {
+  const c = {
+    setMark: vi.fn(() => c),
+    removeEmptyTextStyle: vi.fn(() => c),
+    run: vi.fn(() => runReturn),
+  };
+  return c;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function commandsOf(ext: any, options: Record<string, unknown>) {
+  return ext.configure({}).config.addCommands.call({ options });
+}
+
+describe("FontSize commands", () => {
+  it("setFontSize chains setMark(textStyle, { fontSize }) and returns the chain result", () => {
+    const chain = chainMock(true);
+    const cmds = commandsOf(FontSize, { types: ["textStyle"] });
+
+    const result = cmds.setFontSize("18px")({ chain: () => chain });
+
+    expect(chain.setMark).toHaveBeenCalledWith("textStyle", { fontSize: "18px" });
+    expect(chain.run).toHaveBeenCalledTimes(1);
+    expect(result).toBe(true);
+  });
+
+  it("unsetFontSize clears the mark and removes the empty textStyle", () => {
+    const chain = chainMock(false);
+    const cmds = commandsOf(FontSize, { types: ["textStyle"] });
+
+    const result = cmds.unsetFontSize()({ chain: () => chain });
+
+    expect(chain.setMark).toHaveBeenCalledWith("textStyle", { fontSize: null });
+    expect(chain.removeEmptyTextStyle).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+  });
+});
+
+describe("LetterSpacing commands", () => {
+  it("setLetterSpacing chains setMark(textStyle, { letterSpacing })", () => {
+    const chain = chainMock(true);
+    const cmds = commandsOf(LetterSpacing, { types: ["textStyle"] });
+
+    const result = cmds.setLetterSpacing("2px")({ chain: () => chain });
+
+    expect(chain.setMark).toHaveBeenCalledWith("textStyle", {
+      letterSpacing: "2px",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("unsetLetterSpacing clears the mark and removes the empty textStyle", () => {
+    const chain = chainMock(true);
+    const cmds = commandsOf(LetterSpacing, { types: ["textStyle"] });
+
+    cmds.unsetLetterSpacing()({ chain: () => chain });
+
+    expect(chain.setMark).toHaveBeenCalledWith("textStyle", {
+      letterSpacing: null,
+    });
+    expect(chain.removeEmptyTextStyle).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("LineHeight commands", () => {
+  it("setLineHeight updates the attribute on every configured type", () => {
+    const updateAttributes = vi.fn(() => true);
+    const cmds = commandsOf(LineHeight, { types: ["paragraph", "heading"] });
+
+    const result = cmds.setLineHeight("2.0")({
+      commands: { updateAttributes },
+    });
+
+    expect(updateAttributes).toHaveBeenCalledTimes(2);
+    expect(updateAttributes).toHaveBeenNthCalledWith(1, "paragraph", {
+      lineHeight: "2.0",
+    });
+    expect(updateAttributes).toHaveBeenNthCalledWith(2, "heading", {
+      lineHeight: "2.0",
+    });
+    expect(result).toBe(true);
+  });
+
+  it("setLineHeight short-circuits and returns false when a type update fails", () => {
+    // `every` stops at the first false — the failing type is first here.
+    const updateAttributes = vi.fn((type: string) => type !== "heading");
+    const cmds = commandsOf(LineHeight, { types: ["heading", "paragraph"] });
+
+    const result = cmds.setLineHeight("2.0")({
+      commands: { updateAttributes },
+    });
+
+    expect(result).toBe(false);
+    expect(updateAttributes).toHaveBeenCalledTimes(1);
+    expect(updateAttributes).toHaveBeenCalledWith("heading", {
+      lineHeight: "2.0",
+    });
+  });
+
+  it("unsetLineHeight resets the attribute on every configured type", () => {
+    const resetAttributes = vi.fn(() => true);
+    const cmds = commandsOf(LineHeight, { types: ["paragraph"] });
+
+    const result = cmds.unsetLineHeight()({ commands: { resetAttributes } });
+
+    expect(resetAttributes).toHaveBeenCalledWith("paragraph", "lineHeight");
+    expect(result).toBe(true);
+  });
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function nodeRules(ext: any, kind: "addInputRules" | "addPasteRules", ctx: any) {
+  return ext.configure({}).config[kind].call(ctx);
+}
+
+describe("MergeTagNode input/paste rules", () => {
+  function ctx(mergeTags: Array<{ label: string; value: string }> = []) {
+    return {
+      options: { syntax: SYNTAX_PRESETS.liquid, mergeTags },
+      type: { create: vi.fn((attrs) => ({ __node: true, attrs })) },
+    };
+  }
+
+  it("input rule replaces the matched range with a merge-tag node (resolved label)", () => {
+    const c = ctx([{ label: "First Name", value: "{{first_name}}" }]);
+    const rules = nodeRules(MergeTagNode, "addInputRules", c);
+    expect(rules).toHaveLength(1);
+
+    const replaceWith = vi.fn();
+    rules[0].handler({
+      state: { tr: { replaceWith } },
+      range: { from: 3, to: 17 },
+      match: ["{{first_name}}"],
+    });
+
+    expect(c.type.create).toHaveBeenCalledWith({
+      label: "First Name",
+      value: "{{first_name}}",
+    });
+    const createdNode = c.type.create.mock.results[0].value;
+    expect(replaceWith).toHaveBeenCalledWith(3, 17, createdNode);
+  });
+
+  it("input rule falls back to the raw value as label when no tag matches", () => {
+    const c = ctx([]); // unknown tag
+    const rules = nodeRules(MergeTagNode, "addInputRules", c);
+
+    const replaceWith = vi.fn();
+    rules[0].handler({
+      state: { tr: { replaceWith } },
+      range: { from: 0, to: 11 },
+      match: ["{{unknown}}"],
+    });
+
+    expect(c.type.create).toHaveBeenCalledWith({
+      label: "{{unknown}}",
+      value: "{{unknown}}",
+    });
+  });
+
+  it("paste rule replaces the matched range with a merge-tag node", () => {
+    const c = ctx([{ label: "Email", value: "{{email}}" }]);
+    const rules = nodeRules(MergeTagNode, "addPasteRules", c);
+
+    const replaceWith = vi.fn();
+    rules[0].handler({
+      state: { tr: { replaceWith } },
+      range: { from: 5, to: 14 },
+      match: ["{{email}}"],
+    });
+
+    expect(c.type.create).toHaveBeenCalledWith({
+      label: "Email",
+      value: "{{email}}",
+    });
+    expect(replaceWith).toHaveBeenCalledWith(
+      5,
+      14,
+      c.type.create.mock.results[0].value,
+    );
+  });
+});
+
+describe("LogicMergeTagNode input/paste rules", () => {
+  function ctx() {
+    return {
+      options: { syntax: SYNTAX_PRESETS.liquid },
+      type: { create: vi.fn((attrs) => ({ __logic: true, attrs })) },
+    };
+  }
+
+  it("input rule inserts a logic node with the uppercased keyword for a valid tag", () => {
+    const c = ctx();
+    const rules = nodeRules(LogicMergeTagNode, "addInputRules", c);
+
+    const replaceWith = vi.fn();
+    rules[0].handler({
+      state: { tr: { replaceWith } },
+      range: { from: 0, to: 13 },
+      match: ["{% if user %}"],
+    });
+
+    expect(c.type.create).toHaveBeenCalledWith({
+      value: "{% if user %}",
+      keyword: "IF",
+    });
+    expect(replaceWith).toHaveBeenCalledWith(
+      0,
+      13,
+      c.type.create.mock.results[0].value,
+    );
+  });
+
+  it("input rule bails (no node, no replace) when the match is not a logic tag", () => {
+    const c = ctx();
+    const rules = nodeRules(LogicMergeTagNode, "addInputRules", c);
+
+    const replaceWith = vi.fn();
+    rules[0].handler({
+      state: { tr: { replaceWith } },
+      range: { from: 0, to: 5 },
+      match: ["plain"],
+    });
+
+    expect(c.type.create).not.toHaveBeenCalled();
+    expect(replaceWith).not.toHaveBeenCalled();
+  });
+
+  it("paste rule inserts a logic node for a valid tag", () => {
+    const c = ctx();
+    const rules = nodeRules(LogicMergeTagNode, "addPasteRules", c);
+
+    const replaceWith = vi.fn();
+    rules[0].handler({
+      state: { tr: { replaceWith } },
+      range: { from: 2, to: 17 },
+      match: ["{% for x in y %}"],
+    });
+
+    expect(c.type.create).toHaveBeenCalledWith({
+      value: "{% for x in y %}",
+      keyword: "FOR",
+    });
+  });
+
+  it("paste rule bails when the match is not a logic tag", () => {
+    const c = ctx();
+    const rules = nodeRules(LogicMergeTagNode, "addPasteRules", c);
+
+    const replaceWith = vi.fn();
+    rules[0].handler({
+      state: { tr: { replaceWith } },
+      range: { from: 0, to: 4 },
+      match: ["nope"],
+    });
+
+    expect(c.type.create).not.toHaveBeenCalled();
+    expect(replaceWith).not.toHaveBeenCalled();
+  });
+});

--- a/packages/editor/tests/index-cloud-init.test.ts
+++ b/packages/editor/tests/index-cloud-init.test.ts
@@ -1,0 +1,316 @@
+// @vitest-environment happy-dom
+//
+// Exercises the public SDK entry surface that `index-init.test.ts` and
+// `shadow-mount.test.ts` don't: the full `initCloud()` flow (ready
+// resolution, timeout rejection, content-access-before-ready), the
+// top-level `unmount()` export, and the OSS instance methods
+// (getContent/setContent/setTheme/renderCustomBlock/getCustomBlockStylesheet)
+// in both their pre-ready (ref null) and post-ready branches.
+//
+// Vue / Editor.vue / CloudEditor.vue / i18n are mocked the same way as
+// shadow-mount.test.ts so we drive just the entry logic, not the editor's
+// full bootstrap. A `setup()` render is invoked to capture the props passed
+// to `h(...)`, including the `onReady` callback and the template `ref` — we
+// then resolve readiness / set the instance ourselves.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { Ref } from "vue";
+
+interface Captured {
+  props: Record<string, unknown> | null;
+}
+
+const captured: Captured = { props: null };
+const fakeApps: Array<{ mount: ReturnType<typeof vi.fn>; unmount: ReturnType<typeof vi.fn> }> =
+  [];
+
+let initFn: typeof import("../src/index").init;
+let initCloudFn: typeof import("../src/index").initCloud;
+let unmountFn: typeof import("../src/index").unmount;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  captured.props = null;
+  fakeApps.length = 0;
+
+  vi.doMock("vue", async () => {
+    const actual = await vi.importActual<typeof import("vue")>("vue");
+    return {
+      ...actual,
+      createApp: vi.fn((options: { setup: () => () => unknown }) => {
+        // Run setup() then the render fn so the mocked h captures props.
+        options.setup()();
+        const app = { mount: vi.fn(), unmount: vi.fn() };
+        fakeApps.push(app);
+        return app;
+      }),
+      h: vi.fn((_comp: unknown, props: Record<string, unknown>) => {
+        captured.props = props;
+        return {};
+      }),
+    };
+  });
+  vi.doMock("../src/Editor.vue", () => ({ default: { name: "Editor" } }));
+  vi.doMock("../src/cloud/CloudEditor.vue", () => ({
+    default: { name: "CloudEditor" },
+  }));
+  vi.doMock("../src/i18n", () => ({
+    loadTranslations: vi.fn(() => Promise.resolve({})),
+    loadCloudTranslations: vi.fn(() => Promise.resolve({})),
+  }));
+  vi.doMock("../src/composables", () => ({
+    useFonts: vi.fn(() => ({ fonts: { value: [] } })),
+  }));
+  vi.doMock("../src/utils/toMjml", () => ({
+    toMjmlForInstance: vi.fn(() => Promise.resolve("<mjml>mock</mjml>")),
+  }));
+
+  const mod = await import("../src/index");
+  initFn = mod.init;
+  initCloudFn = mod.initCloud;
+  unmountFn = mod.unmount;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Cast helper — CloudEditor.vue is mocked, so the config is just passed
+// through as a prop and never validated.
+function cloudConfig(container: HTMLElement, extra: Record<string, unknown> = {}) {
+  return {
+    container,
+    shadowDom: false,
+    content: {},
+    ...extra,
+  } as unknown as Parameters<typeof initCloudFn>[0];
+}
+
+describe("initCloud — readiness", () => {
+  it("resolves with an instance once CloudEditor emits ready", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const p = initCloudFn(cloudConfig(container));
+
+    // Wait for createApp/render to run (after the dynamic import + i18n awaits).
+    await vi.waitFor(() => expect(captured.props).not.toBeNull());
+
+    expect(typeof captured.props!.onReady).toBe("function");
+    (captured.props!.onReady as () => void)();
+
+    const instance = await p;
+    expect(typeof instance.save).toBe("function");
+    expect(fakeApps[0].mount).toHaveBeenCalledWith(container);
+  });
+
+  it("rejects with a timeout error when ready never fires", async () => {
+    vi.useFakeTimers();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const p = initCloudFn(cloudConfig(container));
+    p.catch(() => {}); // pre-attach so the rejection isn't unhandled
+
+    // Flush the import/i18n microtasks AND fire the pending 30s timeout.
+    await vi.runAllTimersAsync();
+
+    await expect(p).rejects.toThrow(/timed out/i);
+  });
+
+  it("throws when the container selector matches nothing", async () => {
+    await expect(
+      initCloudFn(cloudConfig(document.createElement("div"), {
+        container: "#does-not-exist",
+      })),
+    ).rejects.toThrow(/Container element not found/);
+  });
+});
+
+describe("initCloud — instance methods", () => {
+  async function mountCloud(refValue: Record<string, unknown> | null) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const p = initCloudFn(cloudConfig(container));
+    await vi.waitFor(() => expect(captured.props).not.toBeNull());
+    if (refValue) {
+      (captured.props!.ref as Ref<unknown>).value = refValue;
+    }
+    (captured.props!.onReady as () => void)();
+    const instance = await p;
+    return { instance, container };
+  }
+
+  it("delegates create/load/save to the mounted CloudEditor instance", async () => {
+    const fakeEditor = {
+      create: vi.fn(() => Promise.resolve({ id: "t1" })),
+      load: vi.fn(() => Promise.resolve({ id: "t2" })),
+      save: vi.fn(() => Promise.resolve({ ok: true })),
+      getContent: vi.fn(() => ({ blocks: [{ id: "b1" }] })),
+      setContent: vi.fn(),
+      setTheme: vi.fn(),
+    };
+    const { instance } = await mountCloud(fakeEditor);
+
+    const created = await instance.create({ blocks: [] } as never);
+    expect(created).toEqual({ id: "t1" });
+    expect(fakeEditor.create).toHaveBeenCalledWith({ blocks: [] });
+
+    await instance.load("tmpl-99");
+    expect(fakeEditor.load).toHaveBeenCalledWith("tmpl-99");
+
+    const saved = await instance.save();
+    expect(saved).toEqual({ ok: true });
+  });
+
+  it("getContent returns a deep clone of the editor's content (post-ready)", async () => {
+    const live = { blocks: [{ id: "b1" }] };
+    const fakeEditor = {
+      create: vi.fn(),
+      load: vi.fn(),
+      save: vi.fn(),
+      getContent: vi.fn(() => live),
+      setContent: vi.fn(),
+      setTheme: vi.fn(),
+    };
+    const { instance } = await mountCloud(fakeEditor);
+
+    const content = instance.getContent();
+    expect(content).toEqual(live);
+    // Deep clone — mutating the result must not touch the editor's object.
+    (content.blocks as Array<{ id: string }>)[0].id = "mutated";
+    expect(live.blocks[0].id).toBe("b1");
+  });
+
+  it("setContent and setTheme forward to the editor instance", async () => {
+    const fakeEditor = {
+      create: vi.fn(),
+      load: vi.fn(),
+      save: vi.fn(),
+      getContent: vi.fn(() => ({})),
+      setContent: vi.fn(),
+      setTheme: vi.fn(),
+    };
+    const { instance } = await mountCloud(fakeEditor);
+
+    const next = { blocks: [{ id: "x" }] } as never;
+    instance.setContent(next);
+    expect(fakeEditor.setContent).toHaveBeenCalledWith(next);
+
+    instance.setTheme("dark" as never);
+    expect(fakeEditor.setTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("rejects create/load/save when the editor ref never populated (not ready)", async () => {
+    // ready fires but the template ref stays null (mount produced no instance).
+    const { instance } = await mountCloud(null);
+
+    await expect(instance.create()).rejects.toThrow(/not ready/i);
+    await expect(instance.load("x")).rejects.toThrow(/not ready/i);
+    await expect(instance.save()).rejects.toThrow(/not ready/i);
+  });
+
+  it("instance.unmount() tears down the cloud app", async () => {
+    const fakeEditor = {
+      create: vi.fn(),
+      load: vi.fn(),
+      save: vi.fn(),
+      getContent: vi.fn(() => ({})),
+      setContent: vi.fn(),
+      setTheme: vi.fn(),
+    };
+    const { instance } = await mountCloud(fakeEditor);
+
+    instance.unmount();
+    expect(fakeApps[0].unmount).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("OSS init — instance methods", () => {
+  async function mountOss(refValue: Record<string, unknown> | null) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const content = { blocks: [{ id: "seed" }] };
+    const instance = await initFn({
+      container,
+      shadowDom: false,
+      content,
+    } as unknown as Parameters<typeof initFn>[0]);
+    if (refValue) {
+      (captured.props!.ref as Ref<unknown>).value = refValue;
+    }
+    return { instance, container, content };
+  }
+
+  it("pre-ready: getContent clones config.content, setContent updates config, accessors are safe", async () => {
+    const { instance, content } = await mountOss(null);
+
+    const got = instance.getContent();
+    expect(got).toEqual(content);
+    expect(got).not.toBe(content); // deep-cloned
+
+    // setContent before ready stores onto config (no editor ref yet).
+    const next = { blocks: [{ id: "later" }] } as never;
+    instance.setContent(next);
+    expect(instance.getContent()).toEqual(next);
+
+    // setTheme is a silent no-op pre-ready (no throw, nothing to assert but state).
+    instance.setTheme("dark" as never);
+
+    expect(instance.getCustomBlockStylesheet("custom-x")).toBeUndefined();
+    await expect(instance.renderCustomBlock({} as never)).rejects.toThrow(
+      /not ready/i,
+    );
+  });
+
+  it("post-ready: methods delegate to the editor instance", async () => {
+    const fakeEditor = {
+      getContent: vi.fn(() => ({ blocks: [{ id: "live" }] })),
+      setContent: vi.fn(),
+      setTheme: vi.fn(),
+      renderCustomBlock: vi.fn(() => Promise.resolve("<div>cb</div>")),
+      getCustomBlockStylesheet: vi.fn(() => ".cb{color:red}"),
+    };
+    const { instance } = await mountOss(fakeEditor);
+
+    expect(instance.getContent()).toEqual({ blocks: [{ id: "live" }] });
+
+    instance.setContent({ blocks: [] } as never);
+    expect(fakeEditor.setContent).toHaveBeenCalledWith({ blocks: [] });
+
+    instance.setTheme("light" as never);
+    expect(fakeEditor.setTheme).toHaveBeenCalledWith("light");
+
+    const html = await instance.renderCustomBlock({ id: "cb1" } as never);
+    expect(html).toBe("<div>cb</div>");
+    expect(instance.getCustomBlockStylesheet("custom-x")).toBe(".cb{color:red}");
+  });
+
+  it("toMjml delegates to toMjmlForInstance", async () => {
+    const { instance } = await mountOss(null);
+    const mjml = await instance.toMjml();
+    expect(mjml).toBe("<mjml>mock</mjml>");
+  });
+});
+
+describe("top-level unmount()", () => {
+  it("tears down the most-recently-created OSS editor and is idempotent", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    await initFn({
+      container,
+      shadowDom: false,
+      content: {},
+    } as unknown as Parameters<typeof initFn>[0]);
+
+    expect(fakeApps[0].unmount).not.toHaveBeenCalled();
+
+    unmountFn();
+    expect(fakeApps[0].unmount).toHaveBeenCalledTimes(1);
+
+    // Second call: nothing tracked → no-op (must not throw or double-unmount).
+    unmountFn();
+    expect(fakeApps[0].unmount).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/editor/tests/mergeTagSuggestionRenderer.test.ts
+++ b/packages/editor/tests/mergeTagSuggestionRenderer.test.ts
@@ -1,0 +1,324 @@
+// @vitest-environment happy-dom
+//
+// Behavior tests for the merge-tag suggestion popup lifecycle. The render
+// factory (`createMergeTagSuggestionRenderer`) returns the
+// `@tiptap/suggestion` handler object — we drive onStart/onUpdate/onKeyDown/
+// onExit directly with mocked `SuggestionProps`, asserting the real DOM,
+// ARIA, positioning, scroll-listener, and cleanup effects — asserting real
+// runtime behavior rather than source-text patterns.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { ref } from "vue";
+import type { MergeTag } from "@templatical/types";
+import { createMergeTagSuggestionRenderer } from "../src/extensions/MergeTagSuggestion";
+
+// Stub the list component so we exercise the popup lifecycle, not the SFC.
+vi.mock("../src/components/MergeTagSuggestionList.vue", () => ({
+  default: { name: "MergeTagSuggestionListStub", render: () => null },
+}));
+
+const TAGS: MergeTag[] = [
+  { label: "First Name", value: "first_name" },
+  { label: "Last Name", value: "last_name" },
+  { label: "Email", value: "email" },
+];
+
+type MutableRect = { left: number; top: number; bottom: number };
+
+function makeRect(r: MutableRect): DOMRect {
+  return {
+    left: r.left,
+    top: r.top,
+    bottom: r.bottom,
+    right: r.left,
+    width: 0,
+    height: r.bottom - r.top,
+    x: r.left,
+    y: r.top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function makeProps(opts: {
+  items?: MergeTag[];
+  command?: (item: MergeTag) => void;
+  editable?: HTMLElement;
+  rect?: MutableRect;
+}) {
+  const editable =
+    opts.editable ?? (() => {
+      const el = document.createElement("div");
+      document.body.appendChild(el);
+      return el;
+    })();
+  const rect = opts.rect ?? { left: 10, top: 5, bottom: 20 };
+  return {
+    props: {
+      items: opts.items ?? TAGS,
+      command: opts.command ?? vi.fn(),
+      clientRect: () => makeRect(rect),
+      editor: { view: { dom: editable } },
+    } as never,
+    editable,
+    rect,
+  };
+}
+
+let rafCb: FrameRequestCallback | null = null;
+const cancelSpy = vi.fn();
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  rafCb = null;
+  cancelSpy.mockClear();
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafCb = cb;
+    return 7;
+  });
+  vi.stubGlobal("cancelAnimationFrame", cancelSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function popup(): HTMLElement | null {
+  return document.querySelector('[data-testid="merge-tag-suggestion-popup"]');
+}
+
+describe("merge-tag suggestion popup — onStart", () => {
+  it("mounts the popup into document.body and wires combobox ARIA", () => {
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props, editable } = makeProps({});
+
+    handlers.onStart!(props);
+
+    const el = popup();
+    expect(el).not.toBeNull();
+    expect(el!.parentNode).toBe(document.body);
+
+    expect(editable.getAttribute("role")).toBe("combobox");
+    expect(editable.getAttribute("aria-haspopup")).toBe("listbox");
+    expect(editable.getAttribute("aria-expanded")).toBe("true");
+
+    const listId = editable.getAttribute("aria-controls");
+    expect(listId).toMatch(/^tpl-merge-tag-suggestion-\d+$/);
+    expect(editable.getAttribute("aria-activedescendant")).toBe(`${listId}-opt-0`);
+
+    // repositionAfterPaint scheduled a frame.
+    expect(typeof rafCb).toBe("function");
+  });
+
+  it("omits aria-activedescendant when there are no items", () => {
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props, editable } = makeProps({ items: [] });
+
+    handlers.onStart!(props);
+
+    expect(editable.getAttribute("role")).toBe("combobox");
+    expect(editable.getAttribute("aria-activedescendant")).toBeNull();
+  });
+
+  it("mounts into the popoverRoot element when provided (shadow-aware path)", () => {
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const handlers = createMergeTagSuggestionRenderer(
+      "No matches",
+      ref(root),
+    )();
+    const { props } = makeProps({});
+
+    handlers.onStart!(props);
+
+    const el = popup();
+    expect(el).not.toBeNull();
+    expect(el!.parentNode).toBe(root);
+  });
+
+  it("copies the theme attribute from the editor's [data-tpl-theme] root", () => {
+    const themeRoot = document.createElement("div");
+    themeRoot.setAttribute("data-tpl-theme", "dark");
+    const editable = document.createElement("div");
+    themeRoot.appendChild(editable);
+    document.body.appendChild(themeRoot);
+
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props } = makeProps({ editable });
+
+    handlers.onStart!(props);
+
+    expect(popup()!.getAttribute("data-tpl-theme")).toBe("dark");
+  });
+});
+
+describe("merge-tag suggestion popup — positioning", () => {
+  it("positions fixed at the caret rect when on-screen", () => {
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props } = makeProps({ rect: { left: 42, top: 100, bottom: 118 } });
+
+    handlers.onStart!(props);
+
+    const el = popup()!;
+    expect(el.style.position).toBe("fixed");
+    expect(el.style.left).toBe("42px");
+    expect(el.style.top).toBe("118px");
+    expect(el.style.zIndex).toBe("9999");
+  });
+
+  it("freezes (does not set position) when the caret has scrolled off-screen", () => {
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props } = makeProps({ rect: { left: 10, top: -80, bottom: -50 } });
+
+    handlers.onStart!(props);
+
+    const el = popup()!;
+    expect(el.style.left).toBe("");
+    expect(el.style.position).toBe("");
+  });
+
+  it("repositions on window resize and stops after exit", () => {
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const rect = { left: 10, top: 5, bottom: 20 };
+    const { props } = makeProps({ rect });
+
+    handlers.onStart!(props);
+    expect(popup()!.style.left).toBe("10px");
+
+    rect.left = 99;
+    window.dispatchEvent(new Event("resize"));
+    expect(popup()!.style.left).toBe("99px");
+
+    handlers.onExit!();
+    // After exit the listener is detached — a further resize is a no-op
+    // (and must not throw now that the container is gone).
+    rect.left = 5;
+    window.dispatchEvent(new Event("resize"));
+    expect(popup()).toBeNull();
+  });
+});
+
+describe("merge-tag suggestion popup — keyboard", () => {
+  it("ArrowDown / ArrowUp cycle the active descendant", () => {
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props, editable } = makeProps({});
+    handlers.onStart!(props);
+    const listId = editable.getAttribute("aria-controls")!;
+
+    const press = (key: string) =>
+      handlers.onKeyDown!({
+        event: new KeyboardEvent("keydown", { key }),
+      } as never);
+
+    expect(press("ArrowDown")).toBe(true);
+    expect(editable.getAttribute("aria-activedescendant")).toBe(`${listId}-opt-1`);
+
+    expect(press("ArrowDown")).toBe(true);
+    expect(editable.getAttribute("aria-activedescendant")).toBe(`${listId}-opt-2`);
+
+    // wraps back to 0
+    expect(press("ArrowDown")).toBe(true);
+    expect(editable.getAttribute("aria-activedescendant")).toBe(`${listId}-opt-0`);
+
+    // ArrowUp wraps to the last item
+    expect(press("ArrowUp")).toBe(true);
+    expect(editable.getAttribute("aria-activedescendant")).toBe(`${listId}-opt-2`);
+  });
+
+  it("Enter selects the active item via the command callback", () => {
+    const command = vi.fn();
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props } = makeProps({ command });
+    handlers.onStart!(props);
+
+    handlers.onKeyDown!({
+      event: new KeyboardEvent("keydown", { key: "ArrowDown" }),
+    } as never);
+    const handled = handlers.onKeyDown!({
+      event: new KeyboardEvent("keydown", { key: "Enter" }),
+    } as never);
+
+    expect(handled).toBe(true);
+    expect(command).toHaveBeenCalledWith(TAGS[1]);
+  });
+
+  it("Escape is handled (returns true) without selecting", () => {
+    const command = vi.fn();
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props } = makeProps({ command });
+    handlers.onStart!(props);
+
+    const handled = handlers.onKeyDown!({
+      event: new KeyboardEvent("keydown", { key: "Escape" }),
+    } as never);
+
+    expect(handled).toBe(true);
+    expect(command).not.toHaveBeenCalled();
+  });
+
+  it("Enter on an empty list is swallowed (true) and selects nothing", () => {
+    const command = vi.fn();
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props } = makeProps({ items: [], command });
+    handlers.onStart!(props);
+
+    const handled = handlers.onKeyDown!({
+      event: new KeyboardEvent("keydown", { key: "Enter" }),
+    } as never);
+
+    expect(handled).toBe(true);
+    expect(command).not.toHaveBeenCalled();
+  });
+});
+
+describe("merge-tag suggestion popup — onUpdate", () => {
+  it("resets the selection when the new item set is shorter", () => {
+    const command = vi.fn();
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props, editable } = makeProps({ command });
+    handlers.onStart!(props);
+    const listId = editable.getAttribute("aria-controls")!;
+
+    // Move selection to index 2.
+    handlers.onKeyDown!({
+      event: new KeyboardEvent("keydown", { key: "ArrowUp" }),
+    } as never);
+    expect(editable.getAttribute("aria-activedescendant")).toBe(`${listId}-opt-2`);
+
+    // Query narrows to a single item — selection must reset to 0.
+    const single: MergeTag[] = [{ label: "Only", value: "only" }];
+    const newCommand = vi.fn();
+    handlers.onUpdate!({
+      items: single,
+      command: newCommand,
+      clientRect: () => makeRect({ left: 10, top: 5, bottom: 20 }),
+      editor: { view: { dom: editable } },
+    } as never);
+
+    expect(editable.getAttribute("aria-activedescendant")).toBe(`${listId}-opt-0`);
+
+    // Enter now selects the new single item via the updated command.
+    handlers.onKeyDown!({
+      event: new KeyboardEvent("keydown", { key: "Enter" }),
+    } as never);
+    expect(newCommand).toHaveBeenCalledWith(single[0]);
+  });
+});
+
+describe("merge-tag suggestion popup — onExit", () => {
+  it("removes the popup, clears ARIA, and cancels the pending frame", () => {
+    const handlers = createMergeTagSuggestionRenderer("No matches", null)();
+    const { props, editable } = makeProps({});
+    handlers.onStart!(props);
+    expect(popup()).not.toBeNull();
+
+    handlers.onExit!();
+
+    expect(popup()).toBeNull();
+    expect(editable.getAttribute("role")).toBeNull();
+    expect(editable.getAttribute("aria-expanded")).toBeNull();
+    expect(editable.getAttribute("aria-controls")).toBeNull();
+    expect(editable.getAttribute("aria-activedescendant")).toBeNull();
+    expect(editable.getAttribute("aria-haspopup")).toBeNull();
+    expect(cancelSpy).toHaveBeenCalledWith(7);
+  });
+});

--- a/packages/editor/tests/useCloudSaveGate.test.ts
+++ b/packages/editor/tests/useCloudSaveGate.test.ts
@@ -1,0 +1,210 @@
+import "./dom-stubs";
+import { describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+import type { PlanConfig } from "@templatical/types";
+import { useCloudSaveGate } from "../src/cloud/composables/useCloudSaveGate";
+import type { LintIssue } from "../src/composables/useTemplateLint";
+
+function makeIssue(
+  severity: LintIssue["severity"],
+  ruleId = `rule-${severity}`,
+): LintIssue {
+  return {
+    blockId: "block-1",
+    ruleId,
+    severity,
+    message: `${severity} issue`,
+  };
+}
+
+/** Minimal PlanConfig — the gate only reads `accessibility.blockOnError`. */
+function makePlanConfig(blockOnError: boolean | undefined): PlanConfig {
+  return { accessibility: { blockOnError } } as unknown as PlanConfig;
+}
+
+function createGate(opts: {
+  issues?: LintIssue[];
+  blockOnError?: boolean | undefined;
+  /** Pass `null` to simulate plan config not yet loaded. */
+  planConfig?: PlanConfig | null;
+}) {
+  const issues = ref<LintIssue[]>(opts.issues ?? []);
+  const planConfig = ref<PlanConfig | null>(
+    opts.planConfig !== undefined
+      ? opts.planConfig
+      : makePlanConfig(opts.blockOnError),
+  );
+  const gate = useCloudSaveGate({ issues, planConfig });
+  return { gate, issues, planConfig };
+}
+
+describe("useCloudSaveGate", () => {
+  describe("blockingIssues / shouldBlock", () => {
+    it("is empty and not blocking when planConfig is null", () => {
+      const { gate } = createGate({
+        issues: [makeIssue("error")],
+        planConfig: null,
+      });
+
+      expect(gate.blockingIssues.value).toEqual([]);
+      expect(gate.shouldBlock.value).toBe(false);
+    });
+
+    it("is empty and not blocking when blockOnError is false, even with errors", () => {
+      const { gate } = createGate({
+        issues: [makeIssue("error"), makeIssue("error", "rule-error-2")],
+        blockOnError: false,
+      });
+
+      expect(gate.blockingIssues.value).toEqual([]);
+      expect(gate.shouldBlock.value).toBe(false);
+    });
+
+    it("is empty and not blocking when blockOnError is undefined", () => {
+      const { gate } = createGate({
+        issues: [makeIssue("error")],
+        blockOnError: undefined,
+      });
+
+      expect(gate.blockingIssues.value).toEqual([]);
+      expect(gate.shouldBlock.value).toBe(false);
+    });
+
+    it("filters to error-severity issues only when blockOnError is true", () => {
+      const error = makeIssue("error");
+      const { gate } = createGate({
+        issues: [makeIssue("warning"), error, makeIssue("info")],
+        blockOnError: true,
+      });
+
+      expect(gate.blockingIssues.value).toEqual([error]);
+      expect(gate.shouldBlock.value).toBe(true);
+    });
+
+    it("does not block when blockOnError is true but only warnings/info exist", () => {
+      const { gate } = createGate({
+        issues: [makeIssue("warning"), makeIssue("info")],
+        blockOnError: true,
+      });
+
+      expect(gate.blockingIssues.value).toEqual([]);
+      expect(gate.shouldBlock.value).toBe(false);
+    });
+
+    it("reacts when issues change after construction", () => {
+      const { gate, issues } = createGate({
+        issues: [],
+        blockOnError: true,
+      });
+
+      expect(gate.shouldBlock.value).toBe(false);
+
+      issues.value = [makeIssue("error")];
+
+      expect(gate.shouldBlock.value).toBe(true);
+      expect(gate.blockingIssues.value).toHaveLength(1);
+    });
+  });
+
+  describe("tryRunSave", () => {
+    it("runs the save immediately and returns true when not blocking", async () => {
+      const { gate } = createGate({ issues: [], blockOnError: true });
+      const run = vi.fn().mockResolvedValue(undefined);
+
+      const result = await gate.tryRunSave(run);
+
+      expect(result).toBe(true);
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(gate.modalOpen.value).toBe(false);
+    });
+
+    it("defers the save, opens the modal, and returns false when blocking", async () => {
+      const { gate } = createGate({
+        issues: [makeIssue("error")],
+        blockOnError: true,
+      });
+      const run = vi.fn().mockResolvedValue(undefined);
+
+      const result = await gate.tryRunSave(run);
+
+      expect(result).toBe(false);
+      expect(run).not.toHaveBeenCalled();
+      expect(gate.modalOpen.value).toBe(true);
+    });
+
+    it("awaits the underlying save before resolving when not blocking", async () => {
+      const { gate } = createGate({ issues: [], blockOnError: true });
+      const order: string[] = [];
+      const run = vi.fn(async () => {
+        await Promise.resolve();
+        order.push("save-settled");
+      });
+
+      await gate.tryRunSave(run);
+      order.push("tryRunSave-returned");
+
+      expect(order).toEqual(["save-settled", "tryRunSave-returned"]);
+    });
+  });
+
+  describe("confirmAndSave", () => {
+    it("runs the pending save and closes the modal", async () => {
+      const { gate } = createGate({
+        issues: [makeIssue("error")],
+        blockOnError: true,
+      });
+      const run = vi.fn().mockResolvedValue(undefined);
+
+      await gate.tryRunSave(run);
+      expect(run).not.toHaveBeenCalled();
+
+      await gate.confirmAndSave();
+
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(gate.modalOpen.value).toBe(false);
+    });
+
+    it("is a no-op when there is no pending save", async () => {
+      const { gate } = createGate({ issues: [], blockOnError: true });
+
+      await gate.confirmAndSave();
+
+      expect(gate.modalOpen.value).toBe(false);
+    });
+
+    it("drains the pending save so a second confirm does not re-run it", async () => {
+      const { gate } = createGate({
+        issues: [makeIssue("error")],
+        blockOnError: true,
+      });
+      const run = vi.fn().mockResolvedValue(undefined);
+
+      await gate.tryRunSave(run);
+      await gate.confirmAndSave();
+      await gate.confirmAndSave();
+
+      expect(run).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("cancel", () => {
+    it("closes the modal and discards the pending save", async () => {
+      const { gate } = createGate({
+        issues: [makeIssue("error")],
+        blockOnError: true,
+      });
+      const run = vi.fn().mockResolvedValue(undefined);
+
+      await gate.tryRunSave(run);
+      expect(gate.modalOpen.value).toBe(true);
+
+      gate.cancel();
+
+      expect(gate.modalOpen.value).toBe(false);
+
+      // Pending save was discarded — confirming afterwards must not run it.
+      await gate.confirmAndSave();
+      expect(run).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vitest/config';
-import vue from '@vitejs/plugin-vue';
-import { resolve } from 'node:path';
-import { inlineStyleCssPlugin } from './scripts/inline-style-css-plugin';
+import { defineConfig } from "vitest/config";
+import vue from "@vitejs/plugin-vue";
+import { resolve } from "node:path";
+import { inlineStyleCssPlugin } from "./scripts/inline-style-css-plugin";
 
 export default defineConfig({
   plugins: [
@@ -9,18 +9,21 @@ export default defineConfig({
     // Resolves `virtual:editor-css` in tests using the source CSS as a
     // fallback (no build artifacts exist in test mode).
     inlineStyleCssPlugin({
-      fallbackSourcePath: resolve(import.meta.dirname, 'src/styles/index.css'),
+      fallbackSourcePath: resolve(import.meta.dirname, "src/styles/index.css"),
     }),
   ],
   test: {
-    include: ['tests/**/*.test.ts'],
-    setupFiles: ['./tests/setup.ts'],
+    include: ["tests/**/*.test.ts"],
+    setupFiles: ["./tests/setup.ts"],
     coverage: {
-      provider: 'v8',
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/*.d.ts', 'src/**/*.vue'],
-      reporter: ['text', 'json'],
-      reportsDirectory: './coverage',
+      provider: "v8",
+      // Include Vue SFCs so component logic (computeds, methods, branch
+      // conditions) is covered. Many components are exercised by mount
+      // tests; the include keeps the rest visible rather than unmeasured.
+      include: ["src/**/*.ts", "src/**/*.vue"],
+      exclude: ["src/**/*.d.ts"],
+      reporter: ["text", "json"],
+      reportsDirectory: "./coverage",
     },
   },
 });

--- a/packages/import-beefree/src/__tests__/block-mapper.test.ts
+++ b/packages/import-beefree/src/__tests__/block-mapper.test.ts
@@ -695,4 +695,193 @@ describe("convertModule", () => {
       }
     });
   });
+
+  // Null-safety / malformed-input coverage for convertText's content-source
+  // fan-out, the unknown-type html-fallback flow, inline font-weight emission,
+  // and menu url precedence. Real exports carry partial descriptors.
+  describe("malformed / null-safety", () => {
+    describe("convertText with no content source", () => {
+      it("returns an empty paragraph when text, paragraph, and list are all absent", () => {
+        const warnings: string[] = [];
+        const mod = makeModule("mailup-bee-newsletter-modules-text", {
+          style: { "padding-top": "5px" },
+        });
+
+        const { block, entry } = convertModule(mod, warnings);
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          // textContent?.html ?? "" → "" with no wrapping applied.
+          expect(block.content).toBe("");
+        }
+        expect(entry.status).toBe("converted");
+        expect(entry.templaticalBlockType).toBe("paragraph");
+        expect(warnings).toHaveLength(0);
+      });
+
+      it("returns an empty paragraph for a list module with no list content", () => {
+        const warnings: string[] = [];
+        const mod = makeModule("mailup-bee-newsletter-modules-list", {});
+
+        const { block, entry } = convertModule(mod, warnings);
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          expect(block.content).toBe("");
+        }
+        expect(entry.status).toBe("converted");
+        expect(entry.templaticalBlockType).toBe("paragraph");
+      });
+    });
+
+    describe("unknown module type — html-fallback flow", () => {
+      it("emits an html block and a fully-populated html-fallback report entry", () => {
+        const warnings: string[] = [];
+        const mod = makeModule("mailup-bee-newsletter-modules-brand-new", {
+          html: { html: "<section>hi</section>" },
+        });
+
+        const { block, entry } = convertModule(mod, warnings);
+
+        // Unknown type short-circuits before the switch (MODULE_TYPE_MAP miss).
+        expect(block.type).toBe("html");
+        if (block.type === "html") {
+          // convertHtmlFallback pulls html.html since text.html is absent.
+          expect(block.content).toBe("<section>hi</section>");
+        }
+        expect(entry.status).toBe("html-fallback");
+        expect(entry.templaticalBlockType).toBe("html");
+        expect(entry.beeFreeModuleType).toBe(
+          "mailup-bee-newsletter-modules-brand-new",
+        );
+        expect(entry.note).toBe(
+          'Unknown module type "mailup-bee-newsletter-modules-brand-new" converted to HTML block.',
+        );
+        expect(warnings).toHaveLength(0);
+      });
+    });
+
+    describe("inlineStylesToHtml font-weight emission", () => {
+      it("does NOT emit a weight span for empty font-weight", () => {
+        const { block } = convertModule(
+          makeModule("mailup-bee-newsletter-modules-text", {
+            text: { html: "<p>Hi</p>", style: { "font-weight": "" } },
+          }),
+          [],
+        );
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          // "" is falsy → guard skips it entirely.
+          expect(block.content).toBe("<p>Hi</p>");
+          expect(block.content).not.toContain("font-weight");
+        }
+      });
+
+      it("does NOT emit a weight span for font-weight 'normal'", () => {
+        const { block } = convertModule(
+          makeModule("mailup-bee-newsletter-modules-text", {
+            text: { html: "<p>Hi</p>", style: { "font-weight": "normal" } },
+          }),
+          [],
+        );
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          expect(block.content).toBe("<p>Hi</p>");
+          expect(block.content).not.toContain("font-weight");
+        }
+      });
+
+      it("emits a weight span for font-weight 'bold'", () => {
+        const { block } = convertModule(
+          makeModule("mailup-bee-newsletter-modules-text", {
+            text: { html: "<p>Hi</p>", style: { "font-weight": "bold" } },
+          }),
+          [],
+        );
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          expect(block.content).toBe(
+            '<p><span style="font-weight: bold">Hi</span></p>',
+          );
+        }
+      });
+
+      it("emits a weight span for font-weight '700'", () => {
+        const { block } = convertModule(
+          makeModule("mailup-bee-newsletter-modules-text", {
+            text: { html: "<p>Hi</p>", style: { "font-weight": "700" } },
+          }),
+          [],
+        );
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          expect(block.content).toBe(
+            '<p><span style="font-weight: 700">Hi</span></p>',
+          );
+        }
+      });
+
+      // "400" is the numeric synonym for "normal", so it must not produce a
+      // redundant span — matching the import-unlayer importer.
+      it("does NOT emit a weight span for font-weight '400'", () => {
+        const { block } = convertModule(
+          makeModule("mailup-bee-newsletter-modules-text", {
+            text: { html: "<p>Hi</p>", style: { "font-weight": "400" } },
+          }),
+          [],
+        );
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          expect(block.content).toBe("<p>Hi</p>");
+        }
+      });
+    });
+
+    describe("menu item url precedence", () => {
+      it("prefers item.link over item.href when both are present", () => {
+        const { block } = convertModule(
+          makeModule("mailup-bee-newsletter-modules-menu", {
+            menu: {
+              items: [
+                {
+                  text: "Both",
+                  link: "https://link.test",
+                  href: "https://href.test",
+                },
+              ],
+            },
+          }),
+          [],
+        );
+
+        expect(block.type).toBe("menu");
+        if (block.type === "menu") {
+          expect(block.items).toHaveLength(1);
+          // `item.link || item.href || "#"` → link wins.
+          expect(block.items[0].url).toBe("https://link.test");
+        }
+      });
+
+      it("falls back to item.href when link is absent", () => {
+        const { block } = convertModule(
+          makeModule("mailup-bee-newsletter-modules-menu", {
+            menu: {
+              items: [{ text: "HrefOnly", href: "https://href.test" }],
+            },
+          }),
+          [],
+        );
+
+        expect(block.type).toBe("menu");
+        if (block.type === "menu") {
+          expect(block.items[0].url).toBe("https://href.test");
+        }
+      });
+    });
+  });
 });

--- a/packages/import-beefree/src/block-mapper.ts
+++ b/packages/import-beefree/src/block-mapper.ts
@@ -146,7 +146,9 @@ function inlineStylesToHtml(
   const color = parseColor(style.color);
   if (color && color !== "#1a1a1a") spanParts.push(`color: ${color}`);
   const fontWeight = style["font-weight"];
-  if (fontWeight && fontWeight !== "normal")
+  // "400" is the numeric synonym for "normal" — neither needs an explicit
+  // span (matches the import-unlayer importer).
+  if (fontWeight && fontWeight !== "normal" && fontWeight !== "400")
     spanParts.push(`font-weight: ${fontWeight}`);
   const fontFamily = parseFontFamily(style["font-family"]);
   if (fontFamily) spanParts.push(`font-family: ${fontFamily}`);

--- a/packages/import-html/src/__tests__/block-mapper.test.ts
+++ b/packages/import-html/src/__tests__/block-mapper.test.ts
@@ -208,6 +208,70 @@ describe("convertElement — divider", () => {
     expect(r.block.thickness).toBe(2);
     expect(r.block.color).toBe("#cccccc");
   });
+
+  it("parses the border shorthand (thickness/style/color) when no border-top is set", () => {
+    const { $, $el } = firstEl('<hr style="border:3px solid #999999" />', "hr");
+    const r = convertElement($el, $)!;
+    if (r.block.type !== "divider") throw new Error("expected divider block");
+    expect(r.block.thickness).toBe(3);
+    expect(r.block.lineStyle).toBe("solid");
+    expect(r.block.color).toBe("#999999");
+  });
+
+  it("prefers border-top over the border shorthand and maps dotted style", () => {
+    const { $, $el } = firstEl(
+      '<hr style="border:1px solid #000000;border-top:4px dotted #abcdef" />',
+      "hr",
+    );
+    const r = convertElement($el, $)!;
+    if (r.block.type !== "divider") throw new Error("expected divider block");
+    expect(r.block.thickness).toBe(4);
+    expect(r.block.lineStyle).toBe("dotted");
+    expect(r.block.color).toBe("#abcdef");
+  });
+
+  it("falls back to defaults when no border styles are present", () => {
+    // No border-top / border → parseBorderShorthand returns its own fallback
+    // (width 0, solid, #000000). thickness 0 becomes 1 via `|| 1`; the
+    // shorthand's #000000 color is truthy so it wins over the #e5e7eb default.
+    const { $, $el } = firstEl("<hr />", "hr");
+    const r = convertElement($el, $)!;
+    if (r.block.type !== "divider") throw new Error("expected divider block");
+    expect(r.block.thickness).toBe(1);
+    expect(r.block.lineStyle).toBe("solid");
+    expect(r.block.color).toBe("#000000");
+  });
+});
+
+describe("convertElement — empty text containers return null", () => {
+  it("returns null for an empty <p> with no media children", () => {
+    const { $, $el } = firstEl("<td><p></p></td>", "p");
+    expect(convertElement($el, $)).toBeNull();
+  });
+
+  it("returns null for a whitespace-only <span>", () => {
+    const { $, $el } = firstEl("<span>   </span>", "span");
+    expect(convertElement($el, $)).toBeNull();
+  });
+
+  it("returns null for an empty <div> with no media children", () => {
+    const { $, $el } = firstEl("<div></div>", "div");
+    expect(convertElement($el, $)).toBeNull();
+  });
+
+  it("still converts an empty <span> that wraps an image", () => {
+    // The null guard only fires when there is no text AND no img/a descendant.
+    const { $, $el } = firstEl(
+      '<span><img src="https://x/x.png" alt="" /></span>',
+      "span",
+    );
+    const r = convertElement($el, $)!;
+    expect(r.entry.templaticalBlockType).toBe("paragraph");
+    expect(r.entry.status).toBe("converted");
+    if (r.block.type !== "paragraph")
+      throw new Error("expected paragraph block");
+    expect(r.block.content).toContain("<img");
+  });
 });
 
 describe("convertElement — fallback", () => {

--- a/packages/import-html/src/__tests__/converter.test.ts
+++ b/packages/import-html/src/__tests__/converter.test.ts
@@ -245,6 +245,96 @@ describe("convertHtmlTemplate — data table preservation", () => {
   });
 });
 
+describe("convertHtmlTemplate — <center> wrapper recursion", () => {
+  const result = convertHtmlTemplate(fixture("center-wrapper.html"));
+
+  it("recurses into a <center>-wrapped table and converts its content", () => {
+    expect(result.content.blocks).toHaveLength(1);
+    const section = result.content.blocks[0] as SectionBlock;
+    expect(section.type).toBe("section");
+    expect(section.columns).toBe("1");
+
+    const title = findBlock(result.content.blocks, "title");
+    expect(title).toBeDefined();
+    expect(title!.level).toBe(1);
+    expect(title!.content).toContain("Centered heading");
+
+    const para = findBlock(result.content.blocks, "paragraph");
+    expect(para).toBeDefined();
+    expect(para!.content).toContain("Inside a center-wrapped table");
+  });
+});
+
+describe("convertHtmlTemplate — <main> wrapper recursion", () => {
+  const result = convertHtmlTemplate(fixture("main-wrapper.html"));
+
+  it("recurses into a <main>-wrapped table and converts its content", () => {
+    expect(result.content.blocks).toHaveLength(1);
+    const section = result.content.blocks[0] as SectionBlock;
+    expect(section.type).toBe("section");
+    expect(section.columns).toBe("1");
+
+    const title = findBlock(result.content.blocks, "title");
+    expect(title).toBeDefined();
+    expect(title!.content).toContain("Main heading");
+
+    const para = findBlock(result.content.blocks, "paragraph");
+    expect(para).toBeDefined();
+    expect(para!.content).toContain("Inside a main-wrapped table");
+  });
+});
+
+describe("convertHtmlTemplate — div wrapping a table with no loose siblings", () => {
+  const result = convertHtmlTemplate(fixture("div-wrapped-table.html"));
+
+  it("emits exactly one section and no spurious empty wrapper section", () => {
+    // The wrapping <div> has only the table as a child — no loose content. The
+    // flushLoose calls around the table must not emit an empty single-column
+    // section, so the result is exactly the table's one section.
+    expect(result.content.blocks).toHaveLength(1);
+    const section = result.content.blocks[0] as SectionBlock;
+    expect(section.type).toBe("section");
+    expect(section.columns).toBe("1");
+
+    const para = findBlock(result.content.blocks, "paragraph");
+    expect(para).toBeDefined();
+    expect(para!.content).toContain("Only table content");
+
+    // None of the sections is an empty wrapper (every column has content).
+    const emptySection = result.content.blocks.find(
+      (b) =>
+        b.type === "section" &&
+        (b as SectionBlock).children.every((col) => col.length === 0),
+    );
+    expect(emptySection).toBeUndefined();
+  });
+});
+
+describe("convertHtmlTemplate — div wrapping a table with loose siblings", () => {
+  it("flushes loose content before AND after the table into their own sections", () => {
+    const html = `<!doctype html><html><body>
+      <div>
+        <h1>Before</h1>
+        <table role="presentation"><tr><td><p>Inside</p></td></tr></table>
+        <p>After</p>
+      </div>
+    </body></html>`;
+    const { content } = convertHtmlTemplate(html);
+
+    // Three sections: leading loose (h1), the table, trailing loose (p).
+    expect(content.blocks).toHaveLength(3);
+    expect(content.blocks.every((b) => b.type === "section")).toBe(true);
+
+    const serialized = JSON.stringify(content.blocks);
+    const beforeIdx = serialized.indexOf("Before");
+    const insideIdx = serialized.indexOf("Inside");
+    const afterIdx = serialized.indexOf("After");
+    expect(beforeIdx).toBeGreaterThanOrEqual(0);
+    expect(insideIdx).toBeGreaterThan(beforeIdx);
+    expect(afterIdx).toBeGreaterThan(insideIdx);
+  });
+});
+
 describe("convertHtmlTemplate — wrapper-div recursion ordering", () => {
   it("keeps loose content before a nested table in source order", () => {
     const html = `<!doctype html><html><body>

--- a/packages/import-html/src/__tests__/css-resolver.test.ts
+++ b/packages/import-html/src/__tests__/css-resolver.test.ts
@@ -60,6 +60,30 @@ describe("parseStyleSheet", () => {
     expect(rules[0].declarations).toEqual({ color: "red" });
     expect(rules[1].declarations).toEqual({ color: "blue" });
   });
+
+  it("skips a semicolon-terminated @charset at-rule, keeps the following rule", () => {
+    // @charset has no `{...}` block — it terminates at the `;`. The stripper
+    // must skip past the semicolon and still parse the trailing p rule.
+    const rules = parseStyleSheet('@charset "UTF-8"; p { color: red; }');
+    expect(rules).toHaveLength(1);
+    expect(rules[0].selectors).toEqual(["p"]);
+    expect(rules[0].declarations).toEqual({ color: "red" });
+  });
+
+  it("skips a semicolon-terminated @import at-rule, keeps the following rule", () => {
+    const rules = parseStyleSheet(
+      "@import url('https://x/reset.css'); h1 { color: blue; }",
+    );
+    expect(rules).toHaveLength(1);
+    expect(rules[0].selectors).toEqual(["h1"]);
+    expect(rules[0].declarations).toEqual({ color: "blue" });
+  });
+
+  it("skips an @import with no trailing semicolon (runs to end of source)", () => {
+    // No `;` and no `{` after the @import means the stripper consumes to EOF.
+    const rules = parseStyleSheet("@import url('x.css')");
+    expect(rules).toEqual([]);
+  });
 });
 
 describe("resolveCssStyles", () => {
@@ -127,5 +151,28 @@ describe("resolveCssStyles", () => {
     );
     resolveCssStyles($);
     expect($("p").attr("style")).toContain("color: green");
+  });
+
+  it("silently skips a selector cheerio cannot parse and still applies the next rule", () => {
+    // `p[` passes the pseudo-class filter (no `:` / `@`) but makes cheerio's
+    // matcher throw — the try/catch must swallow it. The following valid `p`
+    // rule must still resolve onto the element.
+    const $ = load(
+      "<html><head><style>p[ { color: blue; } p { color: red; }</style></head><body><p>hi</p></body></html>",
+    );
+    resolveCssStyles($);
+    const style = $("p").attr("style") ?? "";
+    expect(style).toBe("color: red");
+    expect(style).not.toContain("blue");
+    expect($("style").length).toBe(0);
+  });
+
+  it("does not crash and applies no style when every selector is unparseable", () => {
+    const $ = load(
+      "<html><head><style>p[ { color: blue; } span[[ { color: green; }</style></head><body><p>hi</p></body></html>",
+    );
+    resolveCssStyles($);
+    expect($("p").attr("style")).toBeUndefined();
+    expect($("style").length).toBe(0);
   });
 });

--- a/packages/import-html/src/__tests__/fixtures/center-wrapper.html
+++ b/packages/import-html/src/__tests__/fixtures/center-wrapper.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <body>
+    <center>
+      <table role="presentation" width="600">
+        <tr>
+          <td>
+            <h1>Centered heading</h1>
+            <p>Inside a center-wrapped table.</p>
+          </td>
+        </tr>
+      </table>
+    </center>
+  </body>
+</html>

--- a/packages/import-html/src/__tests__/fixtures/div-wrapped-table.html
+++ b/packages/import-html/src/__tests__/fixtures/div-wrapped-table.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <body>
+    <div>
+      <table role="presentation" width="600">
+        <tr>
+          <td>
+            <p>Only table content, no loose siblings.</p>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </body>
+</html>

--- a/packages/import-html/src/__tests__/fixtures/main-wrapper.html
+++ b/packages/import-html/src/__tests__/fixtures/main-wrapper.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <body>
+    <main>
+      <table role="presentation" width="600">
+        <tr>
+          <td>
+            <h1>Main heading</h1>
+            <p>Inside a main-wrapped table.</p>
+          </td>
+        </tr>
+      </table>
+    </main>
+  </body>
+</html>

--- a/packages/import-html/src/__tests__/fixtures/nested-table.html
+++ b/packages/import-html/src/__tests__/fixtures/nested-table.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <body>
+    <table role="presentation" width="600">
+      <tr>
+        <td>
+          <h2>Section heading</h2>
+          <table role="presentation">
+            <tr>
+              <td>
+                <table role="presentation">
+                  <tr>
+                    <td>
+                      <img src="https://x/nested.jpg" alt="Nested" width="120" />
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/packages/import-html/src/__tests__/section-builder.test.ts
+++ b/packages/import-html/src/__tests__/section-builder.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { load } from "cheerio";
+import { describe, expect, it } from "vitest";
+import { processTable } from "../section-builder";
+import { convertHtmlTemplate } from "../converter";
+import type { Block, SectionBlock } from "@templatical/types";
+import type { Element } from "domhandler";
+import type { Cheerio } from "cheerio";
+import type { ImportReportEntry } from "../types";
+
+const FIXTURE_DIR = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
+
+function fixture(name: string): string {
+  return readFileSync(join(FIXTURE_DIR, name), "utf-8");
+}
+
+/**
+ * Loads HTML, grabs the first `<table>`, and runs `processTable` against it,
+ * collecting the entries/warnings the way the converter would.
+ */
+function runTable(
+  html: string,
+  flattenInline = false,
+): {
+  blocks: Block[];
+  entries: ImportReportEntry[];
+  warnings: string[];
+} {
+  const $ = load(html);
+  const $table = $("table").first() as unknown as Cheerio<Element>;
+  const entries: ImportReportEntry[] = [];
+  const warnings: string[] = [];
+  const blocks = processTable($table, $, entries, warnings, flattenInline);
+  return { blocks, entries, warnings };
+}
+
+describe("processTable — nested layout table flattens into parent column", () => {
+  it("a 2-level nested table with an image flattens into the parent cell column", () => {
+    const { content } = convertHtmlTemplate(fixture("nested-table.html"));
+
+    // Single outer row → single section, single column. The inner tables do
+    // NOT create their own sections — their blocks flatten into the parent
+    // column alongside the heading.
+    expect(content.blocks).toHaveLength(1);
+    const section = content.blocks[0] as SectionBlock;
+    expect(section.type).toBe("section");
+    expect(section.columns).toBe("1");
+    expect(section.children).toHaveLength(1);
+
+    const column = section.children[0];
+    expect(column.map((b) => b.type)).toEqual(["title", "image"]);
+
+    const title = column[0];
+    if (title.type !== "title") throw new Error("expected title block");
+    expect(title.content).toContain("Section heading");
+
+    // The image sits two nested-table levels deep but lands flat in the column.
+    const image = column[1];
+    if (image.type !== "image") throw new Error("expected image block");
+    expect(image.src).toBe("https://x/nested.jpg");
+    expect(image.alt).toBe("Nested");
+    expect(image.width).toBe(120);
+
+    // No nested section block was emitted anywhere.
+    const nestedSection = section.children
+      .flat()
+      .find((b) => b.type === "section");
+    expect(nestedSection).toBeUndefined();
+  });
+
+  it("processTable with flattenInline=true returns a flat block list (no section wrapper)", () => {
+    const { blocks } = runTable(
+      `<table role="presentation"><tr><td><h2>Inner heading</h2></td><td><p>Inner text</p></td></tr></table>`,
+      true,
+    );
+    // Two cells, both flattened to a single flat list — NOT a section.
+    expect(blocks.map((b) => b.type)).toEqual(["title", "paragraph"]);
+    expect(blocks.find((b) => b.type === "section")).toBeUndefined();
+  });
+
+  it("processTable with flattenInline=false wraps the row in a section", () => {
+    const { blocks } = runTable(
+      `<table role="presentation"><tr><td><h2>Heading</h2></td></tr></table>`,
+      false,
+    );
+    expect(blocks).toHaveLength(1);
+    const section = blocks[0] as SectionBlock;
+    expect(section.type).toBe("section");
+    expect(section.columns).toBe("1");
+    expect(section.children[0].map((b) => b.type)).toEqual(["title"]);
+  });
+});
+
+describe("processTable — styled loose anchor in a cell becomes a button", () => {
+  it("a styled <a> loose alongside a nested table converts to a button block", () => {
+    // The cell holds a styled CTA anchor AND a nested table containing a plain
+    // anchor. Two anchors total means the cell is NOT classified as a single
+    // button cell, so the per-child loop runs: the styled <a> hits the
+    // anchor-button branch, and the nested table flattens.
+    const html = `<table role="presentation"><tr><td>
+        <a style="background:#ff0000;padding:10px 20px;border-radius:4px" href="https://cta.com">Styled CTA</a>
+        <table role="presentation"><tr><td>
+          <table role="presentation"><tr><td>
+            <a href="https://inner.com">inner plain link</a>
+          </td></tr></table>
+        </td></tr></table>
+      </td></tr></table>`;
+    const { blocks, entries } = runTable(html, false);
+
+    expect(blocks).toHaveLength(1);
+    const section = blocks[0] as SectionBlock;
+    expect(section.columns).toBe("1");
+    const column = section.children[0];
+    expect(column.map((b) => b.type)).toEqual(["button", "paragraph"]);
+
+    const button = column[0];
+    if (button.type !== "button") throw new Error("expected button block");
+    expect(button.text).toBe("Styled CTA");
+    expect(button.url).toBe("https://cta.com");
+    expect(button.backgroundColor).toBe("#ff0000");
+    expect(button.borderRadius).toBe(4);
+    expect(button.buttonPadding).toEqual({
+      top: 10,
+      right: 20,
+      bottom: 10,
+      left: 20,
+    });
+
+    // The deeply-nested plain anchor flattened to an approximated paragraph.
+    const para = column[1];
+    if (para.type !== "paragraph") throw new Error("expected paragraph block");
+    expect(para.content).toContain("inner plain link");
+
+    // Entry metadata: the styled anchor reports as a converted button.
+    const buttonEntry = entries.find(
+      (e) => e.sourceTag === "a" && e.templaticalBlockType === "button",
+    );
+    expect(buttonEntry).toBeDefined();
+    expect(buttonEntry!.status).toBe("converted");
+  });
+});
+
+describe("processTable — data table preserved as HTML fallback", () => {
+  it("a bare data table (text-only cells) returns a single html-fallback block", () => {
+    const { blocks, entries } = runTable(
+      `<table><tr><td>Name</td><td>Age</td></tr><tr><td>Ada</td><td>30</td></tr></table>`,
+      false,
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("html");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      sourceTag: "table",
+      templaticalBlockType: "html",
+      status: "html-fallback",
+      note: "Data table preserved as HTML block.",
+    });
+  });
+
+  it("a layout table with no rows returns no blocks", () => {
+    // isLayoutTable is true (it finds the descendant <img> in the caption), but
+    // there are no <tr> rows, so the early row-length guard returns [] without
+    // emitting any section or fallback entry.
+    const { blocks, entries } = runTable(
+      `<table role="presentation"><caption><img src="https://x/cap.jpg" /></caption></table>`,
+      false,
+    );
+    expect(blocks).toEqual([]);
+    expect(entries).toEqual([]);
+  });
+});

--- a/packages/import-unlayer/src/__tests__/block-mapper.test.ts
+++ b/packages/import-unlayer/src/__tests__/block-mapper.test.ts
@@ -426,4 +426,158 @@ describe("convertContent", () => {
       }
     });
   });
+
+  // Null-safety / malformed-input coverage for the hand-rolled <p> scanner and
+  // the per-block converters. Real-world Unlayer exports occasionally carry
+  // truncated HTML or missing optional fields — these must degrade, not crash.
+  describe("malformed / null-safety", () => {
+    describe("convertText malformed <p>", () => {
+      // The wrap branch only runs when a non-default style is present, so each
+      // case supplies `color` to exercise wrapParagraphInner's bail paths.
+      it("does not throw on an unclosed <p> and leaves the fragment intact", () => {
+        const warnings: string[] = [];
+        const { block, entry } = convertContent(
+          makeContent("text", { text: "<p>Unclosed", color: "#123456" }),
+          warnings,
+        );
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          // No `</p>` to close → scanner dumps the remainder unchanged.
+          expect(block.content).toBe("<p>Unclosed");
+        }
+        expect(entry.status).toBe("converted");
+        expect(entry.templaticalBlockType).toBe("paragraph");
+        expect(warnings).toHaveLength(0);
+      });
+
+      it("does not throw on two consecutive unclosed <p> tags", () => {
+        const { block } = convertContent(
+          makeContent("text", { text: "<p>start<p>middle", color: "#123456" }),
+          [],
+        );
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          // First `<p` has no `</p>` after it → remainder dumped as-is.
+          expect(block.content).toBe("<p>start<p>middle");
+        }
+      });
+
+      it("wraps the unclosed fragment's content when a closing </p> appears later", () => {
+        const { block } = convertContent(
+          makeContent("text", {
+            text: "<p>first</p><p>second",
+            color: "#123456",
+          }),
+          [],
+        );
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          // First (closed) paragraph is wrapped; trailing unclosed one is left.
+          expect(block.content).toBe(
+            '<p><span style="color: #123456">first</span></p><p>second',
+          );
+        }
+      });
+
+      it("recognizes a <p> with a newline right after the tag name as valid", () => {
+        const { block } = convertContent(
+          makeContent("text", { text: "<p\n>Hello</p>", color: "#123456" }),
+          [],
+        );
+
+        expect(block.type).toBe("paragraph");
+        if (block.type === "paragraph") {
+          // `\n` is in the allowed post-tag-name char set → treated as a real
+          // <p>, so its inner content gets the styled span.
+          expect(block.content).toBe(
+            '<p\n><span style="color: #123456">Hello</span></p>',
+          );
+        }
+      });
+    });
+
+    describe("convertImage missing src", () => {
+      it("produces an image block with empty src and default sizing, no crash", () => {
+        const { block, entry } = convertContent(makeContent("image", {}), []);
+
+        expect(block.type).toBe("image");
+        if (block.type === "image") {
+          expect(block.src).toBe("");
+          expect(block.alt).toBe("");
+          expect(block.width).toBe(600);
+          expect(block.align).toBe("center");
+          expect(block.linkUrl).toBeUndefined();
+        }
+        expect(entry.status).toBe("converted");
+        expect(entry.templaticalBlockType).toBe("image");
+      });
+    });
+
+    describe("convertButton with null/absent optionals", () => {
+      it("falls back to defaults when buttonColors is null and href/padding absent", () => {
+        const { block, entry } = convertContent(
+          // buttonColors typed as optional object; real exports can send null.
+          makeContent("button", {
+            buttonColors: null as unknown as undefined,
+          }),
+          [],
+        );
+
+        expect(block.type).toBe("button");
+        if (block.type === "button") {
+          expect(block.text).toBe("Button");
+          expect(block.url).toBe("#");
+          expect(block.backgroundColor).toBe("#4f46e5");
+          expect(block.textColor).toBe("#ffffff");
+          expect(block.fontSize).toBe(16);
+          expect(block.buttonPadding).toEqual({
+            top: 12,
+            right: 24,
+            bottom: 12,
+            left: 24,
+          });
+        }
+        expect(entry.status).toBe("converted");
+        expect(entry.templaticalBlockType).toBe("button");
+      });
+    });
+
+    describe("parseHeadingLevel fallback", () => {
+      it("falls back to level 2 for an in-shape but out-of-range heading (h5)", () => {
+        const { block } = convertContent(
+          makeContent("heading", { headingType: "h5", text: "x" }),
+          [],
+        );
+        expect(block.type).toBe("title");
+        if (block.type === "title") {
+          expect(block.level).toBe(2);
+        }
+      });
+
+      it("falls back to level 2 for a double-digit heading (h7)", () => {
+        const { block } = convertContent(
+          makeContent("heading", { headingType: "h7", text: "x" }),
+          [],
+        );
+        expect(block.type).toBe("title");
+        if (block.type === "title") {
+          expect(block.level).toBe(2);
+        }
+      });
+
+      it("falls back to level 2 for a non-heading tag (span)", () => {
+        const { block } = convertContent(
+          makeContent("heading", { headingType: "span", text: "x" }),
+          [],
+        );
+        expect(block.type).toBe("title");
+        if (block.type === "title") {
+          expect(block.level).toBe(2);
+        }
+      });
+    });
+  });
 });

--- a/packages/media-library/tests/composable.test.ts
+++ b/packages/media-library/tests/composable.test.ts
@@ -937,6 +937,64 @@ describe('useMediaLibrary', () => {
       expect(lib.findFolderInTree([], 'any-id')).toBeNull();
     });
 
+    it('createFolder calls onError and returns null on failure', async () => {
+      const error = new Error('Create folder failed');
+      vi.mocked(MediaApiClient.prototype.createMediaFolder).mockRejectedValue(error);
+      const loadFoldersSpy = vi.mocked(MediaApiClient.prototype.getMediaFolders);
+      const callsBefore = loadFoldersSpy.mock.calls.length;
+
+      const onError = vi.fn();
+      const lib = useMediaLibrary({
+        projectId: 'proj-1',
+        authManager: createMockAuthManager(),
+        onError,
+      });
+
+      lib.folders.value = [createFolder('f1', 'Existing')];
+
+      const result = await lib.createFolder('New Folder', 'parent-1');
+
+      expect(result).toBeNull();
+      expect(onError).toHaveBeenCalledWith(error);
+      // The reject happens before loadFolders(), so the tree is not reloaded
+      // and existing folders state is left untouched.
+      expect(loadFoldersSpy.mock.calls.length - callsBefore).toBe(0);
+      expect(lib.folders.value).toHaveLength(1);
+      expect(lib.folders.value[0].id).toBe('f1');
+    });
+
+    it('deleteFolder calls onError and leaves state consistent on failure', async () => {
+      const error = new Error('Delete folder failed');
+      vi.mocked(MediaApiClient.prototype.deleteMediaFolder).mockRejectedValue(error);
+      const loadFoldersSpy = vi.mocked(MediaApiClient.prototype.getMediaFolders);
+      const browseSpy = vi.mocked(MediaApiClient.prototype.browseMedia);
+      const loadFoldersCallsBefore = loadFoldersSpy.mock.calls.length;
+      const browseCallsBefore = browseSpy.mock.calls.length;
+
+      const onError = vi.fn();
+      const lib = useMediaLibrary({
+        projectId: 'proj-1',
+        authManager: createMockAuthManager(),
+        onError,
+      });
+
+      lib.folders.value = [createFolder('f1', 'Parent', [createFolder('f2', 'Child')])];
+      lib.folders.value[0].children![0].parent_id = 'f1';
+      lib.currentFolderId.value = 'f2';
+
+      await lib.deleteFolder('f2');
+
+      expect(onError).toHaveBeenCalledWith(error);
+      // The deleteMediaFolder reject happens before currentFolderId is updated,
+      // so the current folder is NOT cleared and no stale reload runs.
+      expect(lib.currentFolderId.value).toBe('f2');
+      expect(loadFoldersSpy.mock.calls.length - loadFoldersCallsBefore).toBe(0);
+      expect(browseSpy.mock.calls.length - browseCallsBefore).toBe(0);
+      // Folder tree is left untouched.
+      expect(lib.folders.value).toHaveLength(1);
+      expect(lib.folders.value[0].id).toBe('f1');
+    });
+
     it('deleteFolder stays in current folder if different from deleted', async () => {
       vi.mocked(MediaApiClient.prototype.deleteMediaFolder).mockResolvedValue(undefined);
 
@@ -1056,6 +1114,31 @@ describe('useMediaLibrary', () => {
       expect(lib.pendingReplaceItem.value).toEqual(item);
       expect(lib.showReplaceWarning.value).toBe(true);
       expect(lib.replaceUsageInfo.value?.template_count).toBe(3);
+    });
+
+    it('checkUsageBeforeReplace calls onError and leaves warning closed on failure', async () => {
+      const error = new Error('Usage check failed');
+      vi.mocked(MediaApiClient.prototype.checkMediaUsage).mockRejectedValue(error);
+
+      const onError = vi.fn();
+      const lib = useMediaLibrary({
+        projectId: 'proj-1',
+        authManager: createMockAuthManager(),
+        onError,
+      });
+
+      const item = createMediaItem('m1');
+      await lib.checkUsageBeforeReplace(item);
+
+      expect(onError).toHaveBeenCalledWith(error);
+      // The reject happens before showReplaceWarning is set, so the warning
+      // stays closed and no usage info is recorded.
+      expect(lib.showReplaceWarning.value).toBe(false);
+      expect(lib.replaceUsageInfo.value).toBeNull();
+      // pendingReplaceItem is set up-front (before the await) and replaceError
+      // is reset to null at the start; both reflect that pre-await state.
+      expect(lib.pendingReplaceItem.value).toEqual(item);
+      expect(lib.replaceError.value).toBeNull();
     });
 
     it('cancelReplace clears all replace state', () => {

--- a/packages/media-library/tests/standalone-visual.test.ts
+++ b/packages/media-library/tests/standalone-visual.test.ts
@@ -424,6 +424,128 @@ describe('standalone visual', () => {
     expect(secondApp.mount).toHaveBeenCalledWith(container);
   });
 
+  it('resolves with an instance whose setTheme applies CSS variables to the container', async () => {
+    const mockAuthManager = {
+      projectId: 'proj-1',
+      tenantSlug: 'acme',
+      initialize: vi.fn().mockResolvedValue(undefined),
+      authenticatedFetch: vi.fn(),
+    };
+
+    const { createSdkAuthManager: mockCreateAuth } = await import(
+      '@templatical/core/cloud'
+    );
+    vi.mocked(mockCreateAuth).mockReturnValue(mockAuthManager as any);
+
+    const { ApiClient: MockApiClient } = await import(
+      '@templatical/core/cloud'
+    );
+    vi.mocked(MockApiClient).mockImplementation(function (this: any) {
+      this.fetchConfig = vi.fn().mockResolvedValue({ storage: {} });
+      return this;
+    } as any);
+
+    const { loadMediaTranslations: mockLoadTranslations } = await import(
+      '../src/i18n'
+    );
+    vi.mocked(mockLoadTranslations).mockResolvedValue({} as any);
+
+    // h captures the props passed to MediaLibrary so we can drive onReady.
+    const { h: mockH, createApp: mockCreateApp } = await import('vue');
+    let capturedOnReady: (() => void) | undefined;
+    vi.mocked(mockH).mockImplementation((_component: any, props: any) => {
+      capturedOnReady = props?.onReady;
+      return { __vnode: true } as any;
+    });
+
+    // createApp calls setup() to get the render fn, then invokes it so h runs
+    // and onReady is captured. mount() then simulates the MediaLibrary
+    // component signalling readiness by firing the captured onReady callback,
+    // which is what resolves the init() promise with the instance.
+    vi.mocked(mockCreateApp).mockImplementation((...args: any[]) => {
+      const component = args[0] as any;
+      const render = component?.setup?.();
+      render?.();
+      return {
+        mount: vi.fn(() => {
+          capturedOnReady?.();
+        }),
+        unmount: vi.fn(),
+      } as any;
+    });
+
+    const container = document.createElement('div');
+
+    const instance = await initFn({
+      container,
+      auth: { projectId: 'p1', token: 't1' },
+    } as any);
+
+    // The resolved instance exposes the documented surface.
+    expect(typeof instance.setTheme).toBe('function');
+    expect(typeof instance.unmount).toBe('function');
+    expect(capturedOnReady).toBeTypeOf('function');
+
+    // setTheme applies concrete CSS custom properties on the container.
+    instance.setTheme({ primaryColor: '#abc', borderRadius: 5 });
+
+    expect(container.style.getPropertyValue('--tpl-primary')).toBe('#abc');
+    expect(container.style.getPropertyValue('--tpl-radius')).toBe('5px');
+    expect(container.style.getPropertyValue('--tpl-radius-sm')).toBe('2px');
+    expect(container.style.getPropertyValue('--tpl-radius-lg')).toBe('9px');
+  });
+
+  it('rejects when createApp/mount throws', async () => {
+    const mockAuthManager = {
+      projectId: 'proj-1',
+      tenantSlug: 'acme',
+      initialize: vi.fn().mockResolvedValue(undefined),
+      authenticatedFetch: vi.fn(),
+    };
+
+    const { createSdkAuthManager: mockCreateAuth } = await import(
+      '@templatical/core/cloud'
+    );
+    vi.mocked(mockCreateAuth).mockReturnValue(mockAuthManager as any);
+
+    const { ApiClient: MockApiClient } = await import(
+      '@templatical/core/cloud'
+    );
+    vi.mocked(MockApiClient).mockImplementation(function (this: any) {
+      this.fetchConfig = vi.fn().mockResolvedValue({ storage: {} });
+      return this;
+    } as any);
+
+    const { loadMediaTranslations: mockLoadTranslations } = await import(
+      '../src/i18n'
+    );
+    vi.mocked(mockLoadTranslations).mockResolvedValue({} as any);
+
+    const mountError = new Error('mount blew up');
+    const { createApp: mockCreateApp } = await import('vue');
+    vi.mocked(mockCreateApp).mockImplementation((...args: any[]) => {
+      const component = args[0] as any;
+      if (component?.setup) {
+        component.setup();
+      }
+      return {
+        mount: vi.fn(() => {
+          throw mountError;
+        }),
+        unmount: vi.fn(),
+      } as any;
+    });
+
+    const container = document.createElement('div');
+
+    await expect(
+      initFn({
+        container,
+        auth: { projectId: 'p1', token: 't1' },
+      } as any),
+    ).rejects.toBe(mountError);
+  });
+
   it('passes locale to loadMediaTranslations', async () => {
     const mockAuthManager = {
       projectId: 'proj-1',

--- a/packages/media-library/vitest.config.ts
+++ b/packages/media-library/vitest.config.ts
@@ -1,15 +1,20 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
+import vue from "@vitejs/plugin-vue";
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
-    include: ['tests/**/*.test.ts'],
-    setupFiles: ['./tests/setup.ts'],
+    include: ["tests/**/*.test.ts"],
+    setupFiles: ["./tests/setup.ts"],
     coverage: {
-      provider: 'v8',
-      include: ['src/**/*.ts'],
-      exclude: ['src/**/*.d.ts', 'src/**/*.vue'],
-      reporter: ['text', 'json'],
-      reportsDirectory: './coverage',
+      provider: "v8",
+      // Include Vue SFCs so component logic (computeds, methods, branch
+      // conditions) is covered, not just the standalone modules and
+      // composables.
+      include: ["src/**/*.ts", "src/**/*.vue"],
+      exclude: ["src/**/*.d.ts"],
+      reporter: ["text", "json"],
+      reportsDirectory: "./coverage",
     },
   },
 });


### PR DESCRIPTION
Close meaningful test-coverage gaps and fix a BeeFree import bug

- `@templatical/import-beefree`: stop emitting a redundant `font-weight: 400` span (now matches `@templatical/import-unlayer`).
- `@templatical/editor`: export the merge-tag suggestion `render` factory so the popup lifecycle is unit-testable (behavior unchanged).
- Added regression tests across editor, import, and media-library packages, and started measuring Vue SFCs in coverage.