### PR TITLE
feat: rebase editor sizing to a fixed base size for independence from host `font-size`

### DIFF
--- a/.changeset/editor-base-size-rebase.md
+++ b/.changeset/editor-base-size-rebase.md
@@ -1,0 +1,10 @@
+---
+"@templatical/editor": patch
+"@templatical/media-library": patch
+---
+
+Make the editor and standalone media library independent of the host page's `html { font-size }` (#209).
+
+The UI's length scale (spacing, font sizes, border radii) is now anchored to a new `--tpl-user-base-size` token that defaults to a fixed `16px`, instead of `rem`. A `rem` always resolves against the document root — even inside the editor's shadow root — so a consumer design system that set e.g. `html { font-size: 8px }` previously shrank the entire editor. It no longer does.
+
+Consumers on a normal 16px root see identical sizing. To scale the whole UI, set `--tpl-user-base-size` on the editor container (or any ancestor): a px value to enlarge/compact (`18px`, `14px`), or a `rem` value such as `2rem` to deliberately track a custom root font-size. Email content on the canvas is unaffected — it uses the pixel sizes stored on each block.

--- a/apps/docs/de/guide/theming.md
+++ b/apps/docs/de/guide/theming.md
@@ -69,6 +69,7 @@ Jedes Token folgt derselben Form: Deklarieren Sie `--tpl-user-<name>` auf dem Co
 | `--tpl-user-danger`          | Gefahren-/Fehlerfarbe                      |
 | `--tpl-user-danger-light`    | Gefahr getönter Hintergrund                |
 | `--tpl-user-canvas-bg`       | Canvas-Bereich hinter dem E-Mail-Template  |
+| `--tpl-user-base-size`       | Größeneinheit der Editor-UI (`16px`) — siehe [Editor-Größe](#editor-groesse) |
 | `--tpl-user-radius`          | Standard-Rahmenradius (`10px`)             |
 | `--tpl-user-radius-sm`       | Kleiner Rahmenradius (`7px`)               |
 | `--tpl-user-radius-lg`       | Großer Rahmenradius (`14px`)               |
@@ -101,6 +102,34 @@ Der Dark-Modus verwendet einen parallelen `--tpl-user-dark-*`-Namensraum, sodass
 Ersetzen Sie `--tpl-user-` durch `--tpl-user-dark-` in jedem Token-Namen aus der obigen Tabelle, um den Dark-Modus anzusprechen. Der Editor aktiviert den Dark-Modus über `data-tpl-theme="dark"` auf seinem Root und liest die Dark-Namespace-Defaults; Ihre `--tpl-user-dark-*`-Überschreibungen klinken sich dort ein.
 
 Der Dark-Modus ist über die `uiTheme`-Konfiguration optional — setzen Sie `'dark'` oder `'auto'`, um ihn zu aktivieren. Siehe [Dark Mode](#dark-mode) unten.
+
+## Editor-Größe und die Root-Schriftgröße der Host-Seite {#editor-groesse}
+
+Die UI-Größe des Editors — Abstände, Schriftgrößen, Rahmenradien — ist an eine einzige Basiseinheit gebunden, `--tpl-user-base-size`, die standardmäßig **`16px`** beträgt.
+
+Da der Standardwert ein fester Pixelwert ist (kein `rem`), **wird der Editor unabhängig von der Root-Schriftgröße Ihrer Seite in einer konstanten Größe dargestellt.** Wenn Ihr Design-System ein eigenes `html { font-size }` setzt — etwa `8px`, damit `1rem = 8px` gilt — bleibt der Editor davon unberührt und behält seine beabsichtigte Größe. (Ein `rem` bezieht sich immer auf das Dokument-Root, auch innerhalb des Shadow-Roots des Editors, sodass eine eigene Root-Schriftgröße ohne diesen Anker den gesamten Editor vergrößern oder verkleinern würde.)
+
+### Editor vergrößern oder verkleinern
+
+Setzen Sie `--tpl-user-base-size` auf dem Container (oder einem beliebigen Vorfahren), um die gesamte Editor-UI proportional zu skalieren:
+
+```css
+#editor {
+  --tpl-user-base-size: 18px; /* ~12% größere UI, Text, Abstände, Radien */
+}
+```
+
+```css
+#editor {
+  --tpl-user-base-size: 14px; /* kompakter */
+}
+```
+
+Jede CSS-Länge funktioniert. Wenn der Editor doch der eigenen Root-Schriftgröße folgen soll, setzen Sie einen `rem`-Wert — z. B. ergibt `--tpl-user-base-size: 2rem` bei einem `8px`-Root genau `16px`.
+
+Dies betrifft nur die **Editor-Oberfläche**. Der E-Mail-Inhalt auf dem Canvas verwendet die auf jedem Block gespeicherten Pixelgrößen, sodass Ihr Template unabhängig von der Skalierung der Editor-UI identisch gerendert wird.
+
+Derselbe `--tpl-user-base-size`-Schalter gilt für das eigenständige [`@templatical/media-library`](../cloud/media-library)-SDK. Wie jede `--tpl-user-*`-Variable funktioniert er in Shadow-DOM- und Light-DOM-Modus identisch.
 
 ## ThemeOverrides-Konfiguration
 

--- a/apps/docs/guide/theming.md
+++ b/apps/docs/guide/theming.md
@@ -69,6 +69,7 @@ Every token follows the same shape: declare `--tpl-user-<name>` on the container
 | `--tpl-user-danger`          | Danger/error state color              |
 | `--tpl-user-danger-light`    | Danger tinted background              |
 | `--tpl-user-canvas-bg`       | Canvas area behind the email template |
+| `--tpl-user-base-size`       | Editor UI sizing unit (`16px`) — see [Editor size](#editor-size-and-the-host-root-font-size) |
 | `--tpl-user-radius`          | Default border radius (`10px`)        |
 | `--tpl-user-radius-sm`       | Small border radius (`7px`)           |
 | `--tpl-user-radius-lg`       | Large border radius (`14px`)          |
@@ -101,6 +102,34 @@ Dark mode uses a parallel `--tpl-user-dark-*` namespace, so you can theme light 
 Replace `--tpl-user-` with `--tpl-user-dark-` in any token name from the table above to target dark mode. The editor activates dark mode via `data-tpl-theme="dark"` on its root and reads the dark-namespace defaults; your `--tpl-user-dark-*` overrides plug in there.
 
 Dark mode is opt-in via the `uiTheme` config — set `'dark'` or `'auto'` to enable. See [Dark mode](#dark-mode) below.
+
+## Editor size and the host root font-size
+
+The editor's UI sizing — spacing, font sizes, border radii — is anchored to a single base unit, `--tpl-user-base-size`, which defaults to **`16px`**.
+
+Because the default is a fixed pixel value (not `rem`), **the editor renders at a consistent size regardless of your page's root font-size.** If your design system sets a custom `html { font-size }` — for example `8px` to make `1rem = 8px` — the editor is unaffected and stays at its intended size. (A `rem` always resolves against the document root, even inside the editor's shadow root, so without this anchor a custom root font-size would scale the whole editor up or down.)
+
+### Scaling the editor up or down
+
+Set `--tpl-user-base-size` on the container (or any ancestor) to scale the entire editor UI proportionally:
+
+```css
+#editor {
+  --tpl-user-base-size: 18px; /* ~12% larger chrome, text, spacing, radii */
+}
+```
+
+```css
+#editor {
+  --tpl-user-base-size: 14px; /* more compact */
+}
+```
+
+Any CSS length works. If you prefer the editor to track your custom root font-size after all, set a `rem` value — e.g. `--tpl-user-base-size: 2rem` against an `8px` root resolves to `16px`.
+
+This affects the **editor chrome** only. The email content on the canvas uses the pixel sizes stored on each block, so your template renders identically no matter how the editor UI is scaled.
+
+The same `--tpl-user-base-size` knob applies to the standalone [`@templatical/media-library`](../cloud/media-library) SDK. Like every `--tpl-user-*` variable, it works identically in shadow-DOM and light-DOM modes.
 
 ## ThemeOverrides config
 

--- a/packages/editor/src/components/MergeTagTextarea.vue
+++ b/packages/editor/src/components/MergeTagTextarea.vue
@@ -42,7 +42,7 @@ const {
 const textareaClass =
   "tpl:w-full tpl:resize-y tpl:rounded-[var(--tpl-radius-sm)] tpl:border tpl:shadow-xs tpl:border-[var(--tpl-border)] tpl:bg-[var(--tpl-bg)] tpl:px-3 tpl:py-2 tpl:text-sm tpl:text-[var(--tpl-text)] tpl:outline-none tpl:transition-all tpl:duration-[120ms] tpl:ease-[cubic-bezier(0.16,1,0.3,1)] tpl:placeholder:text-[var(--tpl-text-dim)] tpl:focus:border-[var(--tpl-primary)] tpl:focus:shadow-[var(--tpl-ring)]";
 const displayClass =
-  "tpl:flex tpl:w-full tpl:min-h-[5rem] tpl:cursor-pointer tpl:items-start tpl:flex-wrap tpl:gap-1 tpl:rounded-[var(--tpl-radius-sm)] tpl:border tpl:shadow-xs tpl:bg-[var(--tpl-bg)] tpl:border-[var(--tpl-border)] tpl:px-3 tpl:py-2 tpl:transition-all tpl:duration-[120ms] tpl:ease-[cubic-bezier(0.16,1,0.3,1)]";
+  "tpl:flex tpl:w-full tpl:min-h-20 tpl:cursor-pointer tpl:items-start tpl:flex-wrap tpl:gap-1 tpl:rounded-[var(--tpl-radius-sm)] tpl:border tpl:shadow-xs tpl:bg-[var(--tpl-bg)] tpl:border-[var(--tpl-border)] tpl:px-3 tpl:py-2 tpl:transition-all tpl:duration-[120ms] tpl:ease-[cubic-bezier(0.16,1,0.3,1)]";
 </script>
 
 <template>

--- a/packages/editor/src/components/blocks/TableBlock.vue
+++ b/packages/editor/src/components/blocks/TableBlock.vue
@@ -151,7 +151,8 @@ function onCellBlur(rowId: string, cellId: string, event: FocusEvent): void {
 .tpl-table-editable :deep(td[contenteditable]) {
   outline: none;
   cursor: text;
-  min-width: 2rem;
+  /* base-size-relative (issue #209) — not `rem`, which couples to host html font-size */
+  min-width: calc(2 * var(--tpl-base-size));
 }
 
 .tpl-table-editable :deep(th[contenteditable]:empty::before),

--- a/packages/editor/src/styles/index.css
+++ b/packages/editor/src/styles/index.css
@@ -19,6 +19,37 @@
         'Geist', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
         'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
+    /* Base-size rebase (issue #209) — anchor every Tailwind length scale to
+     * `--tpl-base-size` (a fixed px on `.tpl`, below) instead of `rem`, so the
+     * editor is immune to the host page's `html { font-size }`. `rem` always
+     * resolves against the document root — even inside a shadow root — so a
+     * consumer's `html { font-size: 8px }` would otherwise shrink the whole
+     * editor. Consumers scale the editor as a whole via `--tpl-user-base-size`.
+     *
+     * Each value carries `var(--tpl-base-size)` into the inlined utility: the
+     * var survives `theme(inline)` because it can't be statically folded, and
+     * resolves on `.tpl` *inside* the shadow root (a `:root`-scoped var would
+     * be unreachable there). Only the scale steps the editor actually uses are
+     * overridden — `tests/rem-rebase-audit.test.ts` fails if a new utility
+     * reintroduces a raw `rem`, prompting the matching token to be added here. */
+    --spacing: calc(var(--tpl-base-size) / 4);
+
+    --text-xs: calc(0.75 * var(--tpl-base-size));
+    --text-sm: calc(0.875 * var(--tpl-base-size));
+    --text-base: var(--tpl-base-size);
+    --text-lg: calc(1.125 * var(--tpl-base-size));
+    --text-4xl: calc(2.25 * var(--tpl-base-size));
+
+    --radius: calc(0.25 * var(--tpl-base-size));
+    --radius-sm: calc(0.25 * var(--tpl-base-size));
+    --radius-md: calc(0.375 * var(--tpl-base-size));
+    --radius-lg: calc(0.5 * var(--tpl-base-size));
+    --radius-xl: calc(0.75 * var(--tpl-base-size));
+
+    --container-sm: calc(24 * var(--tpl-base-size));
+    --container-md: calc(28 * var(--tpl-base-size));
+    --container-2xl: calc(42 * var(--tpl-base-size));
+
     /* Z-index scale — semantic layers for stacking context */
     --z-panel: 45;
     --z-toast: 60;
@@ -47,6 +78,15 @@
  * win over both because inline specificity beats class specificity.
  */
 .tpl {
+    /* Base sizing unit (issue #209). A fixed px so the editor is independent
+     * of the host's `html { font-size }`; defined on `.tpl` so it resolves
+     * inside the shadow root. Consumers set `--tpl-user-base-size` (on the
+     * container or any ancestor) to scale the whole editor — e.g. `2rem` to
+     * compensate an `8px` design-system root, or `20px` to enlarge. The whole
+     * Tailwind length scale (spacing, text, radius, containers) derives from
+     * this via the `@theme inline` overrides above. */
+    --tpl-base-size: var(--tpl-user-base-size, 16px);
+
     /* Warm palette */
     --tpl-bg: var(--tpl-user-bg, oklch(99.5% 0.002 60));
     --tpl-bg-elevated: var(--tpl-user-bg-elevated, oklch(98% 0.004 60));

--- a/packages/editor/tests/rem-rebase-audit.test.ts
+++ b/packages/editor/tests/rem-rebase-audit.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Guards the issue #209 fix: the editor's Tailwind length scale is rebased off
+ * a fixed-px `--tpl-base-size` instead of `rem`, so the editor is immune to the
+ * host page's `html { font-size }`. `rem` always resolves against the document
+ * root — even inside a shadow root — so a consumer's `html { font-size: 8px }`
+ * would otherwise render the whole editor at half size.
+ *
+ * Two regressions are locked here, and they catch opposite failure modes:
+ *
+ *   1. A raw `rem` reappears in a `.tpl:`-prefixed utility — e.g. a new utility
+ *      (`text-2xl`, `rounded-2xl`, a new `--container-*`) whose token wasn't
+ *      added to the `@theme inline` override block in `src/styles/index.css`,
+ *      or one of the existing overrides is dropped. Fix: add/restore the
+ *      matching `--<token>: calc(<ratio> * var(--tpl-base-size))` override.
+ *
+ *   2. The base unit's default is switched back to a `rem` value. That would
+ *      hide the `rem` inside `var(--tpl-base-size)` — so check #1 would still
+ *      pass while the bug silently returns. The default MUST be a px length.
+ *
+ * Runs against the built `dist/style.css`. Requires `pnpm run build` first; in
+ * CI the test job runs after build (see .github/workflows/ci.yml). The CDN
+ * bundle (`dist/cdn/editor.css`) compiles from the same `src/styles/index.css`,
+ * so this npm-CSS check covers it too.
+ */
+
+const STYLE_CSS = join(import.meta.dirname, "..", "dist", "style.css");
+
+/** Every compiled `.tpl\:<util>{…}` rule block in the stylesheet. */
+function tplUtilityRules(css: string): string[] {
+  // Minified output: `.tpl\:p-4{padding:calc(...)}`. The colon is
+  // backslash-escaped in the selector, hence `\\:` in the pattern.
+  return css.match(/\.tpl\\:[^{]+\{[^}]*\}/g) ?? [];
+}
+
+describe("editor rem-rebase audit (issue #209)", () => {
+  let css: string;
+
+  beforeAll(() => {
+    if (!existsSync(STYLE_CSS)) {
+      throw new Error(
+        `dist/style.css not found. Run \`pnpm --filter @templatical/editor run build\` before this test.`,
+      );
+    }
+    css = readFileSync(STYLE_CSS, "utf8");
+  });
+
+  it("defines --tpl-base-size on .tpl with a px default (never rem)", () => {
+    const match = css.match(
+      /--tpl-base-size:\s*var\(--tpl-user-base-size,\s*(\d+(?:\.\d+)?)(px|rem)\)/,
+    );
+    expect(match, "--tpl-base-size declaration not found in compiled CSS").not.toBeNull();
+    // The fallback unit decides whether the editor is immune to the host root
+    // font-size. A `rem` fallback would reintroduce the bug while sneaking past
+    // the no-raw-rem check below.
+    expect(match![2]).toBe("px");
+    expect(Number(match![1])).toBe(16);
+  });
+
+  it("emits no .tpl: utility with a raw rem value (all are rebased onto --tpl-base-size)", () => {
+    const offenders = tplUtilityRules(css).filter((rule) => /[0-9.]+rem\b/.test(rule));
+    expect(
+      offenders,
+      `Found .tpl: utilities still using raw rem (couples them to the host html ` +
+        `font-size). Add a calc(<ratio> * var(--tpl-base-size)) override for each ` +
+        `token to @theme inline in src/styles/index.css (issue #209):\n` +
+        offenders.join("\n"),
+    ).toEqual([]);
+  });
+
+  it("rebases the representative spacing / text / radius utilities onto --tpl-base-size", () => {
+    // Inverse guard: if `theme(inline)` stops carrying the var (e.g. the import
+    // mode changes) these would fold back to literals and #2 would still pass
+    // only because the literals happen to be px — so assert the var is present.
+    const expectVarBased = (selector: string) => {
+      const rule = tplUtilityRules(css).find((r) => r.startsWith(selector + "{"));
+      expect(rule, `utility ${selector} not found in compiled CSS`).toBeDefined();
+      expect(rule).toContain("var(--tpl-base-size)");
+    };
+    expectVarBased(".tpl\\:p-4");
+    expectVarBased(".tpl\\:text-sm");
+    expectVarBased(".tpl\\:rounded");
+    expectVarBased(".tpl\\:size-8");
+  });
+});

--- a/packages/media-library/src/styles/index.css
+++ b/packages/media-library/src/styles/index.css
@@ -18,6 +18,26 @@
     --font-sans:
         'Geist', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
         'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+
+    /* Base-size rebase (issue #209) — anchor Tailwind's length scales to
+     * `--tpl-base-size` (a fixed px on `.tpl`, below) instead of `rem`, so the
+     * standalone media library is immune to the host page's `html { font-size }`.
+     * `rem` always resolves against the document root, even inside a shadow
+     * root. The `var(--tpl-base-size)` reference survives `theme(inline)` and
+     * resolves on `.tpl`. Consumers scale via `--tpl-user-base-size`. Only the
+     * scale steps the package uses are overridden. */
+    --spacing: calc(var(--tpl-base-size) / 4);
+
+    --text-xs: calc(0.75 * var(--tpl-base-size));
+    --text-sm: calc(0.875 * var(--tpl-base-size));
+
+    --radius: calc(0.25 * var(--tpl-base-size));
+    --radius-sm: calc(0.25 * var(--tpl-base-size));
+    --radius-md: calc(0.375 * var(--tpl-base-size));
+    --radius-lg: calc(0.5 * var(--tpl-base-size));
+
+    --container-sm: calc(24 * var(--tpl-base-size));
+    --container-2xl: calc(42 * var(--tpl-base-size));
 }
 
 /* Source paths for Tailwind scanning */
@@ -26,6 +46,13 @@
 
 /* SDK CSS Variables - Default theme, can be overridden via inline styles */
 .tpl {
+    /* Base sizing unit (issue #209). A fixed px so the media library is
+     * independent of the host's `html { font-size }`; defined on `.tpl` so it
+     * resolves inside the shadow root. Consumers set `--tpl-user-base-size` to
+     * scale the whole UI. The Tailwind length scale derives from this via the
+     * `@theme inline` overrides above. */
+    --tpl-base-size: var(--tpl-user-base-size, 16px);
+
     /* Warm palette */
     --tpl-bg: oklch(99.5% 0.002 60);
     --tpl-bg-elevated: oklch(98% 0.004 60);

--- a/packages/media-library/tests/rem-rebase-audit.test.ts
+++ b/packages/media-library/tests/rem-rebase-audit.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Guards the issue #209 fix for the standalone media library: its Tailwind
+ * length scale is rebased off a fixed-px `--tpl-base-size` instead of `rem`, so
+ * the media SDK is immune to the host page's `html { font-size }`. `rem` always
+ * resolves against the document root — even inside a shadow root.
+ *
+ * Locks two opposite regressions (see the editor's rem-rebase-audit for the
+ * detailed rationale):
+ *   1. A raw `rem` reappears in a `.tpl:` utility (a token override is missing
+ *      or was dropped) — add a calc(<ratio> * var(--tpl-base-size)) override to
+ *      @theme inline in src/styles/index.css.
+ *   2. The base default is switched back to a rem value — it MUST stay px, or
+ *      the bug returns hidden inside var(--tpl-base-size) while check #1 passes.
+ *
+ * Runs against the built CSS. Requires `pnpm run build` first; in CI the test
+ * job runs after build.
+ */
+
+const STYLE_CSS = join(
+  import.meta.dirname,
+  "..",
+  "dist",
+  "templatical-media-library.css",
+);
+
+function tplUtilityRules(css: string): string[] {
+  return css.match(/\.tpl\\:[^{]+\{[^}]*\}/g) ?? [];
+}
+
+describe("media-library rem-rebase audit (issue #209)", () => {
+  let css: string;
+
+  beforeAll(() => {
+    if (!existsSync(STYLE_CSS)) {
+      throw new Error(
+        `dist CSS not found. Run \`pnpm --filter @templatical/media-library run build\` before this test.`,
+      );
+    }
+    css = readFileSync(STYLE_CSS, "utf8");
+  });
+
+  it("defines --tpl-base-size on .tpl with a px default (never rem)", () => {
+    const match = css.match(
+      /--tpl-base-size:\s*var\(--tpl-user-base-size,\s*(\d+(?:\.\d+)?)(px|rem)\)/,
+    );
+    expect(match, "--tpl-base-size declaration not found in compiled CSS").not.toBeNull();
+    expect(match![2]).toBe("px");
+    expect(Number(match![1])).toBe(16);
+  });
+
+  it("emits no .tpl: utility with a raw rem value (all are rebased onto --tpl-base-size)", () => {
+    const offenders = tplUtilityRules(css).filter((rule) => /[0-9.]+rem\b/.test(rule));
+    expect(
+      offenders,
+      `Found .tpl: utilities still using raw rem (couples them to the host html ` +
+        `font-size). Add a calc(<ratio> * var(--tpl-base-size)) override for each ` +
+        `token to @theme inline in src/styles/index.css (issue #209):\n` +
+        offenders.join("\n"),
+    ).toEqual([]);
+  });
+
+  it("rebases representative spacing / text / radius utilities onto --tpl-base-size", () => {
+    const expectVarBased = (selector: string) => {
+      const rule = tplUtilityRules(css).find((r) => r.startsWith(selector + "{"));
+      expect(rule, `utility ${selector} not found in compiled CSS`).toBeDefined();
+      expect(rule).toContain("var(--tpl-base-size)");
+    };
+    expectVarBased(".tpl\\:p-4");
+    expectVarBased(".tpl\\:text-sm");
+    expectVarBased(".tpl\\:rounded");
+  });
+});


### PR DESCRIPTION
Closes #209.