### PR TITLE
feat: justify alignment in the paragraph toolbar

### DIFF
--- a/.changeset/beige-dancers-watch.md
+++ b/.changeset/beige-dancers-watch.md
@@ -1,5 +1,5 @@
 ---
-"@templatical/editor": minor
+"@templatical/editor": patch
 ---
 
 Add **justify** to the paragraph toolbar's alignment group

--- a/.changeset/beige-dancers-watch.md
+++ b/.changeset/beige-dancers-watch.md
@@ -1,0 +1,5 @@
+---
+"@templatical/editor": minor
+---
+
+Add **justify** to the paragraph toolbar's alignment group

--- a/packages/editor/src/components/blocks/ParagraphToolbar.vue
+++ b/packages/editor/src/components/blocks/ParagraphToolbar.vue
@@ -9,6 +9,7 @@ import { usePopoverRoot } from "../../composables/usePopoverRoot";
 import type { Editor } from "@tiptap/core";
 import {
   AlignCenter,
+  AlignJustify,
   AlignLeft,
   AlignRight,
   Bold,
@@ -322,6 +323,12 @@ function setHighlight(color: string): void {
             :label="t.paragraphEditor.alignRight"
             :active="editor.isActive({ textAlign: 'right' })"
             @click="editor.chain().focus().setTextAlign('right').run()"
+          />
+          <ToolbarIconButton
+            :icon="AlignJustify"
+            :label="t.paragraphEditor.alignJustify"
+            :active="editor.isActive({ textAlign: 'justify' })"
+            @click="editor.chain().focus().setTextAlign('justify').run()"
           />
           <ToolbarSeparator />
           <ToolbarSelect

--- a/packages/editor/src/i18n/locales/ca.ts
+++ b/packages/editor/src/i18n/locales/ca.ts
@@ -87,6 +87,7 @@ const ca: typeof en = {
     alignLeft: "Alinea a l'esquerra",
     alignCenter: "Alinea al centre",
     alignRight: "Alinea a la dreta",
+    alignJustify: "Justifica",
     clearFormatting: "Neteja el format",
     insertEmoji: "Insereix un emoji",
     fontFamily: "Tipus de lletra",

--- a/packages/editor/src/i18n/locales/de.ts
+++ b/packages/editor/src/i18n/locales/de.ts
@@ -89,6 +89,7 @@ const de: typeof en = {
     alignLeft: "Linksbündig",
     alignCenter: "Zentriert",
     alignRight: "Rechtsbündig",
+    alignJustify: "Blocksatz",
     clearFormatting: "Formatierung entfernen",
     insertEmoji: "Emoji einfügen",
     fontFamily: "Schriftart",

--- a/packages/editor/src/i18n/locales/en.ts
+++ b/packages/editor/src/i18n/locales/en.ts
@@ -85,6 +85,7 @@ export default {
     alignLeft: "Align Left",
     alignCenter: "Align Center",
     alignRight: "Align Right",
+    alignJustify: "Justify",
     clearFormatting: "Clear Formatting",
     insertEmoji: "Insert Emoji",
     fontFamily: "Font Family",

--- a/packages/editor/src/i18n/locales/es.ts
+++ b/packages/editor/src/i18n/locales/es.ts
@@ -88,6 +88,7 @@ const es: typeof en = {
     alignLeft: "Alinear a la izquierda",
     alignCenter: "Alinear al centro",
     alignRight: "Alinear a la derecha",
+    alignJustify: "Justificar",
     clearFormatting: "Borrar formato",
     insertEmoji: "Insertar emoji",
     fontFamily: "Familia tipográfica",

--- a/packages/editor/src/i18n/locales/fr.ts
+++ b/packages/editor/src/i18n/locales/fr.ts
@@ -69,6 +69,7 @@ const fr: typeof en = {
     alignLeft: "Aligner à gauche",
     alignCenter: "Centrer",
     alignRight: "Aligner à droite",
+    alignJustify: "Justifier",
     clearFormatting: "Effacer la mise en forme",
     insertEmoji: "Insérer un émoji",
     fontFamily: "Police",

--- a/packages/editor/src/i18n/locales/nl.ts
+++ b/packages/editor/src/i18n/locales/nl.ts
@@ -69,6 +69,7 @@ const nl: typeof en = {
     alignLeft: "Links uitlijnen",
     alignCenter: "Centreren",
     alignRight: "Rechts uitlijnen",
+    alignJustify: "Uitvullen",
     clearFormatting: "Opmaak wissen",
     insertEmoji: "Emoji invoegen",
     fontFamily: "Lettertype",

--- a/packages/editor/src/i18n/locales/pt-BR.ts
+++ b/packages/editor/src/i18n/locales/pt-BR.ts
@@ -87,6 +87,7 @@ const ptBR: typeof en = {
     alignLeft: "Alinhar à Esquerda",
     alignCenter: "Centralizar",
     alignRight: "Alinhar à Direita",
+    alignJustify: "Justificar",
     clearFormatting: "Limpar Formatação",
     insertEmoji: "Inserir Emoji",
     fontFamily: "Família da Fonte",

--- a/packages/editor/tests/paragraphToolbarAlignment.test.ts
+++ b/packages/editor/tests/paragraphToolbarAlignment.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { TextAlign } from "@tiptap/extension-text-align";
+
+const TOOLBAR_SRC = readFileSync(
+  resolve(__dirname, "../src/components/blocks/ParagraphToolbar.vue"),
+  "utf-8",
+);
+
+const EDITOR_SRC = readFileSync(
+  resolve(__dirname, "../src/components/blocks/ParagraphEditor.vue"),
+  "utf-8",
+);
+
+const ALIGNMENTS = ["left", "center", "right", "justify"] as const;
+
+describe("ParagraphToolbar alignment controls", () => {
+  it("renders a button for all four alignments", () => {
+    for (const alignment of ALIGNMENTS) {
+      expect(TOOLBAR_SRC).toContain(
+        `@click="editor.chain().focus().setTextAlign('${alignment}').run()"`,
+      );
+    }
+  });
+
+  it("marks each alignment button active from the matching textAlign attr", () => {
+    for (const alignment of ALIGNMENTS) {
+      expect(TOOLBAR_SRC).toContain(
+        `:active="editor.isActive({ textAlign: '${alignment}' })"`,
+      );
+    }
+  });
+
+  it("labels each alignment button from i18n, never a hardcoded string", () => {
+    for (const key of [
+      "alignLeft",
+      "alignCenter",
+      "alignRight",
+      "alignJustify",
+    ]) {
+      expect(TOOLBAR_SRC).toContain(`:label="t.paragraphEditor.${key}"`);
+    }
+  });
+
+  it("orders the group left, center, right, justify", () => {
+    const positions = ALIGNMENTS.map((alignment) =>
+      TOOLBAR_SRC.indexOf(`setTextAlign('${alignment}')`),
+    );
+    expect(positions.every((index) => index >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  it("uses the dedicated AlignJustify icon", () => {
+    expect(TOOLBAR_SRC).toContain("AlignJustify");
+    expect(TOOLBAR_SRC).toContain(':icon="AlignJustify"');
+  });
+});
+
+describe("ParagraphEditor TextAlign wiring", () => {
+  it("registers TextAlign for the paragraph type", () => {
+    expect(EDITOR_SRC).toContain(
+      'TextAlign.configure({ types: ["paragraph"] })',
+    );
+  });
+
+  it("relies on a TipTap default that still permits justify", () => {
+    expect(TextAlign.options.alignments).toContain("justify");
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to Templatical!

Before submitting, please skim CONTRIBUTING.md if you haven't already.
Keep PRs small and focused — one concern per PR.
-->

## Summary

This adds the fourth button after "Align right", with the dedicated
`AlignJustify` icon, active from `textAlign: 'justify'` like its siblings. A
template that already carried a justified paragraph now shows that alignment
as selected instead of showing none.

`alignJustify` is translated in every shipped locale (en, de, es, fr, nl,
pt-BR, ca).

## Linked issues

Closes https://github.com/templatical/sdk/issues/503

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Tests / tooling / CI
- [ ] Dependency update

## Affected packages

<!-- Check all that apply. -->

- [x] `@templatical/editor`
- [ ] `@templatical/core` (or `@templatical/core/cloud`)
- [ ] `@templatical/media-library`
- [ ] `@templatical/types`
- [ ] `@templatical/renderer`
- [ ] `@templatical/import-beefree`
- [ ] `apps/playground`
- [ ] `apps/docs`
- [ ] Tooling / CI / repo config

## Checklist

- [x] Tests added or updated (and they fail without my change)
- [x] `pnpm run ci` passes locally (lint + typecheck + build + test)
- [ ] `pnpm run test:e2e` passes (only if this PR touches editor UI)
- [ ] Docs updated — both `apps/docs/<page>.md` and `apps/docs/de/<page>.md` if user-facing
- [x] i18n keys added to both `en.ts` and `de.ts` if I added new strings
- [x] Changeset added (`pnpm exec changeset`) — required for any change to a published package
- [x] PR title is descriptive and follows the existing convention

## Screenshots / recordings

<!-- For UI changes, add before/after screenshots or a short Loom/GIF. Delete this section otherwise. -->

## Notes for reviewers

LLMs have been used to generate the translations
