### PR TITLE
#406 Toggle switches render misaligned because native <button> padding is not reset

### DIFF
--- a/.changeset/shaggy-mails-send.md
+++ b/.changeset/shaggy-mails-send.md
@@ -1,0 +1,5 @@
+---
+"@templatical/editor": major
+---
+
+Toggle switches render misaligned because native <button> padding is not reset

--- a/packages/editor/src/components/ToggleSwitch.vue
+++ b/packages/editor/src/components/ToggleSwitch.vue
@@ -29,7 +29,7 @@ const emit = defineEmits<{
       :aria-label="label"
       :disabled="disabled"
       :class="[
-        'tpl:relative tpl:inline-flex tpl:h-5 tpl:w-9 tpl:shrink-0 tpl:rounded-full tpl:border-2 tpl:border-transparent tpl:transition-colors tpl:duration-200',
+        'tpl:relative tpl:inline-flex tpl:h-5 tpl:w-9 tpl:p-0 tpl:shrink-0 tpl:rounded-full tpl:border-2 tpl:border-transparent tpl:transition-colors tpl:duration-200',
         modelValue
           ? 'tpl:bg-[var(--tpl-primary)]'
           : 'tpl:bg-[var(--tpl-border)]',


### PR DESCRIPTION
<!--
Thanks for contributing to Templatical!

Before submitting, please skim CONTRIBUTING.md if you haven't already.
Keep PRs small and focused — one concern per PR.
-->

## Summary

Adds `tpl:p-0` to the two toggle-switch `<button>`s (template-settings "link underline" toggle and the boolean `ToggleField`).

The switches relied on Tailwind preflight to zero out the browser's default button padding (e.g. `padding: 1px 6px` in Chromium). Since the library ships prefixed utilities without preflight, host apps that don't include their own button reset get the UA padding inside the switch pill, pushing the knob out
of position.

With the explicit `tpl:p-0` the switch renders correctly regardless of host-page CSS.

## Linked issues

fixes #406

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Tests / tooling / CI
- [ ] Dependency update

## Affected packages

<!-- Check all that apply. -->

- [x] `@templatical/editor`
- [ ] `@templatical/core` (or `@templatical/core/cloud`)
- [ ] `@templatical/media-library`
- [ ] `@templatical/types`
- [ ] `@templatical/renderer`
- [ ] `@templatical/import-beefree`
- [ ] `apps/playground`
- [ ] `apps/docs`
- [ ] Tooling / CI / repo config

## Checklist

- [ ] Tests added or updated (and they fail without my change)
- [x] `pnpm run ci` passes locally (lint + typecheck + build + test)
- [x] `pnpm run test:e2e` passes (only if this PR touches editor UI)
- [ ] Docs updated — both `apps/docs/<page>.md` and `apps/docs/de/<page>.md` if user-facing
- [ ] i18n keys added to both `en.ts` and `de.ts` if I added new strings
- [x] Changeset added (`pnpm exec changeset`) — required for any change to a published package
- [ ] PR title is descriptive and follows the existing convention

## Screenshots / recordings

<!-- For UI changes, add before/after screenshots or a short Loom/GIF. Delete this section otherwise. -->

## Notes for reviewers

<!-- Anything specific you'd like feedback on, areas to scrutinize, or known limitations. -->
