### PR TITLE
docs: document the stacking context a host must not put around the editor's container

### DIFF
--- a/apps/docs/de/getting-started/installation.md
+++ b/apps/docs/de/getting-started/installation.md
@@ -46,6 +46,41 @@ Damit der Editor nicht auf Geist angewiesen ist, überschreiben Sie das Schrift-
 
 Der `@import` bleibt dabei im Stylesheet erhalten, die Anfrage wird also weiterhin versucht. Um sie vollständig zu entfernen, hosten Sie Geist selbst und entfernen den `@import` in einem Build-Schritt aus Ihrer Kopie von `dist/style.css`. Die vollständige Schrift-Token-Oberfläche finden Sie unter [Theming](../guide/theming).
 
+## Der Container des Editors
+
+Der Editor mountet seine Dialoge in eine Popover-Wurzel mit `z-index: 10000` innerhalb des Containers, den Sie an `init()` übergeben. Ein z-index wirkt nur innerhalb seines eigenen Stacking-Kontexts. Deshalb **darf der Container keinen eigenen Stacking-Kontext erzeugen** — sonst bleiben alle Dialoge des Editors darin eingeschlossen, und jedes Chrome von Ihnen mit höherem z-index im übergeordneten Kontext überdeckt sie.
+
+Diese Eigenschaften erzeugen einen Stacking-Kontext, wenn sie auf dem Container oder einem Vorfahren zwischen Container und dem Stacking-Kontext Ihres Chromes liegen:
+
+| Eigenschaft | Auslösender Wert |
+| ----------- | ---------------- |
+| `isolation` | `isolate` |
+| `transform` / `translate` / `rotate` / `scale` | alles außer `none` |
+| `filter` / `backdrop-filter` | alles außer `none` |
+| `perspective` | alles außer `none` |
+| `opacity` | kleiner als `1` |
+| `will-change` | `transform`, `filter`, `opacity`, `perspective` |
+| `contain` | `paint`, `layout`, `content`, `strict` |
+| `mix-blend-mode` | alles außer `normal` |
+| `position: fixed` / `sticky` | immer |
+| `position: relative` / `absolute` | mit einem `z-index` außer `auto` |
+
+Wenn sich eine davon nicht vermeiden lässt — ein Route-Übergang, der `transform` animiert, oder ein Wrapper, den Sie nicht kontrollieren — geben Sie diesem Element einen `z-index` oberhalb Ihres eigenen Headers, Ihrer Sidebar oder Ihrer Toast-Ebene:
+
+```css
+#your-editor-container {
+  /* Über Ihrem eigenen Chrome, damit die Dialoge des Editors es auch sind. */
+  z-index: 200;
+  position: relative;
+}
+```
+
+::: tip Warum ein höherer z-index auf dem Dialog nicht hilft
+Ein `fixed` positionierter Nachfahre kann einen Stacking-Kontext mit keinem z-index verlassen — verglichen wird zwischen der Wurzel des Kontexts und Ihrem Chrome, der Wert des Nachfahren geht dabei nie ein. Der Wert muss also auf den Container, nicht auf den Dialog. Den Container höher zu legen ist unbedenklich, weil sich dessen eigene Box nicht mit Ihrem Chrome überschneidet; betroffen sind nur die Dialoge, die `fixed` sind und den Viewport ausfüllen.
+:::
+
+Das verwandte *Größen*-Problem löst der Editor selbst: Ein transformierter Vorfahre wird auch zum umgebenden Block für `fixed` positionierte Nachfahren, und jeder Dialog begrenzt seine Höhe gegen seinen eigenen Backdrop statt gegen den Viewport. So bleibt ein Dialog innerhalb der Box, die er bekommt.
+
 ## npm
 
 ::: code-group

--- a/apps/docs/getting-started/installation.md
+++ b/apps/docs/getting-started/installation.md
@@ -46,6 +46,41 @@ To stop the editor depending on Geist, override the font token:
 
 The `@import` is still present in the stylesheet, so the request is still attempted. To remove it outright, self-host Geist and strip the `@import` from your copy of `dist/style.css` as a build step. See [Theming](../guide/theming) for the full font token surface.
 
+## The editor's container
+
+The editor mounts its dialogs into a popover root at `z-index: 10000`, inside the container you pass to `init()`. A z-index only competes within its own stacking context, so **the container must not establish one** — otherwise every editor dialog is confined to it, and any chrome of yours with a higher z-index in the parent context paints over them.
+
+These properties on the container, or on any ancestor between it and the stacking context your chrome lives in, create one:
+
+| Property | Creating value |
+| -------- | -------------- |
+| `isolation` | `isolate` |
+| `transform` / `translate` / `rotate` / `scale` | anything but `none` |
+| `filter` / `backdrop-filter` | anything but `none` |
+| `perspective` | anything but `none` |
+| `opacity` | less than `1` |
+| `will-change` | `transform`, `filter`, `opacity`, `perspective` |
+| `contain` | `paint`, `layout`, `content`, `strict` |
+| `mix-blend-mode` | anything but `normal` |
+| `position: fixed` / `sticky` | always |
+| `position: relative` / `absolute` | with any `z-index` other than `auto` |
+
+If one of them is unavoidable — a route transition that animates `transform`, a wrapper you do not control — give that element a `z-index` higher than your own header, sidebar, or toast layer:
+
+```css
+#your-editor-container {
+  /* Above your own chrome, so the editor's dialogs are too. */
+  z-index: 200;
+  position: relative;
+}
+```
+
+::: tip Why a higher z-index on the dialog will not help
+A `fixed` descendant cannot escape a stacking context at any z-index — the comparison happens between the context's root and your chrome, and the descendant's own value never enters it. So the value has to go on the container, not on the dialog. Raising the container is safe because its own box does not overlap your chrome; only the dialogs, which are `fixed` and cover the viewport, are affected.
+:::
+
+The editor already handles the related *sizing* problem on its own: a transformed ancestor also becomes the containing block for `fixed` descendants, and every dialog caps its height against its own backdrop rather than the viewport, so a dialog stays inside whatever box it is given.
+
 ## npm
 
 ::: code-group

--- a/apps/playground/e2e/tests/modal-stacking.spec.ts
+++ b/apps/playground/e2e/tests/modal-stacking.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect } from "../fixtures/editor.fixture";
+import { SELECTORS } from "../helpers/selectors";
+import type { Page } from "@playwright/test";
+
+/**
+ * A dialog must paint above the host page's own chrome, not beneath it.
+ *
+ * The editor renders its modals into `.tpl-popover-root` at `z-index: 10000`,
+ * which only wins inside the stacking context it lives in. If the host wraps the
+ * editor container in a stacking context — `isolation: isolate`, `transform`,
+ * `filter`, `will-change`, `opacity < 1`, a positioned element with a
+ * `z-index` — then that whole subtree is confined, and any host chrome with a
+ * higher z-index in the parent context paints over every editor modal. A
+ * `fixed` descendant cannot escape an isolated ancestor at any z-index.
+ *
+ * The playground hit exactly this: `isolate` on the editor container, and a
+ * `<header>` at `z-index: 100`. The modal is centred in the viewport, so its top
+ * edge sits at `0.05 * (viewportHeight - 32) + 16`; below roughly a 672px
+ * viewport that crosses the 48px header and the dialog's title disappears behind
+ * the toolbar. Measured at 380px: 15px of the panel hidden, with
+ * `elementFromPoint` at the panel's top edge returning the HEADER.
+ *
+ * This is the #575 follow-up — a stacking defect, distinct from the
+ * containing-block sizing defect that `modal-height-clamp.spec.ts` covers. The
+ * two are independent: the panel can be correctly sized and still be painted
+ * under the host's chrome.
+ *
+ * The assertion is `elementFromPoint`, deliberately. Comparing z-index values
+ * proves nothing here — the editor's 10000 is genuinely larger than the header's
+ * 100, and it lost anyway, because the numbers are compared in different
+ * stacking contexts. Only hit-testing answers "what does the user actually see
+ * and click".
+ */
+
+/** Short enough that the centred panel's top edge crosses the 48px header. */
+const OVERLAP_VIEWPORT = { width: 1280, height: 380 };
+
+async function openTestEmail(page: Page): Promise<void> {
+  await page.locator(SELECTORS.testEmailTrigger).click();
+  await expect(page.locator(SELECTORS.testEmailDialog)).toBeVisible();
+}
+
+/**
+ * What actually paints at a point, from the top document. `elementFromPoint` on
+ * `document` stops at the shadow host, so the result is reported as the host
+ * when the modal (inside the shadow root) is on top — which is the correct
+ * answer for "is the host's own header covering this point".
+ */
+async function paintedAtPanelTopEdge(page: Page): Promise<{
+  hostHeaderHits: string[];
+  panelTop: number;
+  headerBottom: number;
+  overlapPx: number;
+}> {
+  return page.evaluate(() => {
+    const hosts = Array.from(document.querySelectorAll("*")).filter(
+      (el) => (el as HTMLElement).shadowRoot,
+    ) as HTMLElement[];
+    const roots: Array<Document | ShadowRoot> = [
+      document,
+      ...hosts.map((h) => h.shadowRoot!),
+    ];
+    let panel: HTMLElement | null = null;
+    for (const root of roots) {
+      const found = root.querySelector(
+        '[role="dialog"][aria-labelledby="tpl-test-email-title"]',
+      ) as HTMLElement | null;
+      if (found) {
+        panel = found;
+        break;
+      }
+    }
+    const header = document.querySelector("header") as HTMLElement | null;
+    if (!panel || !header) throw new Error("panel or host header not found");
+
+    const p = panel.getBoundingClientRect();
+    const h = header.getBoundingClientRect();
+
+    // Scan the whole band the header overlaps, across the panel's width, rather
+    // than a single point: the title sits a little below the panel's edge, so
+    // one probe at the very top would miss whether the heading itself is
+    // legible, and a probe at the title alone passes on viewports where only
+    // the panel's top corner is covered. Every point in the overlap must belong
+    // to the dialog, not the host.
+    const hits: string[] = [];
+    const xs = [0.2, 0.5, 0.8].map((f) => Math.round(p.left + p.width * f));
+    for (let y = Math.round(p.top) + 2; y < Math.min(h.bottom, p.bottom); y += 4) {
+      for (const x of xs) {
+        const el = document.elementFromPoint(x, y) as HTMLElement | null;
+        if (el && (header === el || header.contains(el))) {
+          hits.push(`${x},${y}:${el.tagName}`);
+        }
+      }
+    }
+
+    return {
+      hostHeaderHits: hits,
+      panelTop: Math.round(p.top),
+      headerBottom: Math.round(h.bottom),
+      overlapPx: Math.round(h.bottom - p.top),
+    };
+  });
+}
+
+test.describe("modal stacking", () => {
+  test("the host header does not paint over the dialog", async ({
+    editorReady,
+  }) => {
+    const { editorPage } = editorReady;
+    const page = editorPage.page;
+
+    await page.setViewportSize(OVERLAP_VIEWPORT);
+    await openTestEmail(page);
+
+    const painted = await paintedAtPanelTopEdge(page);
+
+    // The geometry that makes this test meaningful: the header's box really does
+    // extend past the panel's top edge, so paint order is what decides whether
+    // the user can see the top of the dialog. Without this the assertion below
+    // would pass on any viewport where the two simply don't overlap.
+    expect(painted.overlapPx).toBeGreaterThan(0);
+    expect(painted.panelTop).toBeLessThan(painted.headerBottom);
+
+    // Pre-fix every one of these returned the HEADER.
+    expect(painted.hostHeaderHits).toEqual([]);
+  });
+
+  test("the editor container establishes no stacking context", async ({
+    editorReady,
+  }) => {
+    const { editorPage } = editorReady;
+    const page = editorPage.page;
+
+    // The structural cause, asserted directly so a reintroduced `isolate` (or a
+    // transform/filter/opacity added for a visual flourish) fails here with a
+    // clear message rather than as a puzzling paint-order failure above.
+    const container = await page.evaluate(() => {
+      const el = document.querySelector(
+        '[data-testid="editor-container"]',
+      ) as HTMLElement | null;
+      if (!el) throw new Error("editor container not found");
+      const cs = getComputedStyle(el);
+      return {
+        isolation: cs.isolation,
+        transform: cs.transform,
+        filter: cs.filter,
+        willChange: cs.willChange,
+        opacity: cs.opacity,
+        perspective: cs.perspective,
+        contain: cs.contain,
+        mixBlendMode: cs.mixBlendMode,
+      };
+    });
+
+    expect(container.isolation).toBe("auto");
+    expect(container.transform).toBe("none");
+    expect(container.filter).toBe("none");
+    expect(container.perspective).toBe("none");
+    expect(container.opacity).toBe("1");
+    expect(container.mixBlendMode).toBe("normal");
+  });
+});

--- a/apps/playground/src/App.vue
+++ b/apps/playground/src/App.vue
@@ -2948,13 +2948,26 @@ onUnmounted(() => {
               {{ t.toolbar.retry }}
             </button>
           </div>
+          <!-- No `isolate` here, and don't add one back. `isolation: isolate`
+               creates a stacking context, which confines the editor's popover
+               root (z-index 10000) inside this element — so our own header,
+               at z-index 100 in the parent context, painted OVER every editor
+               modal. A `fixed` descendant cannot escape an isolated ancestor at
+               any z-index, so the modal's top 15px sat behind the toolbar on
+               any viewport under ~672px tall. That is the #575 follow-up.
+
+               Nothing here needs the isolation: no descendant uses
+               `mix-blend-mode`, and `overflow-hidden` already clips every
+               non-fixed descendant geometrically, so paint order against the
+               header only ever mattered for the fixed overlays we want on top.
+               Guarded by `apps/playground/e2e/tests/modal-stacking.spec.ts`. -->
           <div
             v-else
             :key="shadowDomMode"
             ref="editorContainer"
             data-testid="editor-container"
             data-onboarding="canvas"
-            class="flex-1 min-w-0 isolate rounded-lg border border-gray-200 shadow-sm overflow-hidden bg-white dark:bg-gray-800 dark:border-gray-700"
+            class="flex-1 min-w-0 rounded-lg border border-gray-200 shadow-sm overflow-hidden bg-white dark:bg-gray-800 dark:border-gray-700"
           />
         </main>
       </div>


### PR DESCRIPTION
Relates to #575.