### PR TITLE
fix: clicking a block in the sidebar palette now inserts it directly below the selected block, and scrolls it into view

### DIFF
--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -1,0 +1,18 @@
+---
+"@templatical/editor": patch
+---
+
+Clicking a block in the sidebar palette now inserts it directly below the selected block, and scrolls it into view
+
+Previously a palette click always appended to the end of the template. On anything longer than a screen the new block landed below the fold and the canvas never moved, so the click read as though it had failed (#568).
+
+Insertion now follows the selection, the same rule `duplicateBlock` already used:
+
+- A top-level selection gets the new block immediately after it.
+- A selection nested in a section column gets it in that same column, right after it.
+- Adding a **section** while a nested block is selected places it beside the parent section at the top level — MJML forbids `mj-section` inside `mj-column`, so the column would have rejected it outright.
+- No selection, an unresolvable selection, or a section locked by a collaborator still appends at the end.
+
+Separately, the inserted block is now scrolled into view (`block: "nearest"`, so an already-visible block doesn't jump, and instantly under `prefers-reduced-motion`). This covers the append-at-the-end case too, where the position is correct but the canvas still needs to follow. The Issues panel's **Jump to block** button gained the same scroll — it selected the block without moving the canvas, so on a long template it also appeared to do nothing.
+
+Click-to-insert is unchanged as an affordance; it remains the only keyboard-reachable way to add a block (Enter/Space on a focused palette entry), which is why it was not replaced with a drag-only flow.

--- a/apps/playground/e2e/pages/editor.page.ts
+++ b/apps/playground/e2e/pages/editor.page.ts
@@ -82,6 +82,67 @@ export class EditorPage {
     return ids;
   }
 
+  /**
+   * Click a palette entry to insert a block — the keyboard-reachable path that
+   * exists alongside dragging. Self-verifies that a block actually landed.
+   */
+  async clickPaletteItem(blockType: string): Promise<void> {
+    const before = await this.getBlocks().count();
+    await this.page
+      .locator(SELECTORS.sidebarRail)
+      .locator(paletteByType(blockType))
+      .click();
+    await expect
+      .poll(() => this.getBlocks().count(), { timeout: 5000 })
+      .toBe(before + 1);
+  }
+
+  /**
+   * Whether a block's box currently overlaps the scrolling canvas viewport.
+   *
+   * The selector has to pierce the shadow root in `chromium-shadow`, and the
+   * lookup is inlined because `page.evaluate` serializes its callback and
+   * cannot close over a module-level helper.
+   */
+  async isBlockVisibleInCanvas(blockId: string): Promise<boolean> {
+    return this.page.evaluate((id) => {
+      const selector = `[data-block-id="${id}"]`;
+      let el: Element | null = document.querySelector(selector);
+      if (!el) {
+        for (const host of Array.from(document.querySelectorAll("*"))) {
+          const inside = host.shadowRoot?.querySelector(selector);
+          if (inside) {
+            el = inside;
+            break;
+          }
+        }
+      }
+      if (!el) return false;
+      const body = el.closest(".tpl-body");
+      if (!body) return false;
+      const b = el.getBoundingClientRect();
+      const v = body.getBoundingClientRect();
+      return b.bottom > v.top && b.top < v.bottom;
+    }, blockId);
+  }
+
+  /** The canvas scroll offset, or -1 when the scroll container isn't found. */
+  async getCanvasScrollTop(): Promise<number> {
+    return this.page.evaluate(() => {
+      let body: Element | null = document.querySelector(".tpl-body");
+      if (!body) {
+        for (const host of Array.from(document.querySelectorAll("*"))) {
+          const inside = host.shadowRoot?.querySelector(".tpl-body");
+          if (inside) {
+            body = inside;
+            break;
+          }
+        }
+      }
+      return body ? body.scrollTop : -1;
+    });
+  }
+
   async selectBlock(index: number): Promise<void> {
     await this.getBlocks().nth(index).click();
     await this.page.locator(SELECTORS.blockSelected).waitFor();

--- a/apps/playground/e2e/tests/palette-insert-position.spec.ts
+++ b/apps/playground/e2e/tests/palette-insert-position.spec.ts
@@ -1,0 +1,189 @@
+import { expect } from "@playwright/test";
+import { test } from "../fixtures/editor.fixture";
+import { SELECTORS } from "../helpers/selectors";
+
+/**
+ * Issue #568 — clicking a palette item always appended to the end of the
+ * template. On anything long the new block landed far below the fold and the
+ * canvas never moved, so the click read as a no-op.
+ *
+ * Product Launch is the fixture on purpose: `selectFirstTemplate()` opens it,
+ * it is several screens tall, and it contains a section with column children,
+ * which is what exercises the nested branches.
+ */
+test.describe("palette insert position", () => {
+  test("inserts directly below the selected top-level block", async ({
+    editorReady,
+  }) => {
+    const { editorPage } = editorReady;
+    const typesBefore = await editorPage.getTopLevelBlockTypes();
+    // A block near the top, so an appended block would be far off-screen.
+    const anchorIndex = 3;
+    await editorPage.getTopLevelBlocks().nth(anchorIndex).click();
+    await editorPage.page.locator(SELECTORS.blockSelected).waitFor();
+
+    await editorPage.clickPaletteItem("divider");
+
+    const typesAfter = await editorPage.getTopLevelBlockTypes();
+    expect(typesAfter).toHaveLength(typesBefore.length + 1);
+    expect(typesAfter[anchorIndex + 1]).toBe("divider");
+    // The rest of the template is untouched around the insertion point.
+    expect(typesAfter.slice(0, anchorIndex + 1)).toEqual(
+      typesBefore.slice(0, anchorIndex + 1),
+    );
+    expect(typesAfter.slice(anchorIndex + 2)).toEqual(
+      typesBefore.slice(anchorIndex + 1),
+    );
+  });
+
+  test("leaves the inserted block visible on the canvas", async ({
+    editorReady,
+  }) => {
+    // The reported symptom: the block was created and selected but sat below
+    // the fold with the canvas unmoved, so nothing appeared to happen.
+    const { editorPage } = editorReady;
+    await editorPage.getTopLevelBlocks().nth(3).click();
+    await editorPage.page.locator(SELECTORS.blockSelected).waitFor();
+
+    await editorPage.clickPaletteItem("divider");
+
+    const insertedId = await editorPage.page
+      .locator(SELECTORS.blockSelected)
+      .getAttribute("data-block-id");
+    expect(insertedId).toBeTruthy();
+    await expect
+      .poll(() => editorPage.isBlockVisibleInCanvas(insertedId!), {
+        timeout: 5000,
+      })
+      .toBe(true);
+  });
+
+  test("appends at the end with nothing selected, and scrolls there", async ({
+    editorReady,
+  }) => {
+    // Appending is still right when there is no selection — but the canvas has
+    // to follow, which is the half of the fix that covers this case.
+    const { editorPage } = editorReady;
+    await editorPage.page.keyboard.press("Escape");
+    await expect(editorPage.page.locator(SELECTORS.blockSelected)).toHaveCount(
+      0,
+    );
+    expect(await editorPage.getCanvasScrollTop()).toBe(0);
+    const typesBefore = await editorPage.getTopLevelBlockTypes();
+
+    await editorPage.clickPaletteItem("spacer");
+
+    const typesAfter = await editorPage.getTopLevelBlockTypes();
+    expect(typesAfter).toHaveLength(typesBefore.length + 1);
+    expect(typesAfter[typesAfter.length - 1]).toBe("spacer");
+    await expect
+      .poll(() => editorPage.getCanvasScrollTop(), { timeout: 5000 })
+      .toBeGreaterThan(0);
+  });
+
+  test("inserts into the same section column below a nested selection", async ({
+    editorReady,
+  }) => {
+    const { editorPage } = editorReady;
+    const section = editorPage.page
+      .locator(`${SELECTORS.block}[data-block-type="section"]`)
+      .first();
+    await section.waitFor();
+    const nestedChild = section.locator(SELECTORS.block).first();
+    const childId = await nestedChild.getAttribute("data-block-id");
+    expect(childId).toBeTruthy();
+    const siblingsBefore = await section.locator(SELECTORS.block).count();
+    const topLevelBefore = await editorPage.getTopLevelBlocks().count();
+
+    await nestedChild.click();
+    await expect(
+      editorPage.page.locator(
+        `${SELECTORS.blockSelected}[data-block-id="${childId}"]`,
+      ),
+    ).toHaveCount(1);
+
+    await editorPage.clickPaletteItem("paragraph");
+
+    // The block joined the section rather than the top level.
+    expect(await section.locator(SELECTORS.block).count()).toBe(
+      siblingsBefore + 1,
+    );
+    expect(await editorPage.getTopLevelBlocks().count()).toBe(topLevelBefore);
+    // And it landed immediately after the block that was selected.
+    const ids = await section
+      .locator(SELECTORS.block)
+      .evaluateAll((els) =>
+        els.map((el) => el.getAttribute("data-block-id") ?? ""),
+      );
+    const insertedId = await editorPage.page
+      .locator(SELECTORS.blockSelected)
+      .last()
+      .getAttribute("data-block-id");
+    expect(ids.indexOf(insertedId!)).toBe(ids.indexOf(childId!) + 1);
+  });
+
+  test("adds a section beside the parent when the selection is nested", async ({
+    editorReady,
+  }) => {
+    // A section cannot live in a column — MJML forbids `mj-section` inside
+    // `mj-column`, so the editor refuses that insert outright. Without the
+    // top-level fallback this click would do nothing at all.
+    const { editorPage } = editorReady;
+    const section = editorPage.page
+      .locator(`${SELECTORS.block}[data-block-type="section"]`)
+      .first();
+    await section.waitFor();
+    const nestedChild = section.locator(SELECTORS.block).first();
+    await nestedChild.click();
+    await editorPage.page.locator(SELECTORS.blockSelected).waitFor();
+
+    const idsBefore = await editorPage.getTopLevelBlockIds();
+    const parentId = await section.getAttribute("data-block-id");
+    const parentIndex = idsBefore.indexOf(parentId!);
+    expect(parentIndex).toBeGreaterThan(-1);
+
+    await editorPage.clickPaletteItem("section");
+
+    // Asserted by id against an exact splice, not by the type at a position:
+    // Product Launch has two adjacent sections, so "the type after the parent
+    // is a section" is already true before the insert and stays true for an
+    // append — an assertion like that passes on the unfixed code.
+    const idsAfter = await editorPage.getTopLevelBlockIds();
+    const insertedId = await editorPage.page
+      .locator(SELECTORS.blockSelected)
+      .getAttribute("data-block-id");
+    expect(insertedId).toBeTruthy();
+    expect(idsAfter.indexOf(insertedId!)).toBe(parentIndex + 1);
+
+    const expected = [...idsBefore];
+    expected.splice(parentIndex + 1, 0, insertedId!);
+    expect(idsAfter).toEqual(expected);
+    // Top level, not swallowed into the column the selection lives in.
+    const typesAfter = await editorPage.getTopLevelBlockTypes();
+    expect(typesAfter[parentIndex + 1]).toBe("section");
+  });
+
+  test("keyboard activation places the block by the same rule", async ({
+    editorReady,
+  }) => {
+    // Enter/Space on a focused palette entry is the only pointer-free way to
+    // add a block, so it must not keep the old append-at-the-end behaviour.
+    const { editorPage } = editorReady;
+    const typesBefore = await editorPage.getTopLevelBlockTypes();
+    const anchorIndex = 2;
+    await editorPage.getTopLevelBlocks().nth(anchorIndex).click();
+    await editorPage.page.locator(SELECTORS.blockSelected).waitFor();
+
+    const entry = editorPage.page
+      .locator(SELECTORS.sidebarRail)
+      .locator('[data-palette-type="divider"]');
+    await entry.focus();
+    await entry.press("Enter");
+
+    await expect
+      .poll(() => editorPage.getTopLevelBlocks().count(), { timeout: 5000 })
+      .toBe(typesBefore.length + 1);
+    const typesAfter = await editorPage.getTopLevelBlockTypes();
+    expect(typesAfter[anchorIndex + 1]).toBe("divider");
+  });
+});

--- a/packages/editor/src/components/Sidebar.vue
+++ b/packages/editor/src/components/Sidebar.vue
@@ -9,6 +9,8 @@ import CustomBlockIcon from "./CustomBlockIcon.vue";
 import { blockTypeIcons } from "../utils/blockTypeIcons";
 import { getBlockTypeLabel } from "../utils/blockTypeLabels";
 import { resolvePaletteBlocks } from "../utils/resolvePaletteBlocks";
+import { resolveInsertPosition } from "../utils/resolveInsertPosition";
+import { useScrollToBlock } from "../composables/useScrollToBlock";
 import { logger } from "../utils/logger";
 import {
   CUSTOM_BLOCK_DEFINITIONS_KEY,
@@ -30,6 +32,7 @@ const customBlockDefinitions = inject(CUSTOM_BLOCK_DEFINITIONS_KEY, []);
 const paletteBlocks = inject(PALETTE_BLOCKS_KEY, undefined);
 const blockDefaults = inject(BLOCK_DEFAULTS_KEY, undefined);
 const editor = inject(EDITOR_KEY, null);
+const scrollToBlock = useScrollToBlock();
 
 const caps = inject(CAPABILITIES_KEY, {});
 
@@ -164,8 +167,20 @@ function createBlockFromItem(item: BlockTypeItem): Block {
 function insertBlockFromItem(item: BlockTypeItem): void {
   if (!editor) return;
   const block = createBlockFromItem(item);
-  editor.addBlock(block);
+  // Land below the selection, not at the end: on a template taller than the
+  // viewport an appended block is below the fold, and the canvas does not
+  // follow on its own, so the click reads as a no-op (issue #568).
+  const { targetSectionId, columnIndex, index } = resolveInsertPosition({
+    blockType: item.type,
+    selectedBlockId: editor.state.selectedBlockId,
+    findBlockLocation: editor.findBlockLocation,
+    isBlockLocked: editor.isBlockLocked,
+  });
+  editor.addBlock(block, targetSectionId, columnIndex, index);
   editor.selectBlock(block.id);
+  // Selecting is not visible by itself, and the append fallback above still
+  // lands off-screen — the canvas has to follow either way.
+  scrollToBlock(block.id);
 }
 
 function handlePaletteKeydown(event: KeyboardEvent, item: BlockTypeItem): void {

--- a/packages/editor/src/components/sidebar/IssuesPanel.vue
+++ b/packages/editor/src/components/sidebar/IssuesPanel.vue
@@ -9,12 +9,14 @@ import {
   Wrench,
 } from "@lucide/vue";
 import { useI18n } from "../../composables/useI18n";
+import { useScrollToBlock } from "../../composables/useScrollToBlock";
 import { TEMPLATE_LINT_KEY, EDITOR_KEY } from "../../keys";
 import type { LintIssue } from "../../composables/useTemplateLint";
 
 const { t, format } = useI18n();
 const lint = inject(TEMPLATE_LINT_KEY, null);
 const editor = inject(EDITOR_KEY, null);
+const scrollToBlock = useScrollToBlock();
 
 const errors = computed(() =>
   (lint?.issues.value ?? []).filter((i) => i.severity === "error"),
@@ -32,7 +34,11 @@ const totalCount = computed(
 
 function jumpTo(issue: LintIssue): void {
   if (!editor) return;
-  if (issue.blockId) editor.selectBlock(issue.blockId);
+  if (!issue.blockId) return;
+  editor.selectBlock(issue.blockId);
+  // Selecting is invisible on its own — on a long template the block sits
+  // below the fold and the canvas stays put, so "Jump" appears to do nothing.
+  scrollToBlock(issue.blockId);
 }
 
 function applyFix(issue: LintIssue): void {
@@ -131,6 +137,7 @@ function applyFix(issue: LintIssue): void {
               <button
                 v-if="issue.blockId"
                 type="button"
+                data-testid="issue-jump"
                 class="tpl:flex tpl:items-center tpl:gap-1 tpl:rounded-md tpl:border tpl:border-[var(--tpl-border)] tpl:bg-[var(--tpl-bg-hover)] tpl:px-2 tpl:py-1 tpl:text-[11px] tpl:font-medium tpl:text-[var(--tpl-text)]"
                 @click="jumpTo(issue)"
               >

--- a/packages/editor/src/composables/useScrollToBlock.ts
+++ b/packages/editor/src/composables/useScrollToBlock.ts
@@ -1,0 +1,40 @@
+import { nextTick } from "vue";
+import { useEditorRoot } from "./useEditorRoot";
+
+/**
+ * Returns a function that brings a block into view on the canvas.
+ *
+ * Selecting a block is not by itself visible: on a long template the selected
+ * block can sit far below the fold while the canvas stays exactly where it was,
+ * so an insert or a jump reads as "nothing happened". This is what makes the
+ * outcome visible at the user's position.
+ *
+ * Queries through `useEditorRoot()` rather than `document` — in the default
+ * shadow-DOM mount the blocks live in the shadow tree, where a document-level
+ * query matches nothing.
+ *
+ * Scrolling is deferred one tick so a block inserted in the same call has
+ * rendered by the time it is looked up. `block: "nearest"` leaves an
+ * already-visible block alone instead of yanking it to the top.
+ */
+export function useScrollToBlock(): (blockId: string) => void {
+  const root = useEditorRoot();
+
+  return (blockId: string) => {
+    void nextTick(() => {
+      const target = root.querySelector(`[data-block-id="${blockId}"]`);
+      if (!target) return;
+      target.scrollIntoView({
+        block: "nearest",
+        behavior: prefersReducedMotion() ? "auto" : "smooth",
+      });
+    });
+  };
+}
+
+function prefersReducedMotion(): boolean {
+  // Absent in some embedding contexts; a throw here would break the insert
+  // that asked for the scroll, so treat "can't tell" as motion allowed.
+  if (typeof matchMedia !== "function") return false;
+  return matchMedia("(prefers-reduced-motion: reduce)").matches;
+}

--- a/packages/editor/src/utils/resolveInsertPosition.ts
+++ b/packages/editor/src/utils/resolveInsertPosition.ts
@@ -1,0 +1,79 @@
+/**
+ * Where a palette insert should land, expressed as the trailing arguments of
+ * `editor.addBlock(block, targetSectionId?, columnIndex?, index?)`.
+ *
+ * An empty object means "append at the end" — every field absent, so spreading
+ * it into `addBlock` passes `undefined` for all three and takes the push path.
+ */
+export interface InsertPosition {
+  targetSectionId?: string;
+  columnIndex?: number;
+  index?: number;
+}
+
+export interface ResolveInsertPositionOptions {
+  /**
+   * The type of block about to be inserted. Only `"section"` changes the
+   * outcome — custom types (`custom:*`) behave like any other leaf block.
+   */
+  blockType: string;
+  selectedBlockId: string | null;
+  findBlockLocation: (blockId: string) => {
+    targetSectionId?: string;
+    columnIndex?: number;
+    index: number;
+  } | null;
+  isBlockLocked: (blockId: string) => boolean;
+}
+
+/**
+ * Resolve the insert position for a palette click: directly below the selected
+ * block, falling back to appending at the end.
+ *
+ * Every fallback here exists because `addBlock` refuses the alternative
+ * *silently*. Returning a position it rejects would turn the click into a
+ * complete no-op — worse for the user than landing at the bottom, which is the
+ * behaviour this whole function replaces. So the rule is: only ever return a
+ * position `addBlock` will accept.
+ *
+ * Mirrors `duplicateBlock` in `@templatical/core` (resolve the reference
+ * block's location, bump the index by one, append when it can't be resolved) so
+ * click-to-insert and duplicate place blocks by the same rule.
+ */
+export function resolveInsertPosition(
+  options: ResolveInsertPositionOptions,
+): InsertPosition {
+  const { blockType, selectedBlockId, findBlockLocation, isBlockLocked } =
+    options;
+
+  if (!selectedBlockId) return {};
+
+  // A selection can outlive its block — a collaborator removes it, an undo
+  // drops it — so an unresolvable id means append, never a guessed index.
+  const selected = findBlockLocation(selectedBlockId);
+  if (!selected) return {};
+
+  if (selected.targetSectionId === undefined) {
+    return { index: selected.index + 1 };
+  }
+
+  if (blockType === "section") {
+    // MJML forbids `mj-section` inside `mj-column`, so `addBlock` rejects the
+    // nest outright. Land beside the section the selection sits in instead —
+    // the nearest position that accepts a section at all. Sections never nest,
+    // so the parent's own location is always top-level.
+    const parent = findBlockLocation(selected.targetSectionId);
+    if (!parent || parent.targetSectionId !== undefined) return {};
+    return { index: parent.index + 1 };
+  }
+
+  // `addBlock` bails when the target section is locked, so a locked parent
+  // means the column is unavailable — append rather than lose the block.
+  if (isBlockLocked(selected.targetSectionId)) return {};
+
+  return {
+    targetSectionId: selected.targetSectionId,
+    columnIndex: selected.columnIndex,
+    index: selected.index + 1,
+  };
+}

--- a/packages/editor/tests/issuesPanel.test.ts
+++ b/packages/editor/tests/issuesPanel.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 import { mount } from "@vue/test-utils";
 import IssuesPanel from "../src/components/sidebar/IssuesPanel.vue";
@@ -9,6 +9,20 @@ import {
   TRANSLATIONS_KEY,
 } from "../src/keys";
 import type { LintIssue } from "../src/composables/useTemplateLint";
+
+// The scroll needs real layout; `tests/useScrollToBlock.test.ts` covers what
+// the composable does, so here it is stubbed and asserted on.
+const scrollToBlock = vi.hoisted(() => vi.fn());
+vi.mock("../src/composables/useScrollToBlock", () => ({
+  useScrollToBlock: () => scrollToBlock,
+}));
+
+const selectBlock = vi.hoisted(() => vi.fn());
+
+beforeEach(() => {
+  scrollToBlock.mockClear();
+  selectBlock.mockClear();
+});
 
 const translationsStub = {
   issues: {
@@ -37,7 +51,7 @@ function mountPanel(issues: LintIssue[], applyFix = vi.fn()) {
           applyFix,
           destroy: () => {},
         },
-        [EDITOR_KEY as symbol]: { selectBlock: vi.fn() },
+        [EDITOR_KEY as symbol]: { selectBlock },
         [TRANSLATIONS_KEY as symbol]: translationsStub,
       },
     },
@@ -45,6 +59,43 @@ function mountPanel(issues: LintIssue[], applyFix = vi.fn()) {
 }
 
 describe("IssuesPanel", () => {
+  it("jumping to an issue selects the block and scrolls it into view", async () => {
+    // Selecting alone leaves the canvas where it was, so on a long template
+    // "Jump" looked like it did nothing (the same defect as issue #568).
+    const issues: LintIssue[] = [
+      {
+        blockId: "b1",
+        ruleId: "a11y.image-missing-alt",
+        severity: "error",
+        message: "Image has no alt text.",
+      },
+    ];
+    const wrapper = mountPanel(issues);
+
+    await wrapper.find("button[data-testid=\"issue-jump\"]").trigger("click");
+
+    expect(selectBlock).toHaveBeenCalledWith("b1");
+    expect(scrollToBlock).toHaveBeenCalledWith("b1");
+  });
+
+  it("offers no jump for a template-level issue with no block", () => {
+    // Nothing to scroll to, so the affordance must not render at all rather
+    // than render and do nothing.
+    const issues: LintIssue[] = [
+      {
+        ruleId: "structure.duplicate-ids",
+        severity: "warning",
+        message: "Duplicate block ids.",
+      },
+    ];
+    const wrapper = mountPanel(issues);
+
+    expect(wrapper.find('button[data-testid="issue-jump"]').exists()).toBe(
+      false,
+    );
+    expect(scrollToBlock).not.toHaveBeenCalled();
+  });
+
   it("renders the empty state when no issues exist", () => {
     const wrapper = mountPanel([]);
     expect(wrapper.text()).toContain("No issues — looking good.");

--- a/packages/editor/tests/resolveInsertPosition.test.ts
+++ b/packages/editor/tests/resolveInsertPosition.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveInsertPosition } from "../src/utils/resolveInsertPosition";
+
+type Location = {
+  targetSectionId?: string;
+  columnIndex?: number;
+  index: number;
+};
+
+/**
+ * `findBlockLocation` backed by a plain map, so each case states only the
+ * locations it cares about. An id that isn't listed resolves to `null`, which
+ * is what the real editor returns for a stale selection.
+ */
+function locator(locations: Record<string, Location>) {
+  return vi.fn((blockId: string) => locations[blockId] ?? null);
+}
+
+const nothingLocked = () => false;
+
+describe("resolveInsertPosition", () => {
+  it("appends when nothing is selected", () => {
+    expect(
+      resolveInsertPosition({
+        blockType: "divider",
+        selectedBlockId: null,
+        findBlockLocation: locator({}),
+        isBlockLocked: nothingLocked,
+      }),
+    ).toEqual({});
+  });
+
+  it("appends when the selected block no longer resolves", () => {
+    // A selection can outlive its block — a collaborator removes it, or an
+    // undo drops it — and `findBlockLocation` returns null. Appending is the
+    // only safe answer; deriving an index from a stale id would misplace it.
+    const findBlockLocation = locator({ "block-a": { index: 3 } });
+
+    expect(
+      resolveInsertPosition({
+        blockType: "divider",
+        selectedBlockId: "ghost",
+        findBlockLocation,
+        isBlockLocked: nothingLocked,
+      }),
+    ).toEqual({});
+    expect(findBlockLocation).toHaveBeenCalledWith("ghost");
+  });
+
+  it("inserts directly after a top-level selection", () => {
+    expect(
+      resolveInsertPosition({
+        blockType: "divider",
+        selectedBlockId: "block-a",
+        findBlockLocation: locator({ "block-a": { index: 4 } }),
+        isBlockLocked: nothingLocked,
+      }),
+    ).toEqual({ index: 5 });
+  });
+
+  it("inserts after a top-level selection at index 0", () => {
+    // Guards the falsy-zero class: index 0 is a real position, not "unset".
+    expect(
+      resolveInsertPosition({
+        blockType: "paragraph",
+        selectedBlockId: "first",
+        findBlockLocation: locator({ first: { index: 0 } }),
+        isBlockLocked: nothingLocked,
+      }),
+    ).toEqual({ index: 1 });
+  });
+
+  it("inserts into the same section column after a nested selection", () => {
+    expect(
+      resolveInsertPosition({
+        blockType: "divider",
+        selectedBlockId: "child",
+        findBlockLocation: locator({
+          child: { targetSectionId: "sec-1", columnIndex: 1, index: 2 },
+        }),
+        isBlockLocked: nothingLocked,
+      }),
+    ).toEqual({ targetSectionId: "sec-1", columnIndex: 1, index: 3 });
+  });
+
+  it("preserves columnIndex 0 for a nested selection", () => {
+    // `columnIndex: 0` is falsy, so a truthiness check would silently drop the
+    // column and `addBlock` would default to column 0 by luck rather than by
+    // intent — and would be wrong the moment the default changes.
+    const position = resolveInsertPosition({
+      blockType: "paragraph",
+      selectedBlockId: "child",
+      findBlockLocation: locator({
+        child: { targetSectionId: "sec-1", columnIndex: 0, index: 0 },
+      }),
+      isBlockLocked: nothingLocked,
+    });
+
+    expect(position).toEqual({
+      targetSectionId: "sec-1",
+      columnIndex: 0,
+      index: 1,
+    });
+    expect(Object.hasOwn(position, "columnIndex")).toBe(true);
+  });
+
+  it("places a section after the parent section when the selection is nested", () => {
+    // `addBlock` refuses a section inside a column (MJML forbids `mj-section`
+    // in `mj-column`), so targeting the column would make the click a silent
+    // no-op. Top level, after the section the selection lives in, is the
+    // nearest position that actually accepts the block.
+    expect(
+      resolveInsertPosition({
+        blockType: "section",
+        selectedBlockId: "child",
+        findBlockLocation: locator({
+          child: { targetSectionId: "sec-1", columnIndex: 0, index: 2 },
+          "sec-1": { index: 6 },
+        }),
+        isBlockLocked: nothingLocked,
+      }),
+    ).toEqual({ index: 7 });
+  });
+
+  it("appends a section when the parent section's own location is unknown", () => {
+    expect(
+      resolveInsertPosition({
+        blockType: "section",
+        selectedBlockId: "child",
+        findBlockLocation: locator({
+          child: { targetSectionId: "sec-1", columnIndex: 0, index: 2 },
+          // "sec-1" deliberately absent
+        }),
+        isBlockLocked: nothingLocked,
+      }),
+    ).toEqual({});
+  });
+
+  it("appends when the parent section is locked by a collaborator", () => {
+    // `addBlock` bails on a locked target section, so resolving the column
+    // would drop the block entirely. Appending keeps the insert working.
+    const isBlockLocked = vi.fn((id: string) => id === "sec-1");
+
+    expect(
+      resolveInsertPosition({
+        blockType: "divider",
+        selectedBlockId: "child",
+        findBlockLocation: locator({
+          child: { targetSectionId: "sec-1", columnIndex: 0, index: 2 },
+        }),
+        isBlockLocked,
+      }),
+    ).toEqual({});
+    expect(isBlockLocked).toHaveBeenCalledWith("sec-1");
+  });
+
+  it("does not consult the lock when the selection is top-level", () => {
+    // Top-level inserts have no lock check in `addBlock`, so asking would
+    // imply a constraint that doesn't exist.
+    const isBlockLocked = vi.fn(() => true);
+
+    expect(
+      resolveInsertPosition({
+        blockType: "divider",
+        selectedBlockId: "block-a",
+        findBlockLocation: locator({ "block-a": { index: 1 } }),
+        isBlockLocked,
+      }),
+    ).toEqual({ index: 2 });
+    expect(isBlockLocked).not.toHaveBeenCalled();
+  });
+
+  it("puts an ordinary block after a selected section, never inside it", () => {
+    // A selected section is a top-level selection like any other. Inserting
+    // into its first column would be a different gesture than the user made.
+    expect(
+      resolveInsertPosition({
+        blockType: "paragraph",
+        selectedBlockId: "sec-1",
+        findBlockLocation: locator({ "sec-1": { index: 3 } }),
+        isBlockLocked: nothingLocked,
+      }),
+    ).toEqual({ index: 4 });
+  });
+
+  it("places a section after a selected top-level section", () => {
+    expect(
+      resolveInsertPosition({
+        blockType: "section",
+        selectedBlockId: "sec-1",
+        findBlockLocation: locator({ "sec-1": { index: 3 } }),
+        isBlockLocked: nothingLocked,
+      }),
+    ).toEqual({ index: 4 });
+  });
+
+  it("treats a custom block type like any other non-section block", () => {
+    expect(
+      resolveInsertPosition({
+        blockType: "custom:testimonial",
+        selectedBlockId: "child",
+        findBlockLocation: locator({
+          child: { targetSectionId: "sec-1", columnIndex: 1, index: 0 },
+        }),
+        isBlockLocked: nothingLocked,
+      }),
+    ).toEqual({ targetSectionId: "sec-1", columnIndex: 1, index: 1 });
+  });
+});

--- a/packages/editor/tests/sidebar.test.ts
+++ b/packages/editor/tests/sidebar.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VueDraggable } from 'vue-draggable-plus';
 import Sidebar from '../src/components/Sidebar.vue';
 import { mountEditor } from './helpers/mount';
@@ -10,17 +10,51 @@ import {
   CAPABILITIES_KEY,
 } from '../src/keys';
 
-function makeEditor() {
+// The scroll itself needs real layout, so the composable is stubbed here and
+// asserted on; `tests/useScrollToBlock.test.ts` covers what it does, and the
+// e2e covers that the canvas actually moves.
+const scrollToBlock = vi.hoisted(() => vi.fn());
+vi.mock('../src/composables/useScrollToBlock', () => ({
+  useScrollToBlock: () => scrollToBlock,
+}));
+
+beforeEach(() => {
+  scrollToBlock.mockClear();
+});
+
+type Location = {
+  targetSectionId?: string;
+  columnIndex?: number;
+  index: number;
+};
+
+function makeEditor(
+  options: {
+    selectedBlockId?: string | null;
+    locations?: Record<string, Location>;
+    lockedIds?: string[];
+  } = {},
+) {
   const addBlock = vi.fn();
   const selectBlock = vi.fn();
+  const locations = options.locations ?? {};
+  const locked = new Set(options.lockedIds ?? []);
+  const findBlockLocation = vi.fn(
+    (blockId: string) => locations[blockId] ?? null,
+  );
+  const isBlockLocked = vi.fn((blockId: string) => locked.has(blockId));
   return {
     editor: {
       addBlock,
       selectBlock,
-      state: {},
+      findBlockLocation,
+      isBlockLocked,
+      state: { selectedBlockId: options.selectedBlockId ?? null },
     } as any,
     addBlock,
     selectBlock,
+    findBlockLocation,
+    isBlockLocked,
   };
 }
 
@@ -133,6 +167,143 @@ describe('Sidebar', () => {
     expect(inserted.type).toBe('title');
     expect(inserted.id).toBeTruthy();
     expect(selectBlock).toHaveBeenCalledWith(inserted.id);
+  });
+
+  describe('insert position', () => {
+    // Issue #568: a palette click always appended, so on a long template the
+    // new block landed far below the fold and the canvas never moved — the
+    // click read as a no-op. Insertion now follows the selection, the same
+    // rule `duplicateBlock` already uses.
+
+    it('appends when nothing is selected', async () => {
+      const { editor, addBlock } = makeEditor({ selectedBlockId: null });
+      const wrapper = mountSidebar({ [EDITOR_KEY]: editor });
+
+      await wrapper.find('button[data-palette-type="title"]').trigger('click');
+
+      expect(addBlock).toHaveBeenCalledOnce();
+      const [, targetSectionId, columnIndex, index] = addBlock.mock.calls[0];
+      expect(targetSectionId).toBeUndefined();
+      expect(columnIndex).toBeUndefined();
+      expect(index).toBeUndefined();
+    });
+
+    it('inserts directly below a selected top-level block', async () => {
+      const { editor, addBlock } = makeEditor({
+        selectedBlockId: 'block-a',
+        locations: { 'block-a': { index: 4 } },
+      });
+      const wrapper = mountSidebar({ [EDITOR_KEY]: editor });
+
+      await wrapper
+        .find('button[data-palette-type="divider"]')
+        .trigger('click');
+
+      expect(addBlock).toHaveBeenCalledOnce();
+      const [, targetSectionId, columnIndex, index] = addBlock.mock.calls[0];
+      expect(targetSectionId).toBeUndefined();
+      expect(columnIndex).toBeUndefined();
+      expect(index).toBe(5);
+    });
+
+    it('inserts into the same section column below a nested selection', async () => {
+      const { editor, addBlock } = makeEditor({
+        selectedBlockId: 'child',
+        locations: {
+          child: { targetSectionId: 'sec-1', columnIndex: 1, index: 2 },
+        },
+      });
+      const wrapper = mountSidebar({ [EDITOR_KEY]: editor });
+
+      await wrapper
+        .find('button[data-palette-type="paragraph"]')
+        .trigger('click');
+
+      expect(addBlock).toHaveBeenCalledOnce();
+      const [, targetSectionId, columnIndex, index] = addBlock.mock.calls[0];
+      expect(targetSectionId).toBe('sec-1');
+      expect(columnIndex).toBe(1);
+      expect(index).toBe(3);
+    });
+
+    it('places a section beside the parent section when the selection is nested', async () => {
+      // `addBlock` refuses a section inside a column, so targeting the column
+      // would make this click do nothing at all.
+      const { editor, addBlock } = makeEditor({
+        selectedBlockId: 'child',
+        locations: {
+          child: { targetSectionId: 'sec-1', columnIndex: 0, index: 2 },
+          'sec-1': { index: 6 },
+        },
+      });
+      const wrapper = mountSidebar({ [EDITOR_KEY]: editor });
+
+      await wrapper
+        .find('button[data-palette-type="section"]')
+        .trigger('click');
+
+      expect(addBlock).toHaveBeenCalledOnce();
+      const [, targetSectionId, columnIndex, index] = addBlock.mock.calls[0];
+      expect(targetSectionId).toBeUndefined();
+      expect(columnIndex).toBeUndefined();
+      expect(index).toBe(7);
+    });
+
+    it('appends when the parent section is locked by a collaborator', async () => {
+      const { editor, addBlock } = makeEditor({
+        selectedBlockId: 'child',
+        locations: {
+          child: { targetSectionId: 'sec-1', columnIndex: 0, index: 2 },
+        },
+        lockedIds: ['sec-1'],
+      });
+      const wrapper = mountSidebar({ [EDITOR_KEY]: editor });
+
+      await wrapper.find('button[data-palette-type="image"]').trigger('click');
+
+      expect(addBlock).toHaveBeenCalledOnce();
+      const [, targetSectionId, columnIndex, index] = addBlock.mock.calls[0];
+      expect(targetSectionId).toBeUndefined();
+      expect(columnIndex).toBeUndefined();
+      expect(index).toBeUndefined();
+    });
+
+    it('applies the resolved position to a keyboard-activated insert too', async () => {
+      // The keyboard path is the only way to insert without a pointer, so it
+      // must not quietly keep the old append-at-end behaviour.
+      const { editor, addBlock } = makeEditor({
+        selectedBlockId: 'block-a',
+        locations: { 'block-a': { index: 0 } },
+      });
+      const wrapper = mountSidebar({ [EDITOR_KEY]: editor });
+
+      await wrapper
+        .find('button[data-palette-type="title"]')
+        .trigger('keydown', { key: 'Enter' });
+
+      expect(addBlock).toHaveBeenCalledOnce();
+      expect(addBlock.mock.calls[0][3]).toBe(1);
+    });
+
+    it('scrolls the inserted block into view', async () => {
+      // Selecting the block is not enough to be visible: it can land far below
+      // the fold with the canvas unmoved, which is the reported symptom.
+      const { editor, addBlock } = makeEditor({ selectedBlockId: null });
+      const wrapper = mountSidebar({ [EDITOR_KEY]: editor });
+
+      await wrapper.find('button[data-palette-type="title"]').trigger('click');
+
+      expect(scrollToBlock).toHaveBeenCalledOnce();
+      expect(scrollToBlock).toHaveBeenCalledWith(addBlock.mock.calls[0][0].id);
+    });
+
+    it('does not scroll when there is no editor to insert into', async () => {
+      const wrapper = mountSidebar({ [EDITOR_KEY]: null });
+
+      await wrapper.find('button[data-palette-type="title"]').trigger('click');
+
+      expect(scrollToBlock).not.toHaveBeenCalled();
+    });
   });
 
   it('Enter key on a palette item inserts the block (keyboard accessibility)', async () => {

--- a/packages/editor/tests/useScrollToBlock.test.ts
+++ b/packages/editor/tests/useScrollToBlock.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+//
+// happy-dom has no layout and no scrolling, so `scrollIntoView` is stubbed per
+// element and asserted on. Whether the browser actually moves is covered by
+// `apps/playground/e2e/tests/palette-insert-position.spec.ts`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  type InjectionKey,
+} from "vue";
+import { useScrollToBlock } from "../src/composables/useScrollToBlock";
+import { EDITOR_ROOT_KEY } from "../src/keys";
+
+function withProvide<T>(
+  setup: () => T,
+  provides: Record<symbol, unknown> = {},
+): T {
+  let result!: T;
+  const app = createApp(
+    defineComponent({
+      setup() {
+        result = setup();
+        return () => h("div");
+      },
+    }),
+  );
+  for (const sym of Object.getOwnPropertySymbols(provides)) {
+    app.provide(sym as InjectionKey<unknown>, provides[sym]);
+  }
+  app.mount(document.createElement("div"));
+  return result;
+}
+
+/** A block node carrying the attribute the composable queries on. */
+function blockNode(blockId: string) {
+  const el = document.createElement("div");
+  el.setAttribute("data-block-id", blockId);
+  const scrollIntoView = vi.fn();
+  el.scrollIntoView = scrollIntoView;
+  return { el, scrollIntoView };
+}
+
+function setReducedMotion(reduce: boolean) {
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: reduce && query.includes("prefers-reduced-motion"),
+    media: query,
+  }));
+}
+
+beforeEach(() => {
+  setReducedMotion(false);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+});
+
+describe("useScrollToBlock", () => {
+  it("scrolls the matching block into view", async () => {
+    const { el, scrollIntoView } = blockNode("block-a");
+    document.body.appendChild(el);
+
+    const scrollToBlock = withProvide(() => useScrollToBlock());
+    scrollToBlock("block-a");
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits a tick so a block inserted in the same call has rendered", async () => {
+    // The node does not exist when `scrollToBlock` is called — this is the
+    // real sequence for a palette insert, where Vue has not yet re-rendered.
+    const scrollToBlock = withProvide(() => useScrollToBlock());
+    scrollToBlock("late");
+
+    const { el, scrollIntoView } = blockNode("late");
+    document.body.appendChild(el);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    await nextTick();
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses block: nearest so an already-visible block does not jump", async () => {
+    const { el, scrollIntoView } = blockNode("block-a");
+    document.body.appendChild(el);
+
+    const scrollToBlock = withProvide(() => useScrollToBlock());
+    scrollToBlock("block-a");
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "nearest",
+      behavior: "smooth",
+    });
+  });
+
+  it("scrolls instantly when the user prefers reduced motion", async () => {
+    setReducedMotion(true);
+    const { el, scrollIntoView } = blockNode("block-a");
+    document.body.appendChild(el);
+
+    const scrollToBlock = withProvide(() => useScrollToBlock());
+    scrollToBlock("block-a");
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "nearest",
+      behavior: "auto",
+    });
+  });
+
+  it("is a no-op when no block matches the id", async () => {
+    const { scrollIntoView } = blockNode("block-a");
+    // deliberately not appended
+
+    const scrollToBlock = withProvide(() => useScrollToBlock());
+    scrollToBlock("block-a");
+    await nextTick();
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("queries the injected editor root, not the document", async () => {
+    // In shadow-DOM mode the blocks live in the shadow tree, where a
+    // document-level query finds nothing. Only the shadow node is populated
+    // here, so a document query would scroll nothing.
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    const { el, scrollIntoView } = blockNode("block-a");
+    shadow.appendChild(el);
+
+    const scrollToBlock = withProvide(() => useScrollToBlock(), {
+      [EDITOR_ROOT_KEY]: shadow,
+    });
+    scrollToBlock("block-a");
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a block that only exists outside the injected root", async () => {
+    // Negative control for the case above: without it, that test would pass
+    // even if the composable queried `document` and happened to find a match.
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    const { el, scrollIntoView } = blockNode("block-a");
+    document.body.appendChild(el);
+
+    const scrollToBlock = withProvide(() => useScrollToBlock(), {
+      [EDITOR_ROOT_KEY]: shadow,
+    });
+    scrollToBlock("block-a");
+    await nextTick();
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("survives a missing matchMedia", async () => {
+    // `matchMedia` is absent in some embedding contexts and older jsdom-style
+    // environments; a throw here would break the insert itself.
+    vi.stubGlobal("matchMedia", undefined);
+    const { el, scrollIntoView } = blockNode("block-a");
+    document.body.appendChild(el);
+
+    const scrollToBlock = withProvide(() => useScrollToBlock());
+    scrollToBlock("block-a");
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "nearest",
+      behavior: "smooth",
+    });
+  });
+});


### PR DESCRIPTION
Closes #568.