### PR TITLE
refactor: SDK chunk optimizaion

### DIFF
--- a/.changeset/cdn-lazy-loading.md
+++ b/.changeset/cdn-lazy-loading.md
@@ -1,0 +1,21 @@
+---
+"@templatical/editor": patch
+---
+
+Stop the CDN bundle eagerly shipping lazy-loaded components.
+
+Two independent causes of the same bug: code behind `defineAsyncComponent` was ending up in the entry's static-import closure, so it downloaded on every editor load regardless of whether it was ever used.
+
+**1. The `features` manual chunk.** `vite.cdn.config.ts` grouped six `defineAsyncComponent` cloud panels — AI chat, comments, design reference, template scoring, test email and snapshot history — into a single chunk that was statically reachable from the entry. Every Cloud session downloaded all **66.5 KB gzip** of it whether or not the user opened a single panel. `manualChunks` now groups third-party dependencies only; first-party source splits at its own dynamic-import boundaries.
+
+**2. A duplicate countdown registration.** `countdown` requires Templatical Cloud (its animated GIF renders server-side), so `useEditorCore` registers it as a lazy `defineAsyncComponent`. `Canvas.vue` also listed it in its static `blockComponentMap` — the only one of the four fallback maps that did. Because `resolveBlockComponent` checks the registry first, that entry was unreachable at runtime, but its static `import` still pulled the module into the eager graph. The registry is now the single source, matching `SectionBlock`, `SavedBlockPreviewCanvas` and `PreviewSectionBlock`.
+
+Measured on the CDN build:
+
+- Eager payload (what every session fetches before opening anything): **337.1 → 329.5 KB gzip**.
+- Opening one cloud panel: **0 KB (already paid up front) → 1.7–5.0 KB**, charged only to users who open it. All six in one session: **18.3 KB** across 7 chunks.
+- Eager chunk count rises 14 → 27 while bytes fall, and waterfall depth only moves 5 → 6 — so the extra chunks are fetched in parallel rather than costing round-trips.
+
+Removing only the `features` group would have made things worse: `media-library` becomes the next eager bridge and the eager payload grows 32.7 KB. Grouping first-party source is what creates the bridge, so the rule is a ban rather than a curated list. Guarded by a new `cdn-chunk-granularity` test — `bundle-topology` deliberately skips `dist/cdn/`, which is why this went unnoticed.
+
+No API change and no behaviour change: countdown blocks and all six panels render exactly as before. CDN consumers get a smaller initial download and genuinely on-demand panels; npm consumers are unaffected (that build has no `manualChunks`).

--- a/packages/editor/src/components/Canvas.vue
+++ b/packages/editor/src/components/Canvas.vue
@@ -38,8 +38,14 @@ import MenuBlock from "./blocks/MenuBlock.vue";
 import TableBlock from "./blocks/TableBlock.vue";
 import CustomBlock from "./blocks/CustomBlock.vue";
 import VideoBlock from "./blocks/VideoBlock.vue";
-import CountdownBlockComponent from "./blocks/CountdownBlock.vue";
 
+// `countdown` is deliberately absent: it resolves from the block registry, which
+// `useEditorCore` populates with a lazy `defineAsyncComponent` so OSS bundles
+// don't carry a Cloud-only block. `resolveBlockComponent` checks the registry
+// first, so a static entry here would never be reached — but its static import
+// would still pull the module into the eager graph and defeat the laziness.
+// The other fallback maps (SectionBlock, SavedBlockPreviewCanvas,
+// PreviewSectionBlock) omit it for the same reason.
 const blockComponentMap: Record<string, Component> = {
   section: SectionBlock,
   title: TitleBlock,
@@ -53,7 +59,6 @@ const blockComponentMap: Record<string, Component> = {
   menu: MenuBlock,
   table: TableBlock,
   video: VideoBlock,
-  countdown: CountdownBlockComponent,
   custom: CustomBlock,
 };
 

--- a/packages/editor/tests/block-chrome-structure.test.ts
+++ b/packages/editor/tests/block-chrome-structure.test.ts
@@ -577,3 +577,51 @@ describe("preview-mode visibility gate", () => {
     expect(sectionBlock).toMatch(/:preview-mode="editor\.state\.previewMode"/);
   });
 });
+
+describe("countdown resolves only through the block registry", () => {
+  /**
+   * `countdown` is the one Cloud-only block (its animated GIF is rendered
+   * server-side), so `useEditorCore` registers it as a lazy
+   * `defineAsyncComponent` to keep it out of the OSS payload.
+   *
+   * Regression this guards: `Canvas.vue` also listed it in its static
+   * `blockComponentMap`. That entry was unreachable at runtime — the registry is
+   * checked first — but its static `import` put the module in the entry's
+   * static-import closure, so the CDN bundle shipped it eagerly and the
+   * `defineAsyncComponent` bought nothing. The fallback maps are for surfaces
+   * without a registry; countdown deliberately isn't in any of them.
+   */
+  const FALLBACK_MAP_SURFACES = [
+    "components/Canvas.vue",
+    "components/blocks/SectionBlock.vue",
+    "components/SavedBlockPreviewCanvas.vue",
+    "components/blocks/PreviewSectionBlock.vue",
+  ];
+
+  it.each(FALLBACK_MAP_SURFACES)(
+    "%s does not statically import CountdownBlock.vue",
+    (relPath) => {
+      const source = read(relPath);
+      // A static import — `import X from "..."`. The lazy form lives only in
+      // useEditorCore and is `import("...")`, which this pattern won't match.
+      expect(source).not.toMatch(/^\s*import\s+[^(\n]*CountdownBlock\.vue/m);
+    },
+  );
+
+  it.each(FALLBACK_MAP_SURFACES)(
+    "%s has no countdown entry in its fallback component map",
+    (relPath) => {
+      expect(read(relPath)).not.toMatch(/^\s*countdown:/m);
+    },
+  );
+
+  it("useEditorCore still registers countdown, lazily", () => {
+    const core = read("composables/useEditorCore.ts");
+    // The registry is the single source for the component, so losing this would
+    // make countdown blocks silently stop rendering everywhere.
+    expect(core).toMatch(/countdown:\s*CountdownBlockComponent/);
+    expect(core).toMatch(
+      /CountdownBlockComponent\s*=\s*defineAsyncComponent\(\s*\(\)\s*=>\s*import\(/,
+    );
+  });
+});

--- a/packages/editor/tests/blockComponentResolver.test.ts
+++ b/packages/editor/tests/blockComponentResolver.test.ts
@@ -10,6 +10,7 @@ import {
   createTitleBlock,
   createImageBlock,
   createButtonBlock,
+  createCountdownBlock,
   createDividerBlock,
   createSectionBlock,
   createDefaultTemplateContent,
@@ -76,6 +77,30 @@ describe("resolveBlockComponent", () => {
 
     const result = resolveBlockComponent(block, registry, componentMap);
     expect(result).toBeNull();
+  });
+
+  /**
+   * The registry is the ONLY source for `countdown`, on purpose: it's the one
+   * Cloud-only block, so `useEditorCore` registers it as a lazy
+   * `defineAsyncComponent` and every fallback map omits it. A static entry in a
+   * fallback map would never be reached (registry wins) yet its static import
+   * would still drag the module into the eager bundle — which is exactly what
+   * `Canvas.vue` used to do.
+   */
+  it("resolves a registry-only block type that no fallback map carries", () => {
+    const block = createCountdownBlock();
+    const registry = {
+      getComponent: vi.fn().mockReturnValue(FakeRegistered),
+    } as unknown as UseBlockRegistryReturn;
+
+    // `componentMap` deliberately has no `countdown` key.
+    expect(componentMap.countdown).toBeUndefined();
+    expect(resolveBlockComponent(block, registry, componentMap)).toBe(
+      FakeRegistered,
+    );
+    // Without a registry there is nothing to fall back to — the block simply
+    // doesn't render, which is how the three preview surfaces already behave.
+    expect(resolveBlockComponent(block, null, componentMap)).toBeNull();
   });
 });
 

--- a/packages/editor/tests/canvasCountdownRegistry.test.ts
+++ b/packages/editor/tests/canvasCountdownRegistry.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+import "./dom-stubs";
+import { describe, expect, it, vi } from "vitest";
+import { defineComponent, h, markRaw } from "vue";
+import { useEditor } from "@templatical/core";
+import {
+  createCountdownBlock,
+  createTitleBlock,
+  createDefaultTemplateContent,
+} from "@templatical/types";
+import type { Block } from "@templatical/types";
+import Canvas from "../src/components/Canvas.vue";
+import { mountEditor } from "./helpers/mount";
+import { BLOCK_REGISTRY_KEY, EDITOR_KEY } from "../src/keys";
+import type { UseBlockRegistryReturn } from "../src/composables/useBlockRegistry";
+
+/**
+ * Canvas must render `countdown` blocks via the block registry.
+ *
+ * `countdown` is the one Cloud-only block, so `useEditorCore` registers it as a
+ * lazy `defineAsyncComponent` and Canvas's static `blockComponentMap`
+ * deliberately has no entry for it. That makes the registry the *only* source —
+ * so if Canvas ever stopped consulting it, countdown blocks would silently
+ * vanish from the canvas with nothing else to fall back on.
+ *
+ * The stub stands in for the real async component on purpose: what's under test
+ * is Canvas's routing, not the countdown UI (covered by `countdownBlock.test.ts`).
+ */
+
+const StubCountdown = markRaw(
+  defineComponent({
+    name: "StubCountdown",
+    props: { block: { type: Object, required: true } },
+    setup: () => () => h("div", { class: "stub-countdown" }, "countdown here"),
+  }),
+);
+
+function mountCanvasWith(blocks: Block[], registry: UseBlockRegistryReturn) {
+  const content = createDefaultTemplateContent();
+  content.blocks = blocks;
+  const editor = useEditor({ content });
+
+  return mountEditor(Canvas, {
+    props: {
+      viewport: "desktop",
+      content: editor.content.value,
+      selectedBlockId: null,
+      darkMode: false,
+      previewMode: false,
+    },
+    provides: {
+      [EDITOR_KEY]: editor,
+      [BLOCK_REGISTRY_KEY]: registry,
+    },
+  } as never);
+}
+
+/** A registry that resolves only `countdown`, like the real one does for it. */
+function countdownOnlyRegistry(component: unknown = StubCountdown) {
+  return {
+    getComponent: vi.fn((block: Block) =>
+      block.type === "countdown" ? component : undefined,
+    ),
+  } as unknown as UseBlockRegistryReturn;
+}
+
+describe("Canvas renders countdown through the registry", () => {
+  it("renders the registry's component for a countdown block", () => {
+    const countdown = createCountdownBlock();
+    const registry = countdownOnlyRegistry();
+
+    const wrapper = mountCanvasWith([countdown], registry);
+
+    expect(wrapper.findAll(".stub-countdown")).toHaveLength(1);
+    expect(wrapper.get(".stub-countdown").text()).toBe("countdown here");
+    expect(registry.getComponent).toHaveBeenCalled();
+  });
+
+  it("still renders non-countdown blocks from the static fallback map", () => {
+    // The registry returns undefined for `title`, so this proves removing
+    // countdown from the fallback map didn't disturb the fallback path.
+    const wrapper = mountCanvasWith(
+      [createTitleBlock({ content: "<p>Heading</p>", level: 2 })],
+      countdownOnlyRegistry(),
+    );
+
+    expect(wrapper.text()).toContain("Heading");
+  });
+
+  it("renders both kinds together, each via its own path", () => {
+    const wrapper = mountCanvasWith(
+      [
+        createTitleBlock({ content: "<p>Heading</p>", level: 2 }),
+        createCountdownBlock(),
+      ],
+      countdownOnlyRegistry(),
+    );
+
+    expect(wrapper.text()).toContain("Heading");
+    expect(wrapper.findAll(".stub-countdown")).toHaveLength(1);
+    expect(wrapper.findAll("[data-block-type]")).toHaveLength(2);
+  });
+
+  it("renders nothing for countdown when no registry resolves it", () => {
+    // Canvas has no static countdown entry, so an unresolved countdown block
+    // yields a wrapper with no inner component — the same degradation the three
+    // preview surfaces have always had. Asserted so the behaviour is stated
+    // rather than discovered.
+    const emptyRegistry = {
+      getComponent: vi.fn(() => undefined),
+    } as unknown as UseBlockRegistryReturn;
+
+    const wrapper = mountCanvasWith([createCountdownBlock()], emptyRegistry);
+
+    expect(wrapper.findAll(".stub-countdown")).toHaveLength(0);
+    // The block wrapper itself is still laid out — only its content is missing.
+    expect(
+      wrapper.findAll('[data-block-type="countdown"]'),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/editor/tests/cdn-chunk-granularity.test.ts
+++ b/packages/editor/tests/cdn-chunk-granularity.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, basename, posix, dirname } from "node:path";
+import { init as initLexer, parse } from "es-module-lexer";
+
+/**
+ * Guards the CDN bundle's lazy-loading contract.
+ *
+ * `bundle-topology.test.ts` deliberately skips `dist/cdn/`, so for a long time
+ * nothing checked the CDN build's chunk graph at all — which is how the former
+ * `features` manual chunk went unnoticed. That entry forced six
+ * `defineAsyncComponent` cloud panels (AiChatSidebar, CommentsSidebar,
+ * DesignReferenceSidebar, TemplateScoringPanel, TestEmailModal, SnapshotHistory)
+ * into one chunk that became statically reachable from the entry. Every Cloud
+ * session downloaded all 66.5 KB gzip of it whether or not the user opened a
+ * single panel: `defineAsyncComponent` was fully defeated, silently, for years.
+ *
+ * The invariant here is the one that actually matters to a consumer: **a
+ * component the source lazy-loads must not be in the entry's static-import
+ * closure.** That is deliberately phrased in terms of reachability rather than
+ * chunk names or sizes, because the failure mode moves around — removing only
+ * the `features` group promoted `media-library` to eager instead, and removing
+ * that promoted `quality`. Any `manualChunks` rule over first-party source can
+ * create the bridge, so the test checks the property, not a blocklist.
+ *
+ * Requires the CDN build. The editor's `build:all` runs both vite configs and
+ * the root `build` calls it, so `dist/cdn/` exists in CI's build and test jobs.
+ */
+
+const PKG = join(import.meta.dirname, "..");
+const CDN = join(PKG, "dist", "cdn");
+const SRC = join(PKG, "src");
+const ENTRY = "editor.js";
+
+/** Every `.js` chunk in the CDN output, as paths relative to `dist/cdn`. */
+function listChunks(dir: string, rel = ""): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name);
+    const relPath = rel ? `${rel}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) out.push(...listChunks(abs, relPath));
+    else if (entry.name.endsWith(".js")) out.push(relPath);
+  }
+  return out;
+}
+
+/** Recursively collect `.vue` / `.ts` source files under `src/`. */
+function listSources(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listSources(abs));
+    else if (/\.(vue|ts)$/.test(entry.name)) out.push(abs);
+  }
+  return out;
+}
+
+/**
+ * Component basenames the source lazy-loads, e.g. `TestEmailModal`.
+ *
+ * Read from source rather than hard-coded so a newly added lazy dialog is
+ * covered the moment it lands — the point is that nobody has to remember to
+ * update this test.
+ */
+function findLazyComponents(): Set<string> {
+  const found = new Set<string>();
+  // `defineAsyncComponent(() => import("./Foo.vue"))`, with or without a
+  // wrapping async arrow, across one or more lines.
+  const pattern = /defineAsyncComponent\s*\([\s\S]{0,200}?import\(\s*["']([^"']+\.vue)["']/g;
+  for (const file of listSources(SRC)) {
+    const src = readFileSync(file, "utf8");
+    for (const match of src.matchAll(pattern)) {
+      found.add(basename(match[1], ".vue"));
+    }
+  }
+  return found;
+}
+
+describe("CDN chunk granularity", () => {
+  let chunks: string[];
+  /** chunk -> chunks it imports STATICALLY (dynamic imports excluded). */
+  let staticImports: Map<string, string[]>;
+  /** component basename -> chunk containing it, from the emitted sourcemaps. */
+  let owner: Map<string, string>;
+  /** Chunks reachable from the entry via static imports only. */
+  let eager: Set<string>;
+  let lazyComponents: Set<string>;
+
+  beforeAll(async () => {
+    if (!existsSync(CDN)) {
+      throw new Error(
+        `dist/cdn/ not found. Run \`pnpm --filter @templatical/editor run build:cdn\` before running this test.`,
+      );
+    }
+    await initLexer;
+
+    chunks = listChunks(CDN);
+    staticImports = new Map();
+    owner = new Map();
+
+    for (const rel of chunks) {
+      const source = readFileSync(join(CDN, rel), "utf8");
+      const [imports] = parse(source, rel);
+      staticImports.set(
+        rel,
+        imports
+          // `d === -1` marks a static import. Dynamic imports (`d > -1`) are
+          // separate on-demand fetches and must NOT count toward reachability —
+          // they are the whole mechanism under test.
+          .filter((i) => i.d === -1 && i.n?.startsWith("."))
+          .map((i) => posix.normalize(posix.join(posix.dirname(rel), i.n!))),
+      );
+
+      // Sourcemaps are the only reliable way to map a component to its chunk:
+      // manualChunks renames output files, and most components share only
+      // generic `tpl-*` token classes, so filenames and content probes both lie.
+      try {
+        const map = JSON.parse(readFileSync(join(CDN, `${rel}.map`), "utf8"));
+        for (const src of (map.sources ?? []) as string[]) {
+          if (!src.endsWith(".vue")) continue;
+          const name = basename(src, ".vue");
+          if (!owner.has(name)) owner.set(name, rel);
+        }
+      } catch {
+        // No sourcemap for this chunk; other chunks still provide coverage.
+      }
+    }
+
+    eager = new Set<string>();
+    const stack = [ENTRY];
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      if (eager.has(current) || !staticImports.has(current)) continue;
+      eager.add(current);
+      stack.push(...staticImports.get(current)!);
+    }
+
+    lazyComponents = findLazyComponents();
+  });
+
+  it("emits the entry chunk and sourcemaps to resolve components against", () => {
+    expect(chunks).toContain(ENTRY);
+    expect(existsSync(join(CDN, `${ENTRY}.map`))).toBe(true);
+    // If the sourcemap->component mapping silently produced nothing, every
+    // reachability assertion below would pass vacuously.
+    expect(owner.size).toBeGreaterThan(20);
+  });
+
+  it("finds the lazy components by reading source, and they resolve to chunks", () => {
+    // Sanity-check the source scan itself. Known lazy dialogs across both the
+    // OSS and cloud surfaces — if the regex breaks, this fails loudly instead of
+    // letting the real assertion pass with an empty set.
+    expect(lazyComponents.has("TestEmailModal")).toBe(true);
+    expect(lazyComponents.has("SaveBlockDialog")).toBe(true);
+    expect(lazyComponents.has("AiChatSidebar")).toBe(true);
+    expect(lazyComponents.size).toBeGreaterThanOrEqual(10);
+  });
+
+  it("never puts a lazy-loaded component in the entry's static-import closure", () => {
+    // Deliberately unconditional: a static import site elsewhere is NOT an excuse.
+    // What matters is only whether the component ends up eagerly reachable, and
+    // the closure already answers that — a component can be statically imported
+    // by a parent that is itself lazy and stay correctly lazy (as
+    // `SavedBlockPreviewCanvas` does, shared by the save dialog's preview rows and
+    // the browser modal's preview pane). Excusing every component with a static
+    // site would have silently stopped covering those.
+    const eagerlyShipped: string[] = [];
+    for (const name of lazyComponents) {
+      const chunk = owner.get(name);
+      // Not every lazy component resolves to a chunk (e.g. one gated behind an
+      // optional peer that this build externalizes) — those are simply absent.
+      if (chunk && eager.has(chunk)) {
+        eagerlyShipped.push(`${name} -> ${chunk}`);
+      }
+    }
+    expect(eagerlyShipped).toEqual([]);
+  });
+
+  it("keeps each of the six formerly-merged cloud panels in its own chunk", () => {
+    // The specific regression: these six shared one `features` chunk, so opening
+    // any one of them fetched all six. Asserted as distinct chunks rather than by
+    // size so it stays meaningful as the components grow.
+    const panels = [
+      "AiChatSidebar",
+      "CommentsSidebar",
+      "DesignReferenceSidebar",
+      "TemplateScoringPanel",
+      "TestEmailModal",
+      "SnapshotHistory",
+    ];
+    const resolved = panels.map((name) => owner.get(name));
+    expect(resolved.every((chunk) => typeof chunk === "string")).toBe(true);
+    expect(new Set(resolved).size).toBe(panels.length);
+  });
+
+  it("does not group first-party source into a named vendor chunk", () => {
+    // `manualChunks` may only group third-party dependencies. A chunk named after
+    // one of our own packages or feature areas means a source-grouping rule came
+    // back, which is what made lazy chunks eager in the first place.
+    const banned = ["features-", "media-library-", "quality-", "renderer-"];
+    const offenders = chunks
+      .map((chunk) => basename(chunk))
+      .filter((name) => banned.some((prefix) => name.startsWith(prefix)));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/editor/vite.cdn.config.ts
+++ b/packages/editor/vite.cdn.config.ts
@@ -43,6 +43,30 @@ export default defineConfig({
             external: [],
             output: {
                 chunkFileNames: 'chunks/[name]-[hash].js',
+                // THIRD-PARTY DEPENDENCIES ONLY — never group first-party source.
+                //
+                // Forcing our own modules into a named chunk creates static import
+                // edges between otherwise-independent lazy subgraphs, which silently
+                // makes a lazy chunk EAGER. That is not theoretical: the former
+                // `features` group (6 `defineAsyncComponent` cloud panels) became
+                // statically reachable from the entry, so every Cloud session
+                // downloaded all 66.5 KB gzip of it whether or not the user opened a
+                // single panel — `defineAsyncComponent` was fully defeated for them.
+                //
+                // The failure also moves: removing only `features` promoted
+                // `media-library` to eager (41.2 -> 65.7 KB) and grew the eager
+                // payload by 32.7 KB; removing that too promoted `quality` instead.
+                // Grouping source is what creates the bridge, so the rule is a ban,
+                // not a list to curate.
+                //
+                // Third-party groups stay because they earn their keep on caching:
+                // tiptap alone is 145 KB gzip, and keeping it in a content-addressed
+                // chunk of its own means an editor-only release doesn't invalidate it
+                // for repeat visitors.
+                //
+                // Guarded by `tests/cdn-chunk-granularity.test.ts` — it enumerates
+                // `defineAsyncComponent` call sites from source and fails if any of
+                // them lands in a chunk reachable from the entry by static import.
                 manualChunks: (id) => {
                     if (id.includes('@lucide/vue')) {
                         return 'icons';
@@ -62,35 +86,14 @@ export default defineConfig({
                     if (id.includes('pusher-js')) {
                         return 'pusher';
                     }
-                    if (id.includes('/quality/src/') || id.includes('htmlparser2')) {
-                        return 'quality';
-                    }
-                    if (id.includes('/renderer/src/')) {
-                        return 'renderer';
+                    if (id.includes('htmlparser2')) {
+                        return 'htmlparser';
                     }
                     if (
                         id.includes('vue-draggable-plus') ||
                         id.includes('sortablejs')
                     ) {
                         return 'draggable';
-                    }
-                    if (
-                        id.includes('/media-library/src/components/') ||
-                        id.includes('/media-library/src/composable') ||
-                        id.includes('/media-library/src/api-client') ||
-                        id.includes('/media-library/src/composables/')
-                    ) {
-                        return 'media-library';
-                    }
-                    if (
-                        id.includes('/cloud/components/AiChatSidebar') ||
-                        id.includes('/cloud/components/CommentsSidebar') ||
-                        id.includes('/cloud/components/DesignReferenceSidebar') ||
-                        id.includes('/cloud/components/TemplateScoringPanel') ||
-                        id.includes('/cloud/components/TestEmailModal') ||
-                        id.includes('/cloud/components/SnapshotHistory')
-                    ) {
-                        return 'features';
                     }
                     return undefined;
                 },


### PR DESCRIPTION
## The bug

Two independent causes of the same failure: code behind `defineAsyncComponent` was ending
up in the entry's **static-import closure**, so it downloaded on every editor load whether
or not it was ever used. Lazy loading worked in source and was silently defeated in the
bundle.

### 1. The `features` manual chunk

`vite.cdn.config.ts` grouped six `defineAsyncComponent` cloud panels — AI chat, comments,
design reference, template scoring, test email, snapshot history — into one chunk.

**That chunk was statically reachable from the entry.** Verified by tracing the import
graph: the incremental cost of opening any of the six was **0 KB across 0 chunks**, because
all 66.5 KB gzip was already downloaded on every Cloud editor load. Not an over-fetch on
open — an unconditional tax on every session for panels most users never touch.

Not deliberate: the group is **verbatim from the initial commit** and untouched across the
five commits that have edited the file. At that same commit all six were *already*
`defineAsyncComponent` — as were `CollaboratorBar`, `AiFeatureMenu`, `SaveModuleDialog` and
`ModuleBrowserModal`, which were left **out** of the group. A considered request-count
optimization would have included all ten. The arbitrary subset is the tell.

### 2. A duplicate countdown registration

`countdown` needs Templatical Cloud (server-side animated GIF), so `useEditorCore`
registers it as a lazy `defineAsyncComponent` to keep it out of the OSS payload.
`Canvas.vue` **also** listed it in its static `blockComponentMap`.

`resolveBlockComponent` checks the registry first, so Canvas's entry was unreachable at
runtime — but its static `import` still pulled the module into the eager graph. Canvas was
the **only** one of the four fallback maps carrying it; `SectionBlock`,
`SavedBlockPreviewCanvas` and `PreviewSectionBlock` all omit it. So removing it makes Canvas
consistent with its peers, not countdown inconsistent with the other 13 block types.

## Why not just delete the `features` group

Because that makes it worse. Measured across five strategies — eager payload is the entry's
static-import closure, i.e. what every session pays before opening anything:

| `manualChunks` strategy | chunks | total gz | **eager gz** | depth | one panel | all six |
|---|---|---|---|---|---|---|
| **A. `features` group (before)** | 48 | 550.8 | **337.1** | 5 | 0 † | 0 † |
| B. drop `features` only | 64 | 561.0 | 369.8 | — | 1.7–5.0 | 18.3 |
| C. drop `features` + `media-library` | 67 | 560.2 | 369.1 | — | 1.7–5.0 | 18.3 |
| D. no `manualChunks` at all | 108 | 576.7 | 297.4 | 6 | 1.7–5.7 | 20.5 |
| **E. third-party only (this PR)** | 69 | 559.4 | **330.8** | 6 | 1.7–5.0 | 18.3 |

† already in the eager payload — paid by everyone regardless of use.

**B grows the eager payload by 32.7 KB.** Removing the group makes `media-library` the new
eager bridge (lazy 41.2 → eager 65.7 KB). C is the same story with `quality` taking over
(verified genuinely static: `cloud-*.js` line 3 carries
`import {…} from "./quality-*.js"`).

**The generalisable finding:** forcing first-party source into a named chunk creates static
edges between otherwise-independent lazy subgraphs, which silently makes lazy chunks eager.
Whichever group you remove, another becomes the bridge. So this **bans** first-party
grouping rather than curating a list.

**D vs E.** D has the smallest eager payload but 108 chunks including many sub-1 KB icon
chunks, +25.9 KB total transfer, and lets third-party code co-locate with first-party so an
editor edit rehashes chunks containing vendor code. E keeps the big vendor libs in stable
content-addressed chunks — tiptap alone is 145 KB gzip, and isolating it means an
editor-only release doesn't invalidate it for repeat visitors.

**Chunk count is close to free here.** Waterfall depth is 5–6 across *every* variant, so the
extra chunks are fetched in parallel under HTTP/2. Depth, not count, costs round-trips.

## Net effect

| | before | after |
|---|---|---|
| eager payload (gzip) | 337.1 KB | **329.5 KB** |
| eager chunks / depth | 14 / 5 | 27 / 6 |
| opening one cloud panel | 0 KB (pre-paid) | **1.7–5.0 KB** |
| opening all six | 0 KB (pre-paid) | 18.3 KB / 7 chunks |
| `CountdownBlock` in entry closure | yes | **no** |

Eager chunk count rises while eager bytes fall — that's the point: the code moved out of the
unconditional payload and into on-demand fetches, at unchanged effective depth.

## Behaviour

None. All six panels and countdown blocks render exactly as before. npm consumers are
unaffected — that build has no `manualChunks` and already produced one chunk per component.

The registry is now the *only* source for countdown, so losing the `useEditorCore`
registration would make those blocks stop rendering everywhere — locked by a test.

## Tests (+19)

- **`cdn-chunk-granularity.test.ts`** (new, 5) — enumerates `defineAsyncComponent` call sites
  **from source**, so a newly added lazy dialog is covered the moment it lands, and fails if
  any lands in a chunk reachable from the entry by static import. Component→chunk mapping
  comes from the emitted sourcemaps, because `manualChunks` renames output files and most
  components share only generic `tpl-*` classes — filenames and content probes both lie.
- **`canvasCountdownRegistry.test.ts`** (new, 4) — Canvas renders countdown via the registry,
  non-countdown blocks still use the static fallback, and what happens when nothing resolves
  it. This path previously had **no** coverage.
- **`block-chrome-structure.test.ts`** (+9) — no static import and no `countdown:` entry
  across all four fallback maps, plus the lazy registration still present.
- **`blockComponentResolver.test.ts`** (+1) — a registry-only type that no fallback map carries.

`bundle-topology.test.ts:76` *deliberately skips* `dist/cdn/`, so the CDN graph was
unguarded — that's why this survived. The new guard needs the CDN build; the editor's
`build:all` runs both vite configs and the root `build` calls it, so `dist/cdn/` exists in
CI's build and test jobs.

**Both guards negative-checked.** Re-adding the `features` group fails 3 of the granularity
guard's 5 assertions and names all six panels; restoring Canvas's static import fails 2
structural assertions *and* the granularity guard independently.

The granularity guard is deliberately **unconditional** — a static import site elsewhere is
not an excuse. An earlier draft excused any component with both a static and a lazy site,
which would have silently stopped covering `SavedBlockPreviewCanvas` (statically imported by
`SavedBlockPreviewRow`, lazily by `SavedBlocksBrowserModal`, and *correctly* lazy because
both parents are). Eager **reachability** was always the precise test.

## Verification

`format --check` · `lint` · `typecheck` · `build` · `test` — **4,192 passed**.

`test:e2e` not run locally: the Playwright browser binary for 1.62.0 isn't installed on my
machine (cached 1223/1228 vs required 1234). CI runs it in the `v1.62.0-jammy` image, and
the playground never loads `vite.cdn.config.ts`. The new mount tests cover the countdown
render path a playground check would have exercised.