### PR TITLE
fix: editor primary buttons no longer render with a transparent background

### DIFF
--- a/.changeset/fix-media-library-button-reset-specificity.md
+++ b/.changeset/fix-media-library-button-reset-specificity.md
@@ -1,0 +1,8 @@
+---
+"@templatical/editor": patch
+"@templatical/media-library": patch
+---
+
+Fix: editor primary buttons no longer render with a transparent background in bundled/CDN builds (#357)
+
+`@templatical/media-library`'s shared `.tpl` form-element reset authored its button reset as a bare `.tpl button { background: none; border: none }` (specificity 0,1,1). Because `@templatical/editor` bundles these styles and shares the `.tpl` scope class, that reset out-specified the editor's single-class button utilities such as `.tpl:bg-[var(--tpl-primary)]` (0,1,0) — rendering the Insert/Update Link dialog's primary action button with a transparent background (invisible on light backgrounds) and stripping button borders. It surfaced in the CDN bundle and in any app that bundles the editor from source (e.g. the deployed playground); the npm `dist` was unaffected because it externalizes media-library. The reset is now `:where(.tpl) button` (specificity 0,0,1), matching the editor's own reset, so per-button utilities always win.

--- a/.changeset/fix-media-library-reset-parity.md
+++ b/.changeset/fix-media-library-reset-parity.md
@@ -1,0 +1,7 @@
+---
+"@templatical/media-library": patch
+---
+
+Fix: media-library form controls size with `border-box` and show a keyboard focus ring
+
+This package's shared `.tpl` form-element reset diverged from the editor's in two ways. It omitted `box-sizing: border-box`, so — with Tailwind preflight disabled — a padded `tpl:w-full` input resolved to `width: 100%` + horizontal padding and could overflow its parent (the issue #115 class of bug). It also set `outline: none` unconditionally on every `.tpl button`, removing the keyboard focus ring entirely (an accessibility regression). The reset now matches the editor's: `box-sizing: border-box` on the form-control group, and `outline: none` scoped to `:where(.tpl) button:focus-visible` (plus input/select/textarea) paired with the existing `--tpl-ring` box-shadow so keyboard focus stays visible.

--- a/packages/media-library/src/styles/index.css
+++ b/packages/media-library/src/styles/index.css
@@ -145,19 +145,40 @@
     font-family: var(--tpl-font-family);
 }
 
-/* Form element reset - Preflight is omitted so form elements use browser defaults */
-.tpl button,
-.tpl input,
-.tpl select,
-.tpl textarea {
+/* Form element reset — Preflight is omitted so form controls use browser
+   defaults. `:where()` drops the scope to zero specificity so per-element
+   utilities (e.g. `tpl:bg-[…]`, `tpl:border`) always win. This is critical
+   because the SDK shares the `.tpl` class with `@templatical/editor`, which
+   bundles these styles: a bare `.tpl button` (specificity 0,1,1) would
+   out-specify the editor's single-class button utilities (0,1,0) and render
+   primary buttons transparent + strip their borders (issue #357). Mirrors the
+   editor's reset in `packages/editor/src/styles/index.css`.
+
+   `box-sizing: border-box` is required here because Tailwind preflight (which
+   would set it universally) is disabled. Without it, `tpl:w-full` on a padded
+   input resolves to `width: 100%` + horizontal padding and overflows its
+   parent — see issue #115. */
+:where(.tpl) button,
+:where(.tpl) input,
+:where(.tpl) select,
+:where(.tpl) textarea {
     font-family: inherit;
+    box-sizing: border-box;
 }
 
-.tpl button {
+:where(.tpl) button {
     border: none;
-    outline: none;
     background: none;
     cursor: pointer;
+}
+
+/* Focus ring — visible only for keyboard navigation */
+:where(.tpl) button:focus-visible,
+:where(.tpl) input:focus-visible,
+:where(.tpl) select:focus-visible,
+:where(.tpl) textarea:focus-visible {
+    outline: none;
+    box-shadow: var(--tpl-ring);
 }
 
 /* Scrollbar Styles */

--- a/packages/media-library/tests/button-reset-specificity-audit.test.ts
+++ b/packages/media-library/tests/button-reset-specificity-audit.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Audits this package's `.tpl` form-element reset (`src/styles/index.css`),
+ * which must stay in lockstep with the editor's reset
+ * (`packages/editor/src/styles/index.css`). The two packages share the `.tpl`
+ * SDK class and `@templatical/editor` bundles these styles (CDN build + any
+ * consumer bundling both from source), so a divergence here regresses the
+ * editor.
+ *
+ * Reads source (not dist) so it locks the authoring decisions directly and does
+ * not depend on the build preserving `:where()`.
+ */
+
+const INDEX_CSS = join(import.meta.dirname, "..", "src", "styles", "index.css");
+
+// Strip CSS comments so prose mentioning selectors (e.g. the rationale above
+// the reset) can't trip the checks below.
+const css = readFileSync(INDEX_CSS, "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+
+/** The base `:where(.tpl) button { … }` rule (NOT the `:focus-visible` one). */
+function baseButtonRule(): string | undefined {
+  return css.match(/:where\(\.tpl\)\s+button\s*\{[^}]*\}/)?.[0];
+}
+
+/** The reset rule that carries `font-family: inherit` (the form-control group). */
+function formControlGroupRule(): string | undefined {
+  return css
+    .match(/:where\(\.tpl\)[^{]*\{[^}]*\}/g)
+    ?.find((rule) => /font-family:\s*inherit/.test(rule));
+}
+
+describe("media-library button reset specificity audit (issue #357)", () => {
+  it("scopes the button appearance reset with :where() (zero specificity)", () => {
+    const rule = baseButtonRule();
+    expect(
+      rule,
+      "no `:where(.tpl) button { … }` reset found in src/styles/index.css",
+    ).toBeDefined();
+    expect(rule).toContain("background: none");
+    expect(rule).toContain("border: none");
+  });
+
+  it("never authors a bare `.tpl button` reset (0,1,1 out-specifies utilities — #357)", () => {
+    // `\.tpl\s+button` matches a bare `.tpl button` selector but NOT
+    // `:where(.tpl) button` (there `.tpl` is followed by `)`, not whitespace)
+    // and NOT `.tpl-*` classes (followed by `-`, not whitespace).
+    const bare = css.match(/\.tpl\s+button/);
+    expect(
+      bare,
+      `Found a bare \`.tpl button\` selector (specificity 0,1,1) in ` +
+        `src/styles/index.css. It out-specifies single-class button utilities ` +
+        `(e.g. \`.tpl:bg-[var(--tpl-primary)]\`, 0,1,0) and reintroduces the ` +
+        `invisible-primary-button regression (#357). Scope it with ` +
+        `\`:where(.tpl) button\` instead.\n` +
+        `Match: ${bare?.[0]}`,
+    ).toBeNull();
+  });
+});
+
+describe("media-library reset parity with the editor", () => {
+  it("sets box-sizing: border-box on the form-control reset (issue #115)", () => {
+    // Preflight is omitted, so without this a padded `tpl:w-full` input
+    // resolves to width:100% + padding and overflows its parent (#115).
+    const rule = formControlGroupRule();
+    expect(
+      rule,
+      "no `:where(.tpl) …` reset carrying `font-family: inherit` found",
+    ).toBeDefined();
+    expect(rule).toContain("box-sizing: border-box");
+  });
+
+  it("keeps outline off the base button rule and moves it to :focus-visible with a ring (a11y)", () => {
+    // An unconditional `outline: none` on `.tpl button` removes the keyboard
+    // focus ring entirely. The reset must only drop the outline for
+    // `:focus-visible`, replacing it with the `--tpl-ring` box-shadow.
+    const base = baseButtonRule();
+    expect(base, "base `:where(.tpl) button` rule not found").toBeDefined();
+    expect(
+      /outline/.test(base!),
+      `Base \`:where(.tpl) button\` rule sets \`outline\` unconditionally — ` +
+        `that kills the keyboard focus ring. Move it to a \`:focus-visible\` ` +
+        `rule instead.\nRule: ${base}`,
+    ).toBe(false);
+
+    const focusRule = css.match(
+      /:where\(\.tpl\)\s+button:focus-visible[^{]*\{[^}]*\}/,
+    )?.[0];
+    expect(
+      focusRule,
+      "no `:where(.tpl) button:focus-visible { … }` focus-ring rule found",
+    ).toBeDefined();
+    expect(focusRule).toContain("outline: none");
+    expect(focusRule).toContain("box-shadow: var(--tpl-ring)");
+  });
+});


### PR DESCRIPTION
Closes #357.