### PR TITLE
fix: merge tags whose values contain `<` or `>` (custom `mergeTags.syntax`)

### DIFF
--- a/.changeset/quiet-pugs-invite.md
+++ b/.changeset/quiet-pugs-invite.md
@@ -1,5 +1,5 @@
 ---
-"@templatical/types": minor
+"@templatical/types": patch
 "@templatical/renderer": patch
 ---
 

--- a/.changeset/quiet-pugs-invite.md
+++ b/.changeset/quiet-pugs-invite.md
@@ -1,0 +1,26 @@
+---
+"@templatical/types": minor
+"@templatical/renderer": patch
+---
+
+Fix merge tags whose values contain `<` or `>` (custom `mergeTags.syntax`)
+
+A consumer-configured syntax such as Smarty's `<% $email %>` reaches the stored
+markup as literal `<` / `>` — HTML attribute serialization escapes only `&`, `"`
+and nbsp — and both merge-tag span scanners stopped at the first `>` regardless
+of quoting, so the attribute they parsed was truncated and no tag resolved.
+
+Two symptoms, one cause:
+
+- **Previews.** Sample mode showed the label instead of the configured `sample`,
+  and Label mode left whatever text the span already carried.
+- **Export (worse).** `renderToMjml` left the entire
+  `<span data-merge-tag="…">Label</span>` in the output, so the ESP never
+  received the token and the recipient saw the label text. Silent — visible only
+  in a delivered email.
+
+Tag boundaries and attribute values are now read by two quote-aware primitives
+shared by both packages, `findOpenTagEnd` and `getTagAttrValue` (newly exported
+from `@templatical/types`). Both are forward-only character scans, so the
+linear-time guarantee the previous regexes were written for still holds. Values
+in single-quoted and unquoted attributes now resolve too.

--- a/packages/editor/scripts/e2e-consumer-prepare.mjs
+++ b/packages/editor/scripts/e2e-consumer-prepare.mjs
@@ -47,30 +47,44 @@ if (!existsSync(FIXTURE_DIR)) {
   throw new Error(`fixture dir not found: ${FIXTURE_DIR}`);
 }
 
-// Build editor and renderer in dependency order so packed tarballs ship the
-// latest local source. The renderer is an optional peer of the editor; the
+// Build types, editor and renderer in dependency order so packed tarballs ship
+// the latest local source. The renderer is an optional peer of the editor; the
 // e2e consumer installs both because we exercise `editor.toMjml()`.
+run(`pnpm --filter @templatical/types run build`, { cwd: REPO_ROOT });
 run(`pnpm --filter @templatical/renderer run build`, { cwd: REPO_ROOT });
 run(`pnpm --filter @templatical/editor run build`, { cwd: REPO_ROOT });
 
 const RENDERER_DIR = resolve(REPO_ROOT, "packages/renderer");
+// The renderer is the one package that leaves `@templatical/types` external
+// (the editor bundles it), so the consumer resolves types itself. Pack the
+// workspace copy: without it npm fetches the last *published* types, and any
+// symbol the renderer started importing this release is missing there. All
+// these packages are one fixed version group, so a released renderer never
+// meets an older types — only this harness could manufacture that pairing.
+const TYPES_DIR = resolve(REPO_ROOT, "packages/types");
 
 const packDir = mkdtempSync(join(tmpdir(), "tpl-e2e-pack-"));
 try {
   run(`pnpm pack --pack-destination "${packDir}"`, { cwd: EDITOR_DIR });
   run(`pnpm pack --pack-destination "${packDir}"`, { cwd: RENDERER_DIR });
+  run(`pnpm pack --pack-destination "${packDir}"`, { cwd: TYPES_DIR });
   const editorTarball = readdirSync(packDir).find(
     (f) => f.startsWith("templatical-editor-") && f.endsWith(".tgz"),
   );
   const rendererTarball = readdirSync(packDir).find(
     (f) => f.startsWith("templatical-renderer-") && f.endsWith(".tgz"),
   );
+  const typesTarball = readdirSync(packDir).find(
+    (f) => f.startsWith("templatical-types-") && f.endsWith(".tgz"),
+  );
   if (!editorTarball)
     throw new Error("pnpm pack did not produce an editor .tgz");
   if (!rendererTarball)
     throw new Error("pnpm pack did not produce a renderer .tgz");
+  if (!typesTarball) throw new Error("pnpm pack did not produce a types .tgz");
   const editorTarballPath = join(packDir, editorTarball);
   const rendererTarballPath = join(packDir, rendererTarball);
+  const typesTarballPath = join(packDir, typesTarball);
 
   rmSync(CONSUMER_DIR, { recursive: true, force: true });
   mkdirSync(CONSUMER_DIR, { recursive: true });
@@ -84,7 +98,8 @@ try {
   renameSync(tplPath, consumerPkgPath);
   const consumerPkgText = readFileSync(consumerPkgPath, "utf8")
     .replace("EDITOR_TARBALL_PLACEHOLDER", `file:${editorTarballPath}`)
-    .replace("RENDERER_TARBALL_PLACEHOLDER", `file:${rendererTarballPath}`);
+    .replace("RENDERER_TARBALL_PLACEHOLDER", `file:${rendererTarballPath}`)
+    .replace("TYPES_TARBALL_PLACEHOLDER", `file:${typesTarballPath}`);
   writeFileSync(consumerPkgPath, consumerPkgText);
 
   run(`npm install --no-fund --no-audit`, { cwd: CONSUMER_DIR });

--- a/packages/editor/scripts/webpack-consumer-verify.mjs
+++ b/packages/editor/scripts/webpack-consumer-verify.mjs
@@ -72,15 +72,25 @@ if (!existsSync(FIXTURE_DIR)) {
   fail(`fixture dir not found: ${FIXTURE_DIR}`);
 }
 
+run(`pnpm --filter @templatical/types run build`, { cwd: REPO_ROOT });
 run(`pnpm --filter @templatical/renderer run build`, { cwd: REPO_ROOT });
 run(`pnpm --filter @templatical/editor run build`, { cwd: REPO_ROOT });
 
 const RENDERER_DIR = resolve(REPO_ROOT, "packages/renderer");
+// The renderer is the one package that leaves `@templatical/types` external
+// (the editor bundles it), so the consumer resolves types itself. Pack the
+// workspace copy: without it npm fetches the last *published* types, and any
+// symbol the renderer started importing this release is missing there —
+// webpack reports it as `export '…' was not found`. All these packages are one
+// fixed version group, so a released renderer never meets an older types; only
+// this harness could manufacture that pairing.
+const TYPES_DIR = resolve(REPO_ROOT, "packages/types");
 
 const packDir = mkdtempSync(join(tmpdir(), "tpl-webpack-pack-"));
 try {
   run(`pnpm pack --pack-destination "${packDir}"`, { cwd: EDITOR_DIR });
   run(`pnpm pack --pack-destination "${packDir}"`, { cwd: RENDERER_DIR });
+  run(`pnpm pack --pack-destination "${packDir}"`, { cwd: TYPES_DIR });
 
   const editorTarball = readdirSync(packDir).find(
     (f) => f.startsWith("templatical-editor-") && f.endsWith(".tgz"),
@@ -88,11 +98,16 @@ try {
   const rendererTarball = readdirSync(packDir).find(
     (f) => f.startsWith("templatical-renderer-") && f.endsWith(".tgz"),
   );
+  const typesTarball = readdirSync(packDir).find(
+    (f) => f.startsWith("templatical-types-") && f.endsWith(".tgz"),
+  );
   if (!editorTarball) fail("pnpm pack did not produce an editor .tgz");
   if (!rendererTarball) fail("pnpm pack did not produce a renderer .tgz");
+  if (!typesTarball) fail("pnpm pack did not produce a types .tgz");
 
   const editorTarballPath = join(packDir, editorTarball);
   const rendererTarballPath = join(packDir, rendererTarball);
+  const typesTarballPath = join(packDir, typesTarball);
 
   rmSync(CONSUMER_DIR, { recursive: true, force: true });
   mkdirSync(CONSUMER_DIR, { recursive: true });
@@ -103,7 +118,8 @@ try {
   renameSync(tplPath, consumerPkgPath);
   const consumerPkgText = readFileSync(consumerPkgPath, "utf8")
     .replace("EDITOR_TARBALL_PLACEHOLDER", `file:${editorTarballPath}`)
-    .replace("RENDERER_TARBALL_PLACEHOLDER", `file:${rendererTarballPath}`);
+    .replace("RENDERER_TARBALL_PLACEHOLDER", `file:${rendererTarballPath}`)
+    .replace("TYPES_TARBALL_PLACEHOLDER", `file:${typesTarballPath}`);
   writeFileSync(consumerPkgPath, consumerPkgText);
 
   run(`npm install --no-fund --no-audit`, { cwd: CONSUMER_DIR });

--- a/packages/editor/tests/e2e-fixtures/vanilla-consumer/package.json.tpl
+++ b/packages/editor/tests/e2e-fixtures/vanilla-consumer/package.json.tpl
@@ -9,5 +9,9 @@
   },
   "devDependencies": {
     "vite": "^6.4.2"
+  },
+  "//overrides": "The dependencies above are exactly what a real consumer writes; @templatical/types arrives transitively through the renderer, which is the one package that leaves it external. The override only redirects that transitive resolution to the workspace build — npm would otherwise fetch the last published types, which predates any symbol the renderer started importing this release. The packages ship as one fixed version group, so a real install never pairs a new renderer with an older types.",
+  "overrides": {
+    "@templatical/types": "TYPES_TARBALL_PLACEHOLDER"
   }
 }

--- a/packages/editor/tests/e2e-fixtures/webpack-consumer/package.json.tpl
+++ b/packages/editor/tests/e2e-fixtures/webpack-consumer/package.json.tpl
@@ -10,5 +10,9 @@
     "null-loader": "^4.0.1",
     "webpack": "^5.97.1",
     "webpack-cli": "^5.1.4"
+  },
+  "//overrides": "The dependencies above are exactly what a real consumer writes; @templatical/types arrives transitively through the renderer, which is the one package that leaves it external. The override only redirects that transitive resolution to the workspace build — npm would otherwise fetch the last published types, which predates any symbol the renderer started importing this release. The packages ship as one fixed version group, so a real install never pairs a new renderer with an older types.",
+  "overrides": {
+    "@templatical/types": "TYPES_TARBALL_PLACEHOLDER"
   }
 }

--- a/packages/renderer/src/escape.ts
+++ b/packages/renderer/src/escape.ts
@@ -1,3 +1,5 @@
+import { findOpenTagEnd, getTagAttrValue } from "@templatical/types";
+
 const HTML_ENTITIES: Record<string, string> = {
   "&": "&amp;",
   "<": "&lt;",
@@ -61,8 +63,8 @@ export function escapeCssValue(text: string): string {
  * Uses a single-pass linear scan instead of an `[^>]*…[^>]*` regex because
  * the latter is polynomial-ReDoS over inputs that contain many `<span`
  * starts but no closing `>` — the engine retries `[^>]*` at every span
- * position. The scan below resolves each `<span>` open tag with a bounded
- * `indexOf('>')`, keeping the work strictly O(n).
+ * position. The scan below resolves each `<span>` open tag with a bounded,
+ * quote-aware `findOpenTagEnd`, keeping the work strictly O(n).
  */
 export function convertMergeTagsToValues(html: string): string {
   if (html === "") {
@@ -109,7 +111,7 @@ function rewriteMergeTagSpans(
       i = open + 5;
       continue;
     }
-    const openEnd = html.indexOf(">", open + 5);
+    const openEnd = findOpenTagEnd(html, open + 5);
     if (openEnd === -1) {
       out += html.substring(i);
       break;
@@ -138,11 +140,15 @@ function rewriteMergeTagSpans(
 
 /**
  * Extract the value of `name="…"` from an HTML attribute string, or `null`
- * if absent. Uses `[^<>"]*` for the value match so a missing closing quote
- * fails fast rather than backtracking across the full input.
+ * if absent.
+ *
+ * Delegates to `@templatical/types` so the editor's preview rewriter and this
+ * export rewriter read markup identically. They were separate regexes once, and
+ * both excluded `<` / `>` from the value — which silently left the whole span
+ * in the rendered MJML whenever a consumer configured a merge-tag syntax whose
+ * values contain those characters (`<% $email %>`), so the ESP never received
+ * the token.
  */
 function findAttr(attrs: string, name: string): string | null {
-  const pattern = new RegExp(`(?:^|\\s)${name}="([^"<>]*)"`);
-  const match = pattern.exec(attrs);
-  return match ? match[1] : null;
+  return getTagAttrValue(attrs, name);
 }

--- a/packages/renderer/tests/escape.test.ts
+++ b/packages/renderer/tests/escape.test.ts
@@ -96,4 +96,41 @@ describe('convertMergeTagsToValues', () => {
     expect(result).toBe(adversarial);
     expect(elapsed).toBeLessThan(500);
   });
+
+  // Regression (#543). This is the send path: a tag value the scanner cannot
+  // read leaves the whole span in the rendered output, so the ESP never
+  // receives the token and the recipient sees the label text instead.
+  it('converts a tag value containing `<` and `>` back to the token', () => {
+    const html = '<p>Hi <span data-merge-tag="<% $email %>" data-label="E-Mail">E-Mail</span>,</p>';
+    expect(convertMergeTagsToValues(html)).toBe('<p>Hi <% $email %>,</p>');
+  });
+
+  it('converts a tag value containing `<` only', () => {
+    const html = '<span data-merge-tag="[[a<b]]">Nickname</span>';
+    expect(convertMergeTagsToValues(html)).toBe('[[a<b]]');
+  });
+
+  it('converts a logic tag value containing `<` and `>`', () => {
+    const html = '<span data-logic-merge-tag="<% if $active %>">IF</span>';
+    expect(convertMergeTagsToValues(html)).toBe('<% if $active %>');
+  });
+
+  it('reads a value out of a single-quoted attribute', () => {
+    const html = "<span data-merge-tag='<% $email %>'>E-Mail</span>";
+    expect(convertMergeTagsToValues(html)).toBe('<% $email %>');
+  });
+
+  it('leaves a span whose merge-tag attribute never closes its quote', () => {
+    const html = '<span data-merge-tag="{{name}}>Label</span>';
+    expect(convertMergeTagsToValues(html)).toBe(html);
+  });
+
+  it('runs in linear time when many tag values contain `>` (ReDoS regression)', () => {
+    const adversarial = '<span data-merge-tag="<% $email %>">x</span>'.repeat(5_000);
+    const start = Date.now();
+    const result = convertMergeTagsToValues(adversarial);
+    const elapsed = Date.now() - start;
+    expect(result).toBe('<% $email %>'.repeat(5_000));
+    expect(elapsed).toBeLessThan(500);
+  });
 });

--- a/packages/renderer/tests/merge-tag-fields.test.ts
+++ b/packages/renderer/tests/merge-tag-fields.test.ts
@@ -103,3 +103,39 @@ describe("renderer — group/description fields never leak into MJML", () => {
     expect(mjml).not.toContain("Personalized greeting");
   });
 });
+
+/**
+ * Regression (#543). A consumer-configured custom `mergeTags.syntax` whose tag
+ * values contain `<` / `>` (Smarty-style `<% $email %>`) used to defeat the
+ * span scanner, so the entire `<span data-merge-tag="…">E-Mail</span>` survived
+ * into the rendered MJML: the ESP never saw the token and the recipient got the
+ * literal label text. Silent, and only visible in a delivered email.
+ */
+describe("renderer — angle-bracket merge tag values reach the output as tokens", () => {
+  const smartySpan =
+    '<span data-merge-tag="<% $email %>" data-label="E-Mail">E-Mail</span>';
+
+  it("paragraph block: emits the token, not the span or its label", async () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [
+      createParagraphBlock({ content: `<p>Hi ${smartySpan},</p>` }),
+    ];
+
+    const mjml = await renderToMjml(content);
+
+    expect(mjml).toContain("<p>Hi <% $email %>,</p>");
+    expect(mjml).not.toContain("data-merge-tag");
+    expect(mjml).not.toContain("E-Mail");
+  });
+
+  it("title block: emits the token, not the span or its label", async () => {
+    const content = createDefaultTemplateContent();
+    content.blocks = [createTitleBlock({ content: `<h1>${smartySpan}</h1>` })];
+
+    const mjml = await renderToMjml(content);
+
+    expect(mjml).toContain("<% $email %>");
+    expect(mjml).not.toContain("data-merge-tag");
+    expect(mjml).not.toContain(">E-Mail<");
+  });
+});

--- a/packages/types/src/html-scan.ts
+++ b/packages/types/src/html-scan.ts
@@ -1,0 +1,127 @@
+/**
+ * Minimal, allocation-free primitives for reading an HTML open tag out of a
+ * markup string. They exist because merge-tag markup is rewritten from a raw
+ * string in two packages — `@templatical/types` (label / sample resolution for
+ * the previews) and `@templatical/renderer` (converting spans back to tokens on
+ * export) — and both need the same two answers: where does this open tag end,
+ * and what is the value of one of its attributes.
+ *
+ * Both are hand-written character scans rather than regexes. A regex over an
+ * attribute string with no closing quote backtracks across the whole input,
+ * which is the ReDoS class the span scanners were rewritten to avoid; a scan
+ * that only moves forward cannot.
+ */
+
+const QUOTES = new Set(['"', "'"]);
+
+/**
+ * Index of the `>` that closes the open tag whose name ends at `from`, or `-1`
+ * when the tag never closes.
+ *
+ * Quote-aware: a `>` inside a quoted attribute value does not end the tag.
+ * That matters because a consumer may configure a merge-tag syntax whose tag
+ * values contain `<` / `>` — Smarty-style `<% $email %>` — and HTML attribute
+ * serialization escapes only `&`, `"` and U+00A0, so those characters reach the
+ * markup literally. A plain `indexOf(">")` stops mid-attribute there and every
+ * caller downstream sees a truncated attribute string.
+ *
+ * An unterminated quote yields `-1` rather than a guessed tag end: callers
+ * treat that as "not markup I can rewrite" and emit the input untouched, which
+ * is the safe answer for malformed HTML.
+ */
+export function findOpenTagEnd(html: string, from: number): number {
+  let quote: string | null = null;
+  for (let i = from; i < html.length; i++) {
+    const char = html[i];
+    if (quote !== null) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (QUOTES.has(char)) {
+      quote = char;
+      continue;
+    }
+    if (char === ">") return i;
+  }
+  return -1;
+}
+
+function isAttrNameChar(char: string): boolean {
+  return (
+    char !== " " &&
+    char !== "\t" &&
+    char !== "\n" &&
+    char !== "\r" &&
+    char !== "\f" &&
+    char !== "=" &&
+    char !== ">" &&
+    char !== "/"
+  );
+}
+
+function isWhitespace(char: string): boolean {
+  return (
+    char === " " ||
+    char === "\t" ||
+    char === "\n" ||
+    char === "\r" ||
+    char === "\f"
+  );
+}
+
+/**
+ * The value of the `name` attribute within an open tag's attribute string (the
+ * text between the tag name and its closing `>`), or `null` when the attribute
+ * is absent or its quoted value is never closed.
+ *
+ * Handles double-quoted, single-quoted and unquoted values, and matches the
+ * attribute name case-insensitively, as HTML does. Attribute values are not
+ * entity-decoded — callers compare them against configured merge-tag tokens,
+ * which are stored the same way.
+ */
+export function getTagAttrValue(attrs: string, name: string): string | null {
+  const target = name.toLowerCase();
+  let i = 0;
+
+  while (i < attrs.length) {
+    while (i < attrs.length && (isWhitespace(attrs[i]) || attrs[i] === "/")) {
+      i++;
+    }
+    if (i >= attrs.length) break;
+
+    const nameStart = i;
+    while (i < attrs.length && isAttrNameChar(attrs[i])) i++;
+    const attrName = attrs.substring(nameStart, i).toLowerCase();
+    if (attrName === "") {
+      // Not a name character and not whitespace — e.g. a stray `=`. Step over
+      // it so the scan always advances.
+      i++;
+      continue;
+    }
+
+    while (i < attrs.length && isWhitespace(attrs[i])) i++;
+    if (attrs[i] !== "=") {
+      // A boolean attribute (`hidden`); the cursor already sits on the next
+      // attribute name, so don't consume anything here.
+      continue;
+    }
+    i++; // past `=`
+    while (i < attrs.length && isWhitespace(attrs[i])) i++;
+
+    const quote = attrs[i];
+    if (QUOTES.has(quote)) {
+      const valueStart = i + 1;
+      const valueEnd = attrs.indexOf(quote, valueStart);
+      if (valueEnd === -1) return null; // unterminated value — nothing readable follows
+      if (attrName === target) return attrs.substring(valueStart, valueEnd);
+      i = valueEnd + 1;
+      continue;
+    }
+
+    const valueStart = i;
+    while (i < attrs.length && !isWhitespace(attrs[i]) && attrs[i] !== ">") i++;
+    if (attrName === target) return attrs.substring(valueStart, i);
+  }
+
+  return null;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -137,6 +137,7 @@ export { EventEmitter } from "./events";
 
 // Utilities
 export { safeClone } from "./clone";
+export { findOpenTagEnd, getTagAttrValue } from "./html-scan";
 
 // Merge tags
 export type { SyntaxPreset, SyntaxPresetName } from "./merge-tags";

--- a/packages/types/src/merge-tags.ts
+++ b/packages/types/src/merge-tags.ts
@@ -1,4 +1,5 @@
 import type { MergeTag } from "./config";
+import { findOpenTagEnd, getTagAttrValue } from "./html-scan";
 
 // --- Syntax Presets ---
 
@@ -284,6 +285,13 @@ export function resolveHtmlLogicMergeTagLabels(
  * Replaces the original `/<span[^>]*…[^>]*>(.*?)<\/span>/g` pattern, which
  * was polynomial-ReDoS over inputs that contained many `<span` starts with
  * no closing `>`.
+ *
+ * Tag boundaries and attribute values are resolved by `findOpenTagEnd` /
+ * `getTagAttrValue`, which are quote-aware. A merge-tag value may itself
+ * contain `<` / `>` when the consumer configures a custom syntax — Smarty-style
+ * `<% $email %>` — and those characters survive attribute serialization
+ * verbatim, so anything that treats the first `>` as the tag end reads a
+ * truncated attribute and resolves nothing.
  */
 function rewriteSpanByAttr(
   html: string,
@@ -291,9 +299,6 @@ function rewriteSpanByAttr(
   relabel: (value: string) => string,
   options?: { unwrap?: (value: string) => boolean },
 ): string {
-  // Anchored on `>` per match. `[^<>"]*` for the attribute value fails fast
-  // on a missing closing quote instead of backtracking across the input.
-  const attrPattern = new RegExp(`(?:^|\\s)${attrName}="([^"<>]*)"`);
   let out = "";
   let i = 0;
   while (i < html.length) {
@@ -315,7 +320,7 @@ function rewriteSpanByAttr(
       i = open + 5;
       continue;
     }
-    const openEnd = html.indexOf(">", open + 5);
+    const openEnd = findOpenTagEnd(html, open + 5);
     if (openEnd === -1) {
       out += html.substring(i);
       break;
@@ -326,8 +331,8 @@ function rewriteSpanByAttr(
       break;
     }
     const attrs = html.substring(open + 5, openEnd);
-    const attrMatch = attrPattern.exec(attrs);
-    if (!attrMatch) {
+    const value = getTagAttrValue(attrs, attrName);
+    if (value === null) {
       // This `<span>` isn't the one we're looking for — emit up to and
       // including the `<span` literal and let the next iteration scan
       // inward. Skipping straight to the matching `</span>` would swallow
@@ -336,7 +341,6 @@ function rewriteSpanByAttr(
       i = open + 5;
       continue;
     }
-    const value = attrMatch[1];
     const newLabel = relabel(value);
     if (options?.unwrap?.(value)) {
       // Emit the text before the span, then the replacement alone — the open

--- a/packages/types/tests/html-scan.test.ts
+++ b/packages/types/tests/html-scan.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { findOpenTagEnd, getTagAttrValue } from "../src/html-scan";
+
+describe("findOpenTagEnd", () => {
+  it("returns the index of the `>` that closes the open tag", () => {
+    const html = '<span data-merge-tag="{{a}}">L</span>';
+    const end = findOpenTagEnd(html, 5);
+    expect(end).toBe(28);
+    expect(html[end]).toBe(">");
+  });
+
+  it("ignores a `>` inside a double-quoted attribute value", () => {
+    // Regression (#543): a custom merge-tag syntax whose value contains `>`
+    // — e.g. Smarty-style `<% $email %>` — used to terminate the open-tag
+    // scan mid-attribute, truncating the attribute string.
+    const html = '<span data-merge-tag="<% $email %>">E-Mail</span>';
+    const end = findOpenTagEnd(html, 5);
+    expect(html.substring(5, end)).toBe(' data-merge-tag="<% $email %>"');
+    expect(html[end]).toBe(">");
+  });
+
+  it("ignores a `>` inside a single-quoted attribute value", () => {
+    const html = "<span data-merge-tag='<% $email %>'>E-Mail</span>";
+    const end = findOpenTagEnd(html, 5);
+    expect(html.substring(5, end)).toBe(" data-merge-tag='<% $email %>'");
+  });
+
+  it("does not treat a quote inside the other quote style as a delimiter", () => {
+    const html = `<span title="it's > here" data-merge-tag="{{a}}">L</span>`;
+    const end = findOpenTagEnd(html, 5);
+    expect(html.substring(5, end)).toBe(
+      ` title="it's > here" data-merge-tag="{{a}}"`,
+    );
+  });
+
+  it("returns -1 when the open tag never closes", () => {
+    expect(findOpenTagEnd("<span data-merge-tag=", 5)).toBe(-1);
+  });
+
+  it("returns -1 on an unterminated quote rather than guessing a tag end", () => {
+    expect(findOpenTagEnd('<span data-merge-tag="{{a}}>L</span>', 5)).toBe(-1);
+  });
+
+  it("handles an open tag with no attributes", () => {
+    expect(findOpenTagEnd("<span>L</span>", 5)).toBe(5);
+  });
+});
+
+describe("getTagAttrValue", () => {
+  it("extracts a double-quoted value", () => {
+    expect(getTagAttrValue(' data-merge-tag="{{a}}"', "data-merge-tag")).toBe(
+      "{{a}}",
+    );
+  });
+
+  it("extracts a value containing `<` and `>` (#543)", () => {
+    expect(
+      getTagAttrValue(' data-merge-tag="<% $email %>"', "data-merge-tag"),
+    ).toBe("<% $email %>");
+  });
+
+  it("extracts a single-quoted value", () => {
+    expect(getTagAttrValue(" data-merge-tag='{{a}}'", "data-merge-tag")).toBe(
+      "{{a}}",
+    );
+  });
+
+  it("extracts an unquoted value", () => {
+    expect(
+      getTagAttrValue(" data-merge-tag=abc class=x", "data-merge-tag"),
+    ).toBe("abc");
+  });
+
+  it("matches the attribute name case-insensitively", () => {
+    expect(getTagAttrValue(' DATA-MERGE-TAG="{{a}}"', "data-merge-tag")).toBe(
+      "{{a}}",
+    );
+  });
+
+  it("returns null when the attribute is absent", () => {
+    expect(
+      getTagAttrValue(' class="x" style="color:red"', "data-merge-tag"),
+    ).toBe(null);
+  });
+
+  it("does not match a name that merely ends with the requested one", () => {
+    expect(getTagAttrValue(' xdata-merge-tag="{{a}}"', "data-merge-tag")).toBe(
+      null,
+    );
+  });
+
+  it("does not match the requested name as a prefix of a longer one", () => {
+    expect(getTagAttrValue(' data-merge-tag-index="3"', "data-merge-tag")).toBe(
+      null,
+    );
+  });
+
+  it("returns an empty string for an empty value", () => {
+    expect(getTagAttrValue(' data-merge-tag=""', "data-merge-tag")).toBe("");
+  });
+
+  it("returns null for an unterminated quoted value", () => {
+    expect(getTagAttrValue(' data-merge-tag="{{a}}', "data-merge-tag")).toBe(
+      null,
+    );
+  });
+
+  it("skips a boolean attribute that precedes the match", () => {
+    expect(
+      getTagAttrValue(' hidden data-merge-tag="{{a}}"', "data-merge-tag"),
+    ).toBe("{{a}}");
+  });
+
+  it("runs in linear time over many attributes ending in an unterminated quote", () => {
+    // The shape a backtracking regex chokes on: thousands of candidate
+    // positions for the attribute name, and a value whose quote never closes.
+    const adversarial =
+      ' class="x"'.repeat(20_000) + ' data-merge-tag="unterminated';
+    const start = Date.now();
+    expect(getTagAttrValue(adversarial, "data-merge-tag")).toBe(null);
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  it("pairs quotes the way an HTML parser does", () => {
+    // `"a" b="c` — the second quote closes the first, so `x` reads as `a`.
+    expect(getTagAttrValue(' x="a" data-merge-tag="c"', "x")).toBe("a");
+  });
+});

--- a/packages/types/tests/merge-tags.test.ts
+++ b/packages/types/tests/merge-tags.test.ts
@@ -716,3 +716,80 @@ describe('hasMergeTagSamples', () => {
         ).toBe(true);
     });
 });
+
+// Regression (#543): a consumer-configured custom `mergeTags.syntax` whose tag
+// values contain `<` / `>` — e.g. Smarty-style `<% $email %>` — reaches the
+// attribute as literal characters, because HTML attribute serialization escapes
+// only `&`, `"` and nbsp. The span scanner used to stop at the first `>`
+// regardless of quoting, so neither Label nor Sample mode resolved anything.
+describe('angle-bracket tag values (custom syntax)', () => {
+    const smartyTags: MergeTag[] = [
+        { label: 'E-Mail', value: '<% $email %>', sample: 'foo@example.com' },
+        { label: 'Nickname', value: '[[a<b]]', sample: 'Ada' },
+    ];
+
+    const smartySyntax = {
+        value: /<%\s*\$[^%]*%>/g,
+        logic: /<%\s*(?!\$)(\w+)[^%]*%>/g,
+    };
+
+    it('resolves the label of a value containing `<` and `>`', () => {
+        const html =
+            '<p>Hi <span data-merge-tag="<% $email %>">stale</span>,</p>';
+        expect(resolveHtmlMergeTagLabels(html, smartyTags)).toBe(
+            '<p>Hi <span data-merge-tag="<% $email %>">E-Mail</span>,</p>',
+        );
+    });
+
+    it('resolves the label of a value containing `<` only', () => {
+        const html = '<span data-merge-tag="[[a<b]]">stale</span>';
+        expect(resolveHtmlMergeTagLabels(html, smartyTags)).toBe(
+            '<span data-merge-tag="[[a<b]]">Nickname</span>',
+        );
+    });
+
+    it('substitutes the sample and unwraps the span', () => {
+        const html =
+            '<p>Hi <span data-merge-tag="<% $email %>">E-Mail</span>,</p>';
+        expect(substituteHtmlMergeTagSamples(html, smartyTags)).toBe(
+            '<p>Hi foo@example.com,</p>',
+        );
+    });
+
+    it('keeps the span and shows the label when no sample is configured', () => {
+        const html = '<span data-merge-tag="<% $phone %>">stale</span>';
+        expect(substituteHtmlMergeTagSamples(html, smartyTags)).toBe(
+            // Unknown tag: the label falls back to the raw value (escaped, since
+            // it is being inlined as text), and the span survives.
+            '<span data-merge-tag="<% $phone %>">&lt;% $phone %&gt;</span>',
+        );
+    });
+
+    it('resolves a logic tag whose syntax contains `<` and `>`', () => {
+        const html =
+            '<span data-logic-merge-tag="<% if $active %>">stale</span>';
+        expect(resolveHtmlLogicMergeTagLabels(html, smartySyntax)).toBe(
+            '<span data-logic-merge-tag="<% if $active %>">IF</span>',
+        );
+    });
+
+    it('resolves a tag nested inside a styled span', () => {
+        const html =
+            '<span style="color: red"><span data-merge-tag="<% $email %>">stale</span></span>';
+        expect(resolveHtmlMergeTagLabels(html, smartyTags)).toBe(
+            '<span style="color: red"><span data-merge-tag="<% $email %>">E-Mail</span></span>',
+        );
+    });
+
+    it('runs in linear time when many tag values contain `>` (ReDoS regression)', () => {
+        const adversarial =
+            '<span data-merge-tag="<% $email %>">x</span>'.repeat(5_000);
+        const start = Date.now();
+        const result = resolveHtmlMergeTagLabels(adversarial, smartyTags);
+        const elapsed = Date.now() - start;
+        expect(result).toBe(
+            '<span data-merge-tag="<% $email %>">E-Mail</span>'.repeat(5_000),
+        );
+        expect(elapsed).toBeLessThan(500);
+    });
+});


### PR DESCRIPTION
Closes #543.

Fix merge tags whose values contain `<` or `>` (custom `mergeTags.syntax`)

A consumer-configured syntax such as Smarty's `<% $email %>` reaches the stored markup as literal `<` / `>` — HTML attribute serialization escapes only `&`, `"` and nbsp — and both merge-tag span scanners stopped at the first `>` regardless of quoting, so the attribute they parsed was truncated and no tag resolved.

Two symptoms, one cause:

- **Previews.** Sample mode showed the label instead of the configured `sample`, and Label mode left whatever text the span already carried.
- **Export (worse).** `renderToMjml` left the entire `<span data-merge-tag="…">Label</span>` in the output, so the ESP never received the token and the recipient saw the label text. Silent — visible only in a delivered email.

Tag boundaries and attribute values are now read by two quote-aware primitives shared by both packages, `findOpenTagEnd` and `getTagAttrValue` (newly exported from `@templatical/types`). Both are forward-only character scans, so the linear-time guarantee the previous regexes were written for still holds. Values in single-quoted and unquoted attributes now resolve too.
