### PR TITLE
fix: sidebar rail stays expanded after clicking a palette block

### DIFF
--- a/.changeset/olive-pillows-repeat.md
+++ b/.changeset/olive-pillows-repeat.md
@@ -1,0 +1,11 @@
+---
+"@templatical/editor": patch
+---
+
+The sidebar rail collapses again after a palette entry is clicked
+
+Clicking a block in the palette left the rail stuck expanded: moving the pointer back to the canvas did nothing, and only a completed drag&drop released it (reported on #568). Because the expanded rail is 200px and overlays the canvas — `.tpl-body` starts at the collapsed 48px — it covered the block the click had just scrolled into view.
+
+The rail suppresses its `mouseleave` collapse while a drag is in flight, so the fallback ghost isn't stamped with a mid-transition rect. That guard was set on Sortable's `choose` and cleared only on `end` — but `end` is not the counterpart of `choose`: Sortable gates it on `Sortable.active`, which only a drag that actually started ever sets. A click emits `choose` + `unchoose` and stops there, so the first click latched the guard on for the rest of the session. It is now cleared on `unchoose` as well, which fires on every release, at drop time — after the ghost rect has been captured, so the drag defense is unchanged.
+
+The rail also no longer collapses out from under a keyboard user: while an entry inside it has `:focus-visible`, `mouseleave` leaves it open and focus leaving is what closes it. Collapsing to the 48px icon strip otherwise hides the label of the entry the user has focused. The test is `:focus-visible` rather than `:focus` on purpose — a mouse click leaves the clicked button focused, so `:focus` would pin the rail open exactly as the latched guard did.

--- a/apps/playground/e2e/pages/editor.page.ts
+++ b/apps/playground/e2e/pages/editor.page.ts
@@ -253,6 +253,68 @@ export class EditorPage {
 
   // --- Sidebar ---
 
+  /** Current rendered width of the auto-hiding rail: 48px collapsed, 200px expanded. */
+  async getSidebarRailWidth(): Promise<number> {
+    return this.page
+      .locator(SELECTORS.sidebarRail)
+      .evaluate((el) => (el as HTMLElement).getBoundingClientRect().width);
+  }
+
+  /**
+   * The rail's *declared* width. It flips the instant the expanded state
+   * changes, where the rendered width animates over 200ms — so this is what
+   * distinguishes "stayed open" from "is collapsing" without waiting on a
+   * transition.
+   */
+  async getSidebarRailDeclaredWidth(): Promise<string> {
+    return this.page
+      .locator(SELECTORS.sidebarRail)
+      .evaluate((el) => (el as HTMLElement).style.width);
+  }
+
+  async isSidebarHovered(): Promise<boolean> {
+    return this.page
+      .locator(SELECTORS.sidebarRail)
+      .evaluate((el) => el.matches(":hover"));
+  }
+
+  /** Whether some entry in the rail currently has keyboard-visible focus. */
+  async sidebarHasKeyboardFocus(): Promise<boolean> {
+    return this.page
+      .locator(SELECTORS.sidebarRail)
+      .evaluate((el) => el.querySelector(":focus-visible") != null);
+  }
+
+  /**
+   * A canvas point clear of the rail. The expanded rail is 200px and overlays
+   * the canvas (`.tpl-body` starts at the collapsed 48px), so the canvas box's
+   * own top-left is under it whenever the rail is open.
+   */
+  private async canvasCenter(): Promise<{ x: number; y: number }> {
+    const canvas = await this.page.locator(SELECTORS.canvasBody).boundingBox();
+    if (!canvas) throw new Error("Canvas body not found");
+    return {
+      x: canvas.x + canvas.width / 2,
+      y: canvas.y + canvas.height / 2,
+    };
+  }
+
+  /**
+   * Move the pointer off the rail and onto the canvas, which is what fires the
+   * `mouseleave` that collapses it. Deliberately does not click: the point is
+   * the pointer leaving, not a new selection.
+   */
+  async movePointerOffSidebar(): Promise<void> {
+    const { x, y } = await this.canvasCenter();
+    await this.page.mouse.move(x, y);
+  }
+
+  /** Click on the canvas, clear of the rail — moves focus out of the rail too. */
+  async clickCanvasAwayFromSidebar(): Promise<void> {
+    const { x, y } = await this.canvasCenter();
+    await this.page.mouse.click(x, y);
+  }
+
   async hoverSidebar(): Promise<void> {
     await this.dismissOverlays();
     const rail = this.page.locator(SELECTORS.sidebarRail);

--- a/apps/playground/e2e/tests/palette-insert-position.spec.ts
+++ b/apps/playground/e2e/tests/palette-insert-position.spec.ts
@@ -187,3 +187,90 @@ test.describe("palette insert position", () => {
     expect(typesAfter[anchorIndex + 1]).toBe("divider");
   });
 });
+
+/**
+ * Follow-up reported on #568 once click-to-insert became the natural way to add
+ * a block: the rail stayed expanded afterwards, and only a completed drag&drop
+ * would let it collapse again.
+ *
+ * Sortable dispatches `end` only for a drag that actually started, so a click
+ * emitted `choose` + `unchoose` and left the mid-drag collapse guard latched on
+ * for the rest of the session. The rail overlays the canvas (`.tpl-body` starts
+ * at the collapsed 48px), so a pinned rail covers the content the click just
+ * scrolled into view.
+ */
+test.describe("sidebar rail after a palette click", () => {
+  test("collapses once the pointer leaves", async ({ editorReady }) => {
+    const { editorPage } = editorReady;
+    await editorPage.hoverSidebar();
+
+    await editorPage.clickPaletteItem("divider");
+    // Still expanded while the pointer is on it — hovering is what opened it,
+    // and collapsing under a stationary cursor would fight the next insert.
+    expect(await editorPage.getSidebarRailDeclaredWidth()).toBe("200px");
+
+    await editorPage.movePointerOffSidebar();
+
+    await expect
+      .poll(() => editorPage.getSidebarRailDeclaredWidth(), { timeout: 3000 })
+      .toBe("48px");
+    await expect
+      .poll(() => editorPage.getSidebarRailWidth(), { timeout: 3000 })
+      .toBeLessThan(60);
+  });
+
+  test("collapse still works on every later hover cycle", async ({
+    editorReady,
+  }) => {
+    // The latch survived hover-in/hover-out cycles, so one collapse right
+    // after the click is not enough to prove the guard was actually cleared.
+    const { editorPage } = editorReady;
+    for (const blockType of ["spacer", "divider"]) {
+      await editorPage.hoverSidebar();
+      await editorPage.clickPaletteItem(blockType);
+      await editorPage.movePointerOffSidebar();
+      await expect
+        .poll(() => editorPage.getSidebarRailDeclaredWidth(), { timeout: 3000 })
+        .toBe("48px");
+    }
+  });
+
+  test("stays open while a palette entry holds keyboard focus", async ({
+    editorReady,
+  }) => {
+    // The clicked button keeps DOM focus, which is why the collapse guard
+    // reads `:focus-visible` rather than `:focus` — a `:focus` test would
+    // re-pin the rail on the very click the two tests above cover. Tabbing in
+    // is the case that must keep it open: collapsing to the 48px icon strip
+    // hides the label of the entry the user has focused.
+    const { editorPage } = editorReady;
+    const page = editorPage.page;
+    await editorPage.hoverSidebar();
+
+    await page
+      .locator(SELECTORS.sidebarRail)
+      .locator('[data-palette-type="image"]')
+      .focus();
+    // A real Tab is what puts the browser into keyboard modality; `focus()`
+    // alone does not make an entry match `:focus-visible`.
+    await page.keyboard.press("Tab");
+    expect(await editorPage.sidebarHasKeyboardFocus()).toBe(true);
+
+    await editorPage.movePointerOffSidebar();
+
+    // Wait for the pointer to actually be off the rail — that is the same
+    // input event that dispatches `mouseleave`, so once `:hover` is gone the
+    // handler has run and its decision is final. Asserting the *declared*
+    // width then reads that decision directly, instead of racing the 200ms
+    // width transition (a rendered-width poll would pass on its first tick
+    // even if the rail were already collapsing).
+    await expect.poll(() => editorPage.isSidebarHovered()).toBe(false);
+    expect(await editorPage.getSidebarRailDeclaredWidth()).toBe("200px");
+
+    // Focus leaving the rail is what collapses it in that case.
+    await editorPage.clickCanvasAwayFromSidebar();
+    await expect
+      .poll(() => editorPage.getSidebarRailDeclaredWidth(), { timeout: 3000 })
+      .toBe("48px");
+  });
+});

--- a/packages/editor/src/components/Sidebar.vue
+++ b/packages/editor/src/components/Sidebar.vue
@@ -46,6 +46,23 @@ const showSavedBlocksSection = computed(
 
 const isExpanded = ref(false);
 const isDragging = ref(false);
+const railEl = ref<HTMLElement | null>(null);
+
+// `:focus-visible`, never `:focus`: a mouse click leaves the clicked palette
+// button focused, so a plain `:focus` test would pin the rail open from the
+// first click-to-insert onward — the very symptom this rail already had for
+// another reason (#568). Keyboard focus does keep it open, because collapsing
+// hides the label of the entry the user has focused.
+function hasKeyboardFocusInRail(): boolean {
+  try {
+    return railEl.value?.querySelector(":focus-visible") != null;
+  } catch {
+    // Firefox <85 / Safari <15.4 — reachable on the `shadowDom: false` tier,
+    // whose browser floor predates the selector — throw on it. Reading that
+    // as "no keyboard focus" keeps the collapse working there.
+    return false;
+  }
+}
 
 function handleSidebarLeave(): void {
   // Don't collapse while a Sortable drag is in progress. If the sidebar
@@ -55,6 +72,7 @@ function handleSidebarLeave(): void {
   // stamped with that wrong rect and ends up visibly offset from the
   // cursor for the rest of the drag. Cleared on drag-end.
   if (isDragging.value) return;
+  if (hasKeyboardFocusInRail()) return;
   isExpanded.value = false;
 }
 
@@ -65,6 +83,18 @@ function handleDragChoose(): void {
   // `_dragStarted`, by which time mouseleave may already have flipped
   // `isExpanded` and the sidebar may be mid-collapse.
   isDragging.value = true;
+}
+
+function handleDragUnchoose(): void {
+  // `end` is not the counterpart of `choose` — Sortable gates it on
+  // `Sortable.active`, which only `_dragStarted` sets, so a click on a palette
+  // entry emits `choose` + `unchoose` and no `end` at all. Clearing the guard
+  // only in `handleDragEnd` therefore latches it true on the first click and
+  // `handleSidebarLeave` bails forever after: the rail stays expanded until
+  // some later drag happens to complete (#568). `unchoose` fires on every
+  // release, at drop time — long after `_appendGhost` captured its rect — so
+  // it cannot re-open the race `handleDragChoose` guards.
+  isDragging.value = false;
 }
 
 function handleDragEnd(): void {
@@ -193,6 +223,7 @@ function handlePaletteKeydown(event: KeyboardEvent, item: BlockTypeItem): void {
 
 <template>
   <aside
+    ref="railEl"
     :aria-label="t.sidebarNav.palette"
     class="tpl-sidebar-rail tpl:absolute tpl:top-14 tpl:bottom-0 tpl:left-0 tpl:z-40 tpl:flex tpl:flex-col tpl:overflow-hidden"
     :style="{
@@ -250,6 +281,7 @@ function handlePaletteKeydown(event: KeyboardEvent, item: BlockTypeItem): void {
       :force-fallback="true"
       class="tpl:flex tpl:min-h-0 tpl:flex-1 tpl:flex-col tpl:gap-0.5 tpl:overflow-y-auto tpl:p-1"
       @choose="handleDragChoose"
+      @unchoose="handleDragUnchoose"
       @end="handleDragEnd"
     >
       <button

--- a/packages/editor/tests/block-chrome-structure.test.ts
+++ b/packages/editor/tests/block-chrome-structure.test.ts
@@ -521,6 +521,19 @@ describe("sidebar drag-during-collapse rect-capture defense", () => {
     expect(sidebar).toMatch(/@mouseleave="handleSidebarLeave"/);
   });
 
+  it("keeps the rail open for keyboard focus via `:focus-visible`, not `:focus`", () => {
+    // A mouse click leaves the clicked palette button focused, so a `:focus`
+    // test would pin the rail open from the first click-to-insert onward —
+    // the same user-visible symptom as the latched drag guard below, from a
+    // different cause. `:focus-visible` is false for that click and true for
+    // a tabbed entry, which is exactly the split this needs.
+    expect(sidebar).toMatch(/querySelector\(":focus-visible"\)/);
+    expect(sidebar).not.toMatch(/querySelector\(":focus"\)/);
+    expect(sidebar).toMatch(
+      /function\s+handleSidebarLeave\s*\([^)]*\)[^{]*\{[^}]*if\s*\(\s*hasKeyboardFocusInRail\(\)\s*\)\s*return/,
+    );
+  });
+
   it("VueDraggable wires `@choose` (NOT `@start`) to flip the drag guard", () => {
     // `choose` fires synchronously inside Sortable's `_onTapStart` on
     // pointerdown. `start` fires only after the threshold-move
@@ -534,14 +547,31 @@ describe("sidebar drag-during-collapse rect-capture defense", () => {
     );
   });
 
-  it("VueDraggable wires `@end` to clear `isDragging`", () => {
-    // Without `@end`, `isDragging` would latch true after the first
-    // drag and the sidebar would never collapse again. `end` fires
-    // regardless of drop success or cancellation.
+  it("VueDraggable wires `@end` to clear `isDragging` and collapse the rail", () => {
+    // `end` covers the completed-drag release: it fires whether the drop
+    // succeeded or was cancelled back to the source, and the cursor is out in
+    // the canvas by then, so no mouseleave follows to collapse the rail.
     expect(sidebar).toMatch(/@end="handleDragEnd"/);
     expect(sidebar).toMatch(
       /function\s+handleDragEnd\s*\([^)]*\)[^{]*\{[^}]*isDragging\.value\s*=\s*false/,
     );
+  });
+
+  it("VueDraggable also wires `@unchoose` — `end` never fires for a plain click", () => {
+    // `end` is NOT the counterpart of `choose`: Sortable gates its dispatch on
+    // `Sortable.active`, which only `_dragStarted` sets. Clicking a palette
+    // entry emits `choose` + `unchoose` and stops there, so clearing the guard
+    // on `end` alone latched it true on the first click and the rail never
+    // collapsed again (#568 follow-up). `unchoose` fires on every release, at
+    // drop time — after `_appendGhost` captured its rect — so it cannot
+    // re-open the race `@choose` guards, and it must not collapse the rail
+    // either: after a click the cursor is still on the rail.
+    expect(sidebar).toMatch(/@unchoose="handleDragUnchoose"/);
+    const unchoose = sidebar.match(
+      /function\s+handleDragUnchoose\s*\([^)]*\)[^{]*\{([\s\S]*?)\n\}/,
+    );
+    expect(unchoose?.[1]).toMatch(/isDragging\.value\s*=\s*false/);
+    expect(unchoose?.[1]).not.toMatch(/isExpanded\.value\s*=/);
   });
 });
 

--- a/packages/editor/tests/sidebar.test.ts
+++ b/packages/editor/tests/sidebar.test.ts
@@ -58,9 +58,16 @@ function makeEditor(
   };
 }
 
-function mountSidebar(overrides: Record<symbol, unknown> = {}) {
+function mountSidebar(
+  overrides: Record<symbol, unknown> = {},
+  // Focus tests need a document-attached tree: `.focus()` is a no-op on a
+  // detached element, so `activeElement` never moves and the rail's
+  // `:focus-visible` lookup can't see anything.
+  options: { attachTo?: HTMLElement } = {},
+) {
   return mountEditor(Sidebar, {
     provides: overrides,
+    ...options,
   });
 }
 
@@ -111,6 +118,72 @@ describe('Sidebar', () => {
     draggable.vm.$emit('end');
     await wrapper.vm.$nextTick();
     expect(rail.attributes('style')).toContain('width: 48px');
+  });
+
+  it('does not latch the drag guard when a click ends with `unchoose` and no `end`', async () => {
+    // Sortable dispatches `end` only once a drag actually started; a plain
+    // click on a palette entry emits `choose` + `unchoose` and nothing else.
+    // Verified against the bundled Sortable in a real browser, where a click
+    // logged ["choose", "unchoose"] and a drag logged
+    // ["choose", "clone", "start", "unchoose", "end"].
+    //
+    // With the guard cleared only on `end`, one click pinned the rail open for
+    // the rest of the session — every later mouseleave bailed out, and only a
+    // completed drag&drop could release it (#568 follow-up).
+    const { editor } = makeEditor();
+    const wrapper = mountSidebar({ [EDITOR_KEY]: editor });
+    const rail = wrapper.get('aside.tpl-sidebar-rail');
+    const draggable = wrapper.findComponent(VueDraggable);
+
+    await rail.trigger('mouseenter');
+    expect(rail.attributes('style')).toContain('width: 200px');
+
+    draggable.vm.$emit('choose');
+    draggable.vm.$emit('unchoose');
+    await rail.trigger('mouseleave');
+    expect(rail.attributes('style')).toContain('width: 48px');
+
+    // And the guard is genuinely clear, not merely bypassed once: a second
+    // hover/click/leave cycle behaves the same.
+    await rail.trigger('mouseenter');
+    draggable.vm.$emit('choose');
+    draggable.vm.$emit('unchoose');
+    await rail.trigger('mouseleave');
+    expect(rail.attributes('style')).toContain('width: 48px');
+  });
+
+  it('stays expanded on mouseleave while a palette entry holds keyboard focus', async () => {
+    // Collapsing to the 48px icon strip while the user is tabbing through the
+    // palette hides the label of the entry they have focused. The guard reads
+    // `:focus-visible`, so a mouse click — which also leaves the button
+    // focused — still collapses on leave; that half is covered in Chromium by
+    // `palette-insert-position.spec.ts`, since happy-dom resolves
+    // `:focus-visible` as plain `:focus`.
+    const { editor } = makeEditor();
+    const wrapper = mountSidebar(
+      { [EDITOR_KEY]: editor },
+      { attachTo: document.body },
+    );
+    const rail = wrapper.get('aside.tpl-sidebar-rail');
+
+    await rail.trigger('mouseenter');
+    const entry = wrapper.get<HTMLButtonElement>(
+      '[data-palette-type="divider"]',
+    ).element;
+    entry.focus();
+    await rail.trigger('focusin');
+    expect(document.activeElement).toBe(entry);
+    expect(rail.attributes('style')).toContain('width: 200px');
+
+    await rail.trigger('mouseleave');
+    expect(rail.attributes('style')).toContain('width: 200px');
+
+    // Focus leaving is what collapses it in that case.
+    entry.blur();
+    await rail.trigger('focusout');
+    expect(rail.attributes('style')).toContain('width: 48px');
+
+    wrapper.unmount();
   });
 
   it('palette list is a scroll region so tall block lists stay reachable on short viewports (#231)', () => {


### PR DESCRIPTION
Closes #576.