### PR TITLE
feat: alignment option for button block

### DIFF
--- a/.changeset/button-align.md
+++ b/.changeset/button-align.md
@@ -1,0 +1,18 @@
+---
+"@templatical/types": minor
+"@templatical/renderer": minor
+"@templatical/editor": minor
+"@templatical/import-beefree": minor
+"@templatical/import-unlayer": minor
+"@templatical/import-html": minor
+---
+
+Add an alignment option to the button block (#536).
+
+`ButtonBlock` gains `align: "left" | "center" | "right"`, surfaced in the button toolbar as the same sliding control image, video, social, title, menu and table already use. The renderer passes it through to `mj-button`'s native `align` attribute, and the editor canvas — which previously hardcoded centering — now mirrors it, so the preview, saved-block previews and the test-email dialog all agree with what gets sent.
+
+**Breaking (types):** `align` is required, matching `ImageBlock` / `VideoBlock` / `SocialIconsBlock`. Code that constructs a `ButtonBlock` literal without going through `createButtonBlock()` must add the field. Nothing else changes: the factory defaults to `"center"`, and both the renderer and the editor fall back to `"center"` for templates stored before the field existed, so existing content renders byte-for-byte as it did.
+
+Note `align` has no visible effect when `width` is `"full"` — the button spans the column either way. The control stays visible in that state rather than appearing and disappearing with the width mode, matching the image toolbar.
+
+The three importers now carry button alignment across instead of dropping it: BeeFree and Unlayer read the button's own `text-align`, and the HTML importer reads the wrapping cell's `text-align` or its legacy `align` attribute (an anchor is sized to its content, so its own `text-align` says nothing about placement).

--- a/apps/docs/api/types.md
+++ b/apps/docs/api/types.md
@@ -172,6 +172,7 @@ interface ButtonBlock extends BaseBlock {
   fontFamily?: string;
   openInNewTab?: boolean;
   width?: number | 'full';
+  align: 'left' | 'center' | 'right';
 }
 ```
 

--- a/apps/docs/de/api/types.md
+++ b/apps/docs/de/api/types.md
@@ -172,6 +172,7 @@ interface ButtonBlock extends BaseBlock {
   fontFamily?: string;
   openInNewTab?: boolean;
   width?: number | 'full';
+  align: 'left' | 'center' | 'right';
 }
 ```
 

--- a/apps/docs/de/guide/blocks.md
+++ b/apps/docs/de/guide/blocks.md
@@ -79,6 +79,7 @@ Eine Call-to-Action-Schaltfläche mit anpassbarem Erscheinungsbild.
 | `fontFamily` | `string` | Überschreibung der Schriftfamilie |
 | `openInNewTab` | `boolean` | Verhalten des Linkziels |
 | `width` | `number \| 'full'` | Feste Breite in px oder `'full'` für 100%. Weglassen, um an den Inhalt anzupassen. |
+| `align` | `'left' \| 'center' \| 'right'` | Ausrichtung innerhalb der Spalte. Ohne sichtbare Wirkung, wenn `width` auf `'full'` steht. |
 
 ## Divider
 

--- a/apps/docs/guide/blocks.md
+++ b/apps/docs/guide/blocks.md
@@ -79,6 +79,7 @@ A call-to-action button with customizable appearance.
 | `fontFamily` | `string` | Font family override |
 | `openInNewTab` | `boolean` | Link target behavior |
 | `width` | `number \| 'full'` | Fixed width in px, or `'full'` for 100%. Omit to size to content. |
+| `align` | `'left' \| 'center' \| 'right'` | Placement within the column. No visible effect when `width` is `'full'`. |
 
 ## Divider
 

--- a/packages/editor/src/components/blocks/ButtonBlock.vue
+++ b/packages/editor/src/components/blocks/ButtonBlock.vue
@@ -36,10 +36,16 @@ const buttonStyle = computed(() => {
   }
   return style;
 });
+
+// Mirrors the renderer's fallback so a template stored before `align` existed
+// previews the same way it renders.
+const wrapperStyle = computed(() => ({
+  textAlign: props.block.align ?? "center",
+}));
 </script>
 
 <template>
-  <div class="tpl:text-center">
+  <div :style="wrapperStyle">
     <a
       :href="block.url || '#'"
       :style="buttonStyle"

--- a/packages/editor/src/components/toolbar/ButtonToolbar.vue
+++ b/packages/editor/src/components/toolbar/ButtonToolbar.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 import ColorPicker from "../ColorPicker.vue";
 import MergeTagInput from "../MergeTagInput.vue";
+import SlidingPillSelect from "../SlidingPillSelect.vue";
 import ToggleSwitch from "../ToggleSwitch.vue";
 import { useI18n } from "../../composables/useI18n";
 import {
@@ -190,5 +191,17 @@ function updateCustomWidth(raw: string): void {
       />
       <span :class="inputSuffixClass">px</span>
     </div>
+  </div>
+  <div class="tpl:mb-3.5">
+    <label :class="labelClass">{{ t.title.align }}</label>
+    <SlidingPillSelect
+      :options="[
+        { value: 'left', label: t.title.alignLeft },
+        { value: 'center', label: t.title.alignCenter },
+        { value: 'right', label: t.title.alignRight },
+      ]"
+      :model-value="block.align ?? 'center'"
+      @update:model-value="updateField('align', $event)"
+    />
   </div>
 </template>

--- a/packages/editor/tests/buttonBlock.test.ts
+++ b/packages/editor/tests/buttonBlock.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import "./dom-stubs";
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { SYNTAX_PRESETS, createButtonBlock } from "@templatical/types";
+import type { ButtonBlock as ButtonBlockType } from "@templatical/types";
+import enTranslations from "../src/i18n/locales/en";
+import {
+  MERGE_TAGS_KEY,
+  MERGE_TAG_SYNTAX_KEY,
+  TRANSLATIONS_KEY,
+} from "../src/keys";
+import ButtonBlock from "../src/components/blocks/ButtonBlock.vue";
+
+function mountButton(block: ButtonBlockType) {
+  return mount(ButtonBlock, {
+    props: { block, viewport: "desktop" },
+    global: {
+      provide: {
+        [TRANSLATIONS_KEY as symbol]: enTranslations,
+        [MERGE_TAG_SYNTAX_KEY as symbol]: SYNTAX_PRESETS.liquid,
+        [MERGE_TAGS_KEY as symbol]: [],
+      },
+    },
+  });
+}
+
+/**
+ * The canvas is the WYSIWYG contract, and this component also backs
+ * `BlockPreviewCanvas` — so a hardcoded alignment here would misreport what
+ * gets sent in saved-block previews and the test-email dialog too.
+ */
+describe("ButtonBlock alignment", () => {
+  it.each(["left", "center", "right"] as const)(
+    "places the button %s",
+    (align) => {
+      const wrapper = mountButton(createButtonBlock({ text: "Go", align }));
+      const wrapperEl = wrapper.element as HTMLElement;
+      expect(wrapperEl.style.textAlign).toBe(align);
+    },
+  );
+
+  it("centers a button stored without align", () => {
+    const block = createButtonBlock({ text: "Go" });
+    delete (block as { align?: unknown }).align;
+
+    const wrapperEl = mountButton(block).element as HTMLElement;
+    expect(wrapperEl.style.textAlign).toBe("center");
+  });
+
+  it("keeps the alignment on a full-width button", () => {
+    // The anchor spans the column so there is nothing to move, but the wrapper
+    // must still carry the stored value rather than silently normalizing it.
+    const wrapper = mountButton(
+      createButtonBlock({ text: "Go", align: "left", width: "full" }),
+    );
+    expect((wrapper.element as HTMLElement).style.textAlign).toBe("left");
+    expect((wrapper.find("a").element as HTMLElement).style.width).toBe("100%");
+  });
+});

--- a/packages/editor/tests/buttonToolbar.test.ts
+++ b/packages/editor/tests/buttonToolbar.test.ts
@@ -77,6 +77,49 @@ describe("ButtonToolbar width control", () => {
   });
 });
 
+describe("ButtonToolbar align control", () => {
+  function alignRadios(wrapper: ReturnType<typeof mountIt>) {
+    return wrapper.find('[role="radiogroup"]').findAll('[role="radio"]');
+  }
+
+  it("reflects the block's alignment", () => {
+    const wrapper = mountIt(createButtonBlock({ align: "right" }));
+    const checked = alignRadios(wrapper).filter(
+      (r) => r.attributes("aria-checked") === "true",
+    );
+    expect(checked).toHaveLength(1);
+    expect(checked[0].attributes("aria-label")).toBe("title.alignRight");
+  });
+
+  it("emits the picked alignment", async () => {
+    const wrapper = mountIt(createButtonBlock({ align: "center" }));
+
+    await alignRadios(wrapper)[0].trigger("click");
+
+    const [update] = wrapper.emitted("update")![0] as [Partial<ButtonBlock>];
+    expect(update.align).toBe("left");
+  });
+
+  it("shows center for a block stored without align", () => {
+    // Templates predating the field must not render an empty control.
+    const block = createButtonBlock();
+    delete (block as { align?: unknown }).align;
+
+    const checked = alignRadios(mountIt(block)).filter(
+      (r) => r.attributes("aria-checked") === "true",
+    );
+    expect(checked).toHaveLength(1);
+    expect(checked[0].attributes("aria-label")).toBe("title.alignCenter");
+  });
+
+  it("stays available for a full-width button", () => {
+    // No visible effect at full width, but hiding it would make the control
+    // appear and disappear as the width mode changes. Mirrors ImageToolbar.
+    const wrapper = mountIt(createButtonBlock({ width: "full" }));
+    expect(alignRadios(wrapper)).toHaveLength(3);
+  });
+});
+
 describe("ButtonToolbar color layout", () => {
   it("stacks Background and Text Color vertically rather than in a 2-col grid", () => {
     // Each ColorPicker is a 40px swatch + a hex input; half the sidebar width

--- a/packages/import-beefree/src/__tests__/block-mapper.test.ts
+++ b/packages/import-beefree/src/__tests__/block-mapper.test.ts
@@ -186,6 +186,38 @@ describe("convertModule", () => {
       }
     });
 
+    it("carries the button's alignment across", () => {
+      const warnings: string[] = [];
+      const mod = makeModule("mailup-bee-newsletter-modules-button", {
+        button: {
+          label: "Click Me",
+          href: "https://example.com",
+          style: { "text-align": "left" },
+        },
+      });
+
+      const { block } = convertModule(mod, warnings);
+
+      expect(block.type).toBe("button");
+      if (block.type === "button") {
+        expect(block.align).toBe("left");
+      }
+    });
+
+    it("falls back to center when the button has no alignment", () => {
+      const warnings: string[] = [];
+      const mod = makeModule("mailup-bee-newsletter-modules-button", {
+        button: { label: "Click Me", href: "https://example.com", style: {} },
+      });
+
+      const { block } = convertModule(mod, warnings);
+
+      expect(block.type).toBe("button");
+      if (block.type === "button") {
+        expect(block.align).toBe("center");
+      }
+    });
+
     it("uses default styles when no button descriptor", () => {
       const warnings: string[] = [];
       const mod = makeModule("mailup-bee-newsletter-modules-button", {});

--- a/packages/import-beefree/src/block-mapper.ts
+++ b/packages/import-beefree/src/block-mapper.ts
@@ -304,6 +304,7 @@ function convertButton(descriptor: BeeFreeeModuleDescriptor): Block {
     borderRadius: parsePxValue(style["border-radius"]),
     fontSize: parsePxValue(style["font-size"]) || 16,
     fontFamily: parseFontFamily(style["font-family"]) || undefined,
+    align: toAlign(style["text-align"], "center"),
     buttonPadding: {
       top: parsePxValue(style["padding-top"]) || 12,
       right: parsePxValue(style["padding-right"]) || 24,

--- a/packages/import-html/src/__tests__/block-mapper.test.ts
+++ b/packages/import-html/src/__tests__/block-mapper.test.ts
@@ -188,6 +188,60 @@ describe("convertElement — anchors", () => {
     });
   });
 
+  const BUTTON_STYLE =
+    "background-color:#ff0000;padding:10px 20px;border-radius:6px;color:#ffffff";
+
+  function buttonInCell(cellAttrs: string) {
+    const { $, $el } = firstEl(
+      `<table><tr><td ${cellAttrs}><a href="https://example.com" style="${BUTTON_STYLE}">Click</a></td></tr></table>`,
+      "a",
+    );
+    const r = convertElement($el, $)!;
+    if (r.block.type !== "button") throw new Error("expected button block");
+    return r.block;
+  }
+
+  it("reads button alignment from the wrapping cell's text-align", () => {
+    expect(buttonInCell('style="text-align:left"').align).toBe("left");
+  });
+
+  it("reads button alignment from the wrapping cell's legacy align attribute", () => {
+    expect(buttonInCell('align="right"').align).toBe("right");
+  });
+
+  it("prefers the cell's text-align over its align attribute", () => {
+    // CSS wins in every modern client, so the attribute is the fallback.
+    expect(buttonInCell('align="right" style="text-align:left"').align).toBe(
+      "left",
+    );
+  });
+
+  it("centers a button whose cell says nothing about alignment", () => {
+    expect(buttonInCell("").align).toBe("center");
+  });
+
+  it("centers a button with no wrapping cell at all", () => {
+    const { $, $el } = firstEl(
+      `<a href="https://example.com" style="${BUTTON_STYLE}">Click</a>`,
+      "a",
+    );
+    const r = convertElement($el, $)!;
+    if (r.block.type !== "button") throw new Error("expected button block");
+    expect(r.block.align).toBe("center");
+  });
+
+  it("ignores the anchor's own text-align", () => {
+    // The anchor is sized to its content, so its text-align says nothing
+    // about where the button sits — only the cell does.
+    const { $, $el } = firstEl(
+      `<table><tr><td><a href="https://example.com" style="${BUTTON_STYLE};text-align:right">Click</a></td></tr></table>`,
+      "a",
+    );
+    const r = convertElement($el, $)!;
+    if (r.block.type !== "button") throw new Error("expected button block");
+    expect(r.block.align).toBe("center");
+  });
+
   it("plain anchor falls back to paragraph (approximated)", () => {
     const { $, $el } = firstEl('<a href="https://x.com">link</a>', "a");
     const r = convertElement($el, $)!;

--- a/packages/import-html/src/block-mapper.ts
+++ b/packages/import-html/src/block-mapper.ts
@@ -197,6 +197,24 @@ export function looksLikeButton(styles: Record<string, string>): boolean {
   return false;
 }
 
+/**
+ * Reads a button's placement from the cell that wraps it. An anchor styled as
+ * a button is sized to its own content, so its `text-align` says nothing about
+ * where it sits — table-based email puts that on the containing `<td>`, as
+ * either a `text-align` style or the legacy `align` attribute. Only the
+ * immediate parent is consulted; walking further up would start reporting the
+ * alignment of the surrounding layout rather than of the button.
+ */
+function readButtonAlign($el: Cheerio<Element>): "left" | "center" | "right" {
+  const parent = $el.parent();
+  if (parent.length === 0) return "center";
+
+  const fromStyle = parseStyleAttribute(parent.attr("style"))["text-align"];
+  if (fromStyle) return parseAlignment(fromStyle, "center");
+
+  return parseAlignment(parent.attr("align"), "center");
+}
+
 function convertButton($el: Cheerio<Element>): Block {
   const styles = getStyles($el);
   const text = ($el.text() ?? "Button").trim() || "Button";
@@ -215,6 +233,7 @@ function convertButton($el: Cheerio<Element>): Block {
     borderRadius: parsePxValue(styles["border-radius"]),
     fontSize: parsePxValue(styles["font-size"]) || 16,
     fontFamily: parseFontFamily(styles["font-family"]) || undefined,
+    align: readButtonAlign($el),
     buttonPadding: readPaddingFromStyles(styles),
     styles: {
       padding: emptyPadding(),

--- a/packages/import-unlayer/src/__tests__/block-mapper.test.ts
+++ b/packages/import-unlayer/src/__tests__/block-mapper.test.ts
@@ -192,6 +192,26 @@ describe("convertContent", () => {
       expect(entry.status).toBe("converted");
     });
 
+    it("carries the button's alignment across", () => {
+      const { block } = convertContent(
+        makeContent("button", { text: "Hi", textAlign: "right" }),
+        [],
+      );
+      if (block.type === "button") {
+        expect(block.align).toBe("right");
+      }
+    });
+
+    it("falls back to center when the button has no alignment", () => {
+      const { block } = convertContent(
+        makeContent("button", { text: "Hi" }),
+        [],
+      );
+      if (block.type === "button") {
+        expect(block.align).toBe("center");
+      }
+    });
+
     it("uses default url '#' when href missing", () => {
       const { block } = convertContent(
         makeContent("button", { text: "Hi" }),

--- a/packages/import-unlayer/src/block-mapper.ts
+++ b/packages/import-unlayer/src/block-mapper.ts
@@ -277,6 +277,7 @@ function convertButton(values: UnlayerContentValues): Block {
     borderRadius: parsePxValue(values.borderRadius),
     fontSize: parsePxValue(values.fontSize) || 16,
     fontFamily: parseFontFamily(values.fontFamily) || undefined,
+    align: toAlign(values.textAlign, "center"),
     buttonPadding: padding,
     styles: makeStyles(values),
   });

--- a/packages/renderer/src/renderers/button.ts
+++ b/packages/renderer/src/renderers/button.ts
@@ -35,6 +35,9 @@ export function renderButton(
   const fontFamilyAttr = renderFontFamilyAttr(block.fontFamily, context);
   const widthAttr = renderWidthAttr(block.width);
   const visibilityAttr = getCssClassAttr(block);
+  // Templates stored before `align` existed have no value for it. Fall back to
+  // MJML's own default so they keep rendering exactly as they did.
+  const align = block.align ?? "center";
 
   return `<mj-button${hrefAttr}${targetAttr}
   background-color="${backgroundColor}"
@@ -43,6 +46,7 @@ export function renderButton(
   font-weight="bold"
   border-radius="${borderRadius}px"
   inner-padding="${buttonPadding}"
+  align="${align}"
   padding="${padding}"${bgColor}${fontFamilyAttr}${widthAttr}${visibilityAttr}
 >${text}</mj-button>`;
 }

--- a/packages/renderer/tests/mjml-button-align-roundtrip.test.ts
+++ b/packages/renderer/tests/mjml-button-align-roundtrip.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import mjml2html from "mjml";
+import { createButtonBlock } from "@templatical/types";
+import { renderBlock, RenderContext } from "../src";
+
+/**
+ * `align` on `mj-button` lands on the table cell that wraps the button, which
+ * is what actually moves it within the column. A string check on the MJML
+ * alone would pass even if MJML dropped the attribute, so these compile the
+ * renderer's output and assert on the emitted cell.
+ *
+ * Note the button's own inner `<td>` carries a hardcoded `align="center"` from
+ * MJML — hence the assertions anchor on the outer cell (the one carrying
+ * `word-break`) rather than searching the whole document for an align value.
+ */
+
+const ctx = new RenderContext(600, [], "Arial, sans-serif", true);
+
+async function compile(mjml: string): Promise<string> {
+  const result = await mjml2html(mjml);
+  expect(result.errors).toEqual([]);
+  return result.html;
+}
+
+function wrapBlock(blockMjml: string): string {
+  return `<mjml><mj-body><mj-section><mj-column>${blockMjml}</mj-column></mj-section></mj-body></mjml>`;
+}
+
+/** The alignment of the cell MJML wraps the button in. */
+function buttonCellAlign(html: string): string | null {
+  const match = html.match(/align="(left|center|right)"[^>]*word-break/);
+  return match ? match[1] : null;
+}
+
+describe("button align round-trip through MJML compiler", () => {
+  it.each(["left", "center", "right"] as const)(
+    "carries align=%s into the compiled cell",
+    async (align) => {
+      const block = createButtonBlock({ text: "Go", url: "#", align });
+
+      const mjml = renderBlock(block, ctx);
+      expect(mjml).toContain(`align="${align}"`);
+
+      const html = await compile(wrapBlock(mjml));
+      expect(buttonCellAlign(html)).toBe(align);
+    },
+  );
+
+  it("renders a button with no stored align exactly like a centered one", async () => {
+    const legacy = createButtonBlock({ text: "Go", url: "#" });
+    delete (legacy as { align?: unknown }).align;
+    const centered = createButtonBlock({
+      id: legacy.id,
+      text: "Go",
+      url: "#",
+      align: "center",
+    });
+
+    const legacyHtml = await compile(wrapBlock(renderBlock(legacy, ctx)));
+    const centeredHtml = await compile(wrapBlock(renderBlock(centered, ctx)));
+
+    expect(legacyHtml).toBe(centeredHtml);
+  });
+});

--- a/packages/renderer/tests/renderers.test.ts
+++ b/packages/renderer/tests/renderers.test.ts
@@ -112,6 +112,20 @@ describe('renderBlock', () => {
     expect(result).toContain('width="240px"');
   });
 
+  it('renders button alignment', () => {
+    for (const align of ['left', 'center', 'right'] as const) {
+      const block = createButtonBlock({ text: 'Click Me', align });
+      expect(renderBlock(block, ctx)).toContain(`align="${align}"`);
+    }
+  });
+
+  it('falls back to center for a button stored without align', () => {
+    const block = createButtonBlock({ text: 'Click Me' });
+    // Templates predating the field carry no `align` at all.
+    delete (block as { align?: unknown }).align;
+    expect(renderBlock(block, ctx)).toContain('align="center"');
+  });
+
   it('renders divider block', () => {
     const block = createDividerBlock({ color: '#ccc', thickness: 2, lineStyle: 'dashed' });
     const result = renderBlock(block, ctx);

--- a/packages/types/src/blocks.ts
+++ b/packages/types/src/blocks.ts
@@ -108,6 +108,11 @@ export interface ButtonBlock extends BaseBlock {
   buttonPadding: SpacingValue;
   fontFamily?: string;
   width?: number | "full";
+  /**
+   * Placement of the button within its column. No visible effect when `width`
+   * is `"full"`, since the button then spans the column.
+   */
+  align: "left" | "center" | "right";
 }
 
 export interface DividerBlock extends BaseBlock {

--- a/packages/types/src/defaults.ts
+++ b/packages/types/src/defaults.ts
@@ -66,6 +66,7 @@ export const BUTTON_BLOCK_DEFAULTS: BlockDefaultsFor<ButtonBlock> = {
   borderRadius: 6,
   fontSize: 15,
   buttonPadding: { top: 12, right: 24, bottom: 12, left: 24 },
+  align: "center",
 };
 
 export const DIVIDER_BLOCK_DEFAULTS: BlockDefaultsFor<DividerBlock> = {

--- a/packages/types/tests/factory.test.ts
+++ b/packages/types/tests/factory.test.ts
@@ -76,6 +76,13 @@ describe("block factory functions", () => {
     expect(block.type).toBe("button");
     expect(block.text).toBe("Click Here");
     expect(block.backgroundColor).toBe("#333333");
+    // Matches MJML's own default, so a new button renders where it always did.
+    expect(block.align).toBe("center");
+  });
+
+  it("creates a button block with an explicit align", () => {
+    const block = createButtonBlock({ align: "left" });
+    expect(block.align).toBe("left");
   });
 
   it("creates a divider block with defaults", () => {

--- a/skills/templatical-email/.claude-plugin/plugin.json
+++ b/skills/templatical-email/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "templatical-email",
   "description": "Generate and validate Templatical email templates as JSON — no backend, no API key.",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "author": { "name": "Templatical" },
   "homepage": "https://templatical.com",
   "repository": "https://github.com/templatical/sdk",

--- a/skills/templatical-email/reference/block-guide.md
+++ b/skills/templatical-email/reference/block-guide.md
@@ -121,6 +121,8 @@ underline: bool, color?: hex }`.
 - `backgroundColor` (hex), `textColor` (hex).
 - `borderRadius` (int), `fontSize` (int).
 - `buttonPadding` — `{ top, right, bottom, left }`.
+- `align` — `"left" | "center" | "right"`. Placement within the column; no
+  visible effect when `width` is `"full"`.
 - `openInNewTab` (bool, _optional_), `fontFamily` (_optional_), `width` (int |
   `"full"`, _optional_).
 

--- a/skills/templatical-email/reference/examples/event-invite.json
+++ b/skills/templatical-email/reference/examples/event-invite.json
@@ -90,7 +90,8 @@
               "right": 28,
               "bottom": 14,
               "left": 28
-            }
+            },
+            "align": "center"
           }
         ]
       ]

--- a/skills/templatical-email/reference/examples/product-sale.json
+++ b/skills/templatical-email/reference/examples/product-sale.json
@@ -57,7 +57,8 @@
               "right": 28,
               "bottom": 14,
               "left": 28
-            }
+            },
+            "align": "center"
           }
         ]
       ]

--- a/skills/templatical-email/reference/examples/receipt.json
+++ b/skills/templatical-email/reference/examples/receipt.json
@@ -132,7 +132,8 @@
               "right": 24,
               "bottom": 12,
               "left": 24
-            }
+            },
+            "align": "center"
           }
         ]
       ]

--- a/skills/templatical-email/reference/examples/welcome.json
+++ b/skills/templatical-email/reference/examples/welcome.json
@@ -62,7 +62,8 @@
               "right": 28,
               "bottom": 14,
               "left": 28
-            }
+            },
+            "align": "center"
           }
         ]
       ]

--- a/skills/templatical-email/reference/schema.json
+++ b/skills/templatical-email/reference/schema.json
@@ -533,9 +533,19 @@
               "const": "full"
             }
           ]
+        },
+        "align": {
+          "type": "string",
+          "enum": [
+            "left",
+            "center",
+            "right"
+          ],
+          "description": "Placement of the button within its column. No visible effect when `width` is `\"full\"`, since the button then spans the column."
         }
       },
       "required": [
+        "align",
         "backgroundColor",
         "borderRadius",
         "buttonPadding",


### PR DESCRIPTION
Closes #536.

`ButtonBlock` gains `align: "left" | "center" | "right"`, surfaced in the button toolbar as the same sliding control image, video, social, title, menu and table already use. The renderer passes it through to `mj-button`'s native `align` attribute, and the editor canvas — which previously hardcoded centering — now mirrors it, so the preview, saved-block previews and the test-email dialog all agree with what gets sent.

**Breaking (types):** `align` is required, matching `ImageBlock` / `VideoBlock` / `SocialIconsBlock`. Code that constructs a `ButtonBlock` literal without going through `createButtonBlock()` must add the field. Nothing else changes: the factory defaults to `"center"`, and both the renderer and the editor fall back to `"center"` for templates stored before the field existed, so existing content renders byte-for-byte as it did.

Note `align` has no visible effect when `width` is `"full"` — the button spans the column either way. The control stays visible in that state rather than appearing and disappearing with the width mode, matching the image toolbar.

The three importers now carry button alignment across instead of dropping it: BeeFree and Unlayer read the button's own `text-align`, and the HTML importer reads the wrapping cell's `text-align` or its legacy `align` attribute (an anchor is sized to its content, so its own `text-align` says nothing about placement).
