### PR TITLE
feat(editor): add footerBlocks for content the host appends at send time

### DIFF
--- a/.changeset/tall-donkeys-smile.md
+++ b/.changeset/tall-donkeys-smile.md
@@ -1,0 +1,5 @@
+---
+"@templatical/editor": minor
+---
+
+Add `footerBlocks`: read-only blocks rendered after the template's own, for showing an author the footer your platform appends at send time. Display-only — never part of `getContent()`, a send or an export, so the saved template stays exactly what the author wrote.

--- a/apps/docs/api/editor.md
+++ b/apps/docs/api/editor.md
@@ -62,6 +62,7 @@ unmount();
 | `savedBlocks`       | `SavedBlocksProvider`                                             | No       | Storage backend for saved blocks — reusable block groups users save and re-insert. The editor provides the UI; you provide persistence. The same object also carries the `onCreated`, `onUpdated` and `onDeleted` events. Omit to disable the feature entirely. Use `createLocalStorageSavedBlocksProvider()` for a zero-backend option. See [Saved Blocks](/backend/saved-blocks) |
 | `testEmail`         | `TestEmailProvider`                                               | No       | Sending backend for test emails — lets users mail themselves the template they are editing. The editor provides the trigger, dialog, validation and states; you provide delivery. The same object also carries the `onSent` event. Omit to disable the feature entirely. `allowedRecipients` restricts the picker but is **not** a security boundary — validate server-side. See [Test Emails](/backend/test-email) |
 | `paletteBlocks`     | `string[]`                                                        | No       | Allowlist + order for the block palette. Only the listed types appear, in this order; unlisted built-ins are hidden. Built-ins use their bare type (`'image'`), custom blocks the `custom:`-prefixed type (`'custom:qrcode'`). See [Customizing the block palette](#customizing-the-block-palette) |
+| `footerBlocks`      | `Block[]`                                                         | No       | Read-only blocks rendered after the template's own. Display-only: never part of `getContent()`, a send or an export. See [Showing content your application appends](#showing-content-your-application-appends) |
 | `htmlBlockPreview`  | `boolean \| { enabled: boolean }`                                 | No       | Render each HTML block's content as a live preview in the canvas — inside a sandboxed `<iframe>` with no script execution — instead of the static placeholder. Defaults to `false`. Preview-only; the MJML/HTML export renders HTML blocks regardless. See [Previewing HTML blocks](#previewing-html-blocks) |
 | `blockDefaults`     | `BlockDefaults`                                                   | No       | Default property overrides for new blocks. See [Defaults](/guide/defaults)                                                                                                                                                                                                                 |
 | `templateDefaults`  | `TemplateDefaults`                                                | No       | Default template settings for empty templates. See [Defaults](/guide/defaults)                                                                                                                                                                                                             |
@@ -85,6 +86,38 @@ The default (shadow DOM) mount calls `attachShadow()` on your container, and the
 If your integration must use an unsupported element (e.g. mounting into a `<form>` cell of a CMS layout), pass `shadowDom: false` — light-DOM mount accepts any element. The trade-off is the host-CSS isolation you give up.
 
 ### Customizing the block palette
+
+### Showing content your application appends
+
+If your platform adds something to every email after it leaves the editor — a
+plan badge, a legal footer, an unsubscribe line — `footerBlocks` renders it at
+the bottom of the canvas so the author can see it. The blocks are read-only:
+they cannot be selected, edited, dragged or deleted.
+
+```ts
+footerBlocks: [
+  {
+    id: "platform-footer",
+    type: "html",
+    props: { html: '<p style="text-align:center">Sent with Acme</p>' },
+  },
+]
+```
+
+They render inline at the bottom of the email frame, with the template's own
+fonts and link styles, so they look like part of the message rather than a
+separate card.
+
+They are **display-only**. They never reach `getContent()`, `toMjml()`, a send
+or an export, so the template the author saves stays exactly what they authored.
+
+That is deliberate, and it is why this is not the same as putting the block in
+the template and locking it. A block in the template is saved, so it freezes
+whatever was true when the author last hit save — if the badge depends on their
+plan, it keeps sending after they upgrade. And a client-side lock is not a
+guarantee once the same content is writable through your API. Keep appending
+the footer wherever you already do it at send time; `footerBlocks` only shows
+the author what that step will add.
 
 By default the sidebar palette lists every built-in block type. Pass `paletteBlocks` to restrict the palette to a specific set and control their order — useful for hiding block types you don't use (`video`, `table`, …) or promoting a frequently-used [custom block](/guide/custom-blocks) above the built-ins.
 

--- a/apps/docs/de/api/editor.md
+++ b/apps/docs/de/api/editor.md
@@ -62,6 +62,7 @@ unmount();
 | `savedBlocks`       | `SavedBlocksProvider`                                             | Nein     | Speicher-Backend für gespeicherte Blöcke — wiederverwendbare Blockgruppen, die Nutzer speichern und erneut einfügen. Der Editor stellt die Oberfläche, Sie die Persistenz. Dasselbe Objekt trägt auch die Events `onCreated`, `onUpdated` und `onDeleted`. Weglassen deaktiviert die Funktion vollständig. `createLocalStorageSavedBlocksProvider()` bietet eine Variante ohne Backend. Siehe [Gespeicherte Blöcke](/de/backend/saved-blocks) |
 | `testEmail`         | `TestEmailProvider`                                               | Nein     | Versand-Backend für Test-E-Mails — Nutzer senden sich die Vorlage zu, die sie bearbeiten. Der Editor stellt Auslöser, Dialog, Prüfung und Zustände; Sie stellen den Versand. Dasselbe Objekt trägt auch das Event `onSent`. Weglassen deaktiviert die Funktion vollständig. `allowedRecipients` schränkt nur die Auswahl ein und ist **keine** Sicherheitsgrenze — serverseitig prüfen. Siehe [Test-E-Mails](/de/backend/test-email) |
 | `paletteBlocks`     | `string[]`                                                        | Nein     | Allowlist + Reihenfolge für die Block-Palette. Nur die aufgeführten Typen erscheinen, in dieser Reihenfolge; nicht aufgeführte integrierte Blöcke werden ausgeblendet. Integrierte Blöcke über ihren reinen Typ (`'image'`), benutzerdefinierte über den `custom:`-präfixierten Typ (`'custom:qrcode'`). Siehe [Block-Palette anpassen](#block-palette-anpassen) |
+| `footerBlocks`      | `Block[]`                                                         | Nein     | Schreibgeschützte Blöcke, die nach den Blöcken der Vorlage gerendert werden. Nur zur Anzeige: nie in `getContent()`, im Versand oder im Export. Siehe [Inhalte anzeigen, die Ihre Anwendung anhängt](#inhalte-anzeigen-die-ihre-anwendung-anhaengt) |
 | `htmlBlockPreview`  | `boolean \| { enabled: boolean }`                                 | Nein     | Rendert den Inhalt jedes HTML-Blocks als Live-Vorschau in der Leinwand — in einem sandboxed `<iframe>` ohne Skriptausführung — statt des statischen Platzhalters. Standardmäßig `false`. Nur Vorschau; der MJML-/HTML-Export rendert HTML-Blöcke unabhängig davon. Siehe [HTML-Blöcke in der Vorschau](#html-bloecke-in-der-vorschau) |
 | `blockDefaults`     | `BlockDefaults`                                                   | Nein     | Standard-Property-Überschreibungen für neue Blöcke. Siehe [Standardwerte](/de/guide/defaults)                                                                                                                                                                                                                                     |
 | `templateDefaults`  | `TemplateDefaults`                                                | Nein     | Standardeinstellungen für leere Templates. Siehe [Standardwerte](/de/guide/defaults)                                                                                                                                                                                                                                              |
@@ -85,6 +86,40 @@ Das Standard-Mount (Shadow DOM) ruft `attachShadow()` auf Ihrem Container auf, u
 Wenn Ihre Integration ein nicht unterstütztes Element verwenden muss (z. B. Mount in eine `<form>`-Zelle eines CMS-Layouts), übergeben Sie `shadowDom: false` — das Light-DOM-Mount akzeptiert jedes Element. Der Kompromiss ist die Host-CSS-Isolation, auf die Sie verzichten.
 
 ### Block-Palette anpassen
+
+### Inhalte anzeigen, die Ihre Anwendung anhängt {#inhalte-anzeigen-die-ihre-anwendung-anhaengt}
+
+Wenn Ihre Plattform jeder E-Mail nach dem Editor etwas hinzufügt — ein
+Tarif-Abzeichen, eine rechtliche Zeile, einen Abmelde-Hinweis —, rendert
+`footerBlocks` diese Inhalte am unteren Rand der Leinwand, damit die
+bearbeitende Person sie sieht. Die Blöcke sind schreibgeschützt: Sie lassen sich
+weder auswählen noch bearbeiten, verschieben oder löschen.
+
+```ts
+footerBlocks: [
+  {
+    id: "platform-footer",
+    type: "html",
+    props: { html: '<p style="text-align:center">Gesendet mit Acme</p>' },
+  },
+]
+```
+
+Sie werden inline im E-Mail-Rahmen gerendert, mit den Schriften und Link-Stilen
+der Vorlage, damit sie wie ein Teil der Nachricht wirken und nicht wie eine
+separate Karte.
+
+Sie dienen **nur zur Anzeige**: nie in `getContent()`, `toMjml()`, im Versand
+oder im Export. Die gespeicherte Vorlage bleibt also genau das, was die
+bearbeitende Person verfasst hat.
+
+Das ist Absicht, und darum ist es nicht dasselbe, wie den Block in die Vorlage
+zu legen und zu sperren. Ein Block in der Vorlage wird gespeichert und friert
+damit den Stand des letzten Speicherns ein — hängt das Abzeichen am Tarif, wird
+es nach einem Upgrade weiterhin mitgesendet. Und eine clientseitige Sperre ist
+keine Garantie, sobald dieselben Inhalte über Ihre API beschreibbar sind. Hängen
+Sie den Footer weiterhin dort an, wo Sie es beim Versand ohnehin tun;
+`footerBlocks` zeigt lediglich, was dieser Schritt ergänzt.
 
 Standardmäßig listet die Seitenleisten-Palette jeden integrierten Blocktyp auf. Übergeben Sie `paletteBlocks`, um die Palette auf eine bestimmte Menge zu beschränken und ihre Reihenfolge zu steuern — nützlich, um nicht verwendete Blocktypen (`video`, `table`, …) auszublenden oder einen häufig genutzten [benutzerdefinierten Block](/de/guide/custom-blocks) über die integrierten Blöcke zu stellen.
 

--- a/packages/editor/src/cloud/cloudConfig.ts
+++ b/packages/editor/src/cloud/cloudConfig.ts
@@ -1,4 +1,5 @@
 import type {
+  Block,
   AiConfig,
   BlockDefaults,
   CollaborationConfig,
@@ -182,6 +183,14 @@ export interface TemplaticalCloudEditorConfig {
    * editor config for details.
    */
   paletteBlocks?: string[];
+
+  /**
+   * Read-only blocks rendered after the template's own, so an author can see
+   * what your platform appends at send time. Display-only: never part of
+   * `getContent()`, a send or an export. See `footerBlocks` on the OSS editor
+   * config for why this is not the same as locking a block in the template.
+   */
+  footerBlocks?: Block[];
 
   /**
    * Render each HTML block's raw content as a live preview in the editor

--- a/packages/editor/src/components/BlockPreviewCanvas.vue
+++ b/packages/editor/src/components/BlockPreviewCanvas.vue
@@ -54,8 +54,16 @@ const props = withDefaults(
      * and get the wrong answer.
      */
     applyConditionFilter?: boolean;
+    /**
+     * Drops the stage — its width, email background, rounded corners and shadow —
+     * and lets the content column fill the caller instead of setting its own
+     * width. For callers already inside an email frame: the canvas renders
+     * `footerBlocks` this way, and with the stage the footer reads as a second
+     * card floating inside the email rather than a continuation of it.
+     */
+    embedded?: boolean;
   }>(),
-  { viewport: "desktop", applyConditionFilter: true },
+  { viewport: "desktop", applyConditionFilter: true, embedded: false },
 );
 
 const blockRegistry = inject(BLOCK_REGISTRY_KEY);
@@ -178,25 +186,38 @@ function getBlockComponent(block: Block): Component | null {
        carried the width itself. -->
   <div
     data-testid="block-preview-stage"
-    class="tpl:pointer-events-none tpl:mx-auto tpl:flex tpl:select-none tpl:justify-center tpl:rounded-lg"
-    :style="{
-      width: `${stageWidth}px`,
-      minWidth: `${frameWidth}px`,
-      maxWidth: '100%',
-      backgroundColor: emailBackground,
-      boxShadow: 'var(--tpl-shadow-sm)',
-    }"
+    class="tpl:pointer-events-none tpl:select-none"
+    :class="
+      embedded
+        ? undefined
+        : 'tpl:mx-auto tpl:flex tpl:justify-center tpl:rounded-lg'
+    "
+    :style="
+      embedded
+        ? undefined
+        : {
+            width: `${stageWidth}px`,
+            minWidth: `${frameWidth}px`,
+            maxWidth: '100%',
+            backgroundColor: emailBackground,
+            boxShadow: 'var(--tpl-shadow-sm)',
+          }
+    "
   >
     <!-- CONTENT COLUMN — the blocks at their true email width. Keeps the
          testid: this is the element whose width *is* the email width, which is
          what every viewport assertion measures. -->
     <div
       data-testid="block-preview-canvas"
-      :style="{
-        width: `${frameWidth}px`,
-        transition: EMAIL_FRAME_WIDTH_TRANSITION,
-        ...documentStyle,
-      }"
+      :style="
+        embedded
+          ? documentStyle
+          : {
+              width: `${frameWidth}px`,
+              transition: EMAIL_FRAME_WIDTH_TRANSITION,
+              ...documentStyle,
+            }
+      "
     >
       <div
         v-for="block in visibleBlocks"

--- a/packages/editor/src/components/Canvas.vue
+++ b/packages/editor/src/components/Canvas.vue
@@ -16,6 +16,7 @@ import {
   CONDITION_PREVIEW_KEY,
   BLOCK_REGISTRY_KEY,
   CAPABILITIES_KEY,
+  FOOTER_BLOCKS_KEY,
   MERGE_TAG_SAMPLE_MODE_KEY,
   PREVIEW_RESOLUTION_KEY,
   USE_MERGE_TAG_SAMPLES_KEY,
@@ -33,6 +34,7 @@ import {
 } from "../utils/emailFrameWidth";
 import { readableTextColor } from "../utils/readableTextColor";
 
+import BlockPreviewCanvas from "./BlockPreviewCanvas.vue";
 import BlockWrapper from "./blocks/BlockWrapper.vue";
 import SectionBlock from "./blocks/SectionBlock.vue";
 import TitleBlock from "./blocks/TitleBlock.vue";
@@ -106,6 +108,8 @@ const caps = inject(CAPABILITIES_KEY, {});
 const mergeTagSampleMode = inject(MERGE_TAG_SAMPLE_MODE_KEY, null);
 // Null in headless mounts and when no resolver is configured.
 const previewResolution = inject(PREVIEW_RESOLUTION_KEY, null);
+// Undefined unless the consumer configured `footerBlocks`.
+const footerBlocks = inject(FOOTER_BLOCKS_KEY, undefined);
 provide(
   USE_MERGE_TAG_SAMPLES_KEY,
   computed(
@@ -496,6 +500,18 @@ function handleFetchData(
             </div>
           </div>
         </VueDraggable>
+
+        <!-- Outside VueDraggable on purpose: these are not in `content`, so
+             they cannot be reordered into it, and `getContent()` never sees
+             them. -->
+        <BlockPreviewCanvas
+          v-if="footerBlocks?.length"
+          v-show="!previewResolution?.isInitialResolve.value"
+          data-testid="footer-blocks"
+          embedded
+          :blocks="footerBlocks"
+          :viewport="viewport"
+        />
       </div>
     </div>
   </div>

--- a/packages/editor/src/composables/useEditorCore.ts
+++ b/packages/editor/src/composables/useEditorCore.ts
@@ -63,6 +63,7 @@ import {
   BLOCK_REGISTRY_KEY,
   CUSTOM_BLOCK_DEFINITIONS_KEY,
   PALETTE_BLOCKS_KEY,
+  FOOTER_BLOCKS_KEY,
   HTML_BLOCK_PREVIEW_KEY,
   COLORS_KEY,
   CUSTOM_BLOCK_STYLESHEETS_KEY,
@@ -222,6 +223,7 @@ export interface UseEditorCoreOptions {
     templateDefaults?: TemplateDefaults;
     customBlocks?: CustomBlockDefinition[];
     paletteBlocks?: string[];
+    footerBlocks?: Block[];
     htmlBlockPreview?: HtmlBlockPreviewConfig;
     colors?: ColorsConfig;
     mergeTags?: MergeTagsConfig;
@@ -557,6 +559,7 @@ export function useEditorCore(
   provide(BLOCK_REGISTRY_KEY, registry);
   provide(CUSTOM_BLOCK_DEFINITIONS_KEY, config.customBlocks ?? []);
   provide(PALETTE_BLOCKS_KEY, config.paletteBlocks);
+  provide(FOOTER_BLOCKS_KEY, config.footerBlocks);
   provide(
     HTML_BLOCK_PREVIEW_KEY,
     resolveHtmlBlockPreview(config.htmlBlockPreview),

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -3,6 +3,7 @@
 import { createApp, h, ref, type App, type Ref } from "vue";
 import { DEFAULT_AUTO_SAVE_DEBOUNCE_MS } from "@templatical/core";
 import type {
+  Block,
   BlockDefaults,
   ColorsConfig,
   CommentsProvider,
@@ -321,6 +322,28 @@ export interface TemplaticalEditorConfig {
    * block type still renders correctly.
    */
   paletteBlocks?: string[];
+
+  /**
+   * Blocks rendered after the template's own, read-only.
+   *
+   * Display-only: they never reach `getContent()`, a send or an export, and
+   * they cannot be selected, edited, dragged or deleted. They exist so an
+   * author can SEE content the host application appends outside the editor —
+   * a platform footer, a plan badge, a legal line — without that content
+   * becoming part of the template.
+   *
+   * Storing such a block in the template instead looks equivalent and is not.
+   * It would be saved, so it freezes at edit time rather than tracking what
+   * your application appends at send time — and a client-side lock is no
+   * guarantee once the same content is writable through your API.
+   *
+   * ```ts
+   * footerBlocks: [
+   *   { id: "platform-footer", type: "html", props: { html: "<p>Sent with Acme</p>" } },
+   * ]
+   * ```
+   */
+  footerBlocks?: Block[];
 
   /**
    * Render each HTML block's raw content as a live preview in the editor
@@ -1085,6 +1108,7 @@ export async function initCloud(
       templateDefaults: config.templateDefaults,
       customBlocks: config.customBlocks,
       paletteBlocks: config.paletteBlocks,
+      footerBlocks: config.footerBlocks,
       htmlBlockPreview: config.htmlBlockPreview,
       colors: config.colors,
       fonts: config.fonts,

--- a/packages/editor/src/keys.ts
+++ b/packages/editor/src/keys.ts
@@ -5,6 +5,7 @@ import type {
   UseConditionPreviewReturn,
 } from "@templatical/core";
 import type {
+  Block,
   BlockDefaults,
   CustomBlockDefinition,
   DisplayCondition,
@@ -84,6 +85,15 @@ export const CUSTOM_BLOCK_DEFINITIONS_KEY: InjectionKey<
  */
 export const PALETTE_BLOCKS_KEY: InjectionKey<string[] | undefined> =
   Symbol("paletteBlocks");
+
+/**
+ * Consumer-supplied blocks rendered after the template's own, read-only
+ * (`config.footerBlocks`). Never part of `getContent()`, so they cannot be
+ * saved, exported or edited — they exist so an author can SEE what the host
+ * application appends at send time. Consumed by `Canvas.vue`.
+ */
+export const FOOTER_BLOCKS_KEY: InjectionKey<Block[] | undefined> =
+  Symbol("footerBlocks");
 
 /**
  * Whether HTML blocks render a live sandboxed-iframe preview in the canvas

--- a/packages/editor/tests/blockPreviewCanvas.test.ts
+++ b/packages/editor/tests/blockPreviewCanvas.test.ts
@@ -19,13 +19,16 @@ import type { TemplateSettings } from '@templatical/types';
  * rendered in a saved-block preview lost its underline and serif face while
  * the identical block on the canvas kept both.
  */
-function mountCanvas(settings?: Partial<TemplateSettings>) {
+function mountCanvas(
+  settings?: Partial<TemplateSettings>,
+  props: { embedded?: boolean } = {},
+) {
   const content = createDefaultTemplateContent();
   content.settings = { ...content.settings, ...settings };
   content.blocks = [createParagraphBlock({ content: '<p><a href="#">x</a></p>' })];
 
   return mountEditor(BlockPreviewCanvas, {
-    props: { blocks: content.blocks },
+    props: { blocks: content.blocks, ...props },
     provides: settings
       ? { [EDITOR_KEY]: { content: ref(content), state: {} } }
       : {},
@@ -171,6 +174,36 @@ describe('BlockPreviewCanvas email background', () => {
  * includes condition-excluded content is worse than no preview at all, because
  * the user trusts it.
  */
+/**
+ * `embedded` is for callers that already sit inside an email frame — the canvas
+ * rendering `footerBlocks`. Keeping the standalone frame there draws a second
+ * card inside the email rather than a continuation of it.
+ */
+describe('BlockPreviewCanvas embedded', () => {
+  it('drops the stage but keeps the document style', () => {
+    const wrapper = mountCanvas({ fontFamily: 'Georgia, serif' }, { embedded: true });
+    const stage = wrapper.find('[data-testid="block-preview-stage"]');
+    const column = wrapper.find('[data-testid="block-preview-canvas"]');
+
+    expect(stage.attributes('style')).toBeUndefined();
+    expect(stage.classes()).not.toContain('tpl:rounded-lg');
+    // The column fills the caller rather than setting the email width itself.
+    expect(column.attributes('style') ?? '').not.toContain('width:');
+    // Same font and link rules as the blocks it sits under.
+    expect(column.attributes('style') ?? '').toContain('Georgia, serif');
+  });
+
+  it('keeps the stage by default, so existing callers are untouched', () => {
+    const wrapper = mountCanvas({ fontFamily: 'Georgia, serif' });
+    const stage = wrapper.find('[data-testid="block-preview-stage"]');
+
+    expect(stage.attributes('style') ?? '').toContain('box-shadow');
+    expect(
+      wrapper.find('[data-testid="block-preview-canvas"]').attributes('style') ?? '',
+    ).toContain('width: 600px');
+  });
+});
+
 describe('BlockPreviewCanvas visibility and viewport', () => {
   /**
    * `hideExcluded` rather than an id list: the blocks are created inside, so a

--- a/packages/editor/tests/canvas-footer-blocks.test.ts
+++ b/packages/editor/tests/canvas-footer-blocks.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+import "./dom-stubs";
+import { describe, expect, it } from "vitest";
+import { useEditor } from "@templatical/core";
+import {
+  createParagraphBlock,
+  createDefaultTemplateContent,
+} from "@templatical/types";
+import type { Block } from "@templatical/types";
+import Canvas from "../src/components/Canvas.vue";
+import { mountEditor } from "./helpers/mount";
+import { EDITOR_KEY, FOOTER_BLOCKS_KEY } from "../src/keys";
+
+/**
+ * `footerBlocks` renders consumer-supplied blocks after the template's own,
+ * read-only. The property that makes them useful is what they are NOT: they
+ * never enter `content`, so a host application can show an author the footer it
+ * appends at send time without that footer becoming part of the template — and
+ * therefore without it being saved, exported, or editable.
+ */
+function mountCanvasWith(footerBlocks?: Block[]) {
+  const content = createDefaultTemplateContent();
+  content.blocks = [createParagraphBlock({ content: "<p>authored</p>" })];
+  const editor = useEditor({ content });
+
+  const wrapper = mountEditor(Canvas, {
+    props: {
+      viewport: "desktop",
+      content: editor.content.value,
+      selectedBlockId: null,
+      darkMode: false,
+      previewMode: false,
+    },
+    provides: {
+      [EDITOR_KEY]: editor,
+      [FOOTER_BLOCKS_KEY]: footerBlocks,
+    },
+  } as never);
+
+  return { wrapper, editor };
+}
+
+function footerParagraph() {
+  return createParagraphBlock({ content: "<p>Sent with Acme</p>" });
+}
+
+describe("Canvas footerBlocks", () => {
+  it("renders the consumer's blocks after the template's own", () => {
+    const { wrapper } = mountCanvasWith([footerParagraph()]);
+
+    const footer = wrapper.find('[data-testid="footer-blocks"]');
+    expect(footer.exists()).toBe(true);
+    expect(footer.text()).toContain("Sent with Acme");
+
+    // After, not before: the authored paragraph still comes first in the DOM.
+    const html = wrapper.html();
+    expect(html.indexOf("authored")).toBeLessThan(html.indexOf("Sent with Acme"));
+  });
+
+  it("renders nothing when the consumer supplies none", () => {
+    expect(
+      mountCanvasWith(undefined).wrapper.find('[data-testid="footer-blocks"]').exists(),
+    ).toBe(false);
+
+    expect(
+      mountCanvasWith([]).wrapper.find('[data-testid="footer-blocks"]').exists(),
+    ).toBe(false);
+  });
+
+  // The whole point. A footer block that reached `content` would be saved by
+  // the consumer, exported by `toMjml()`, and would then be appended twice by
+  // any host that also adds it at send time.
+  it("keeps them out of the editor's content", () => {
+    const footer = footerParagraph();
+    const { editor } = mountCanvasWith([footer]);
+
+    expect(editor.content.value.blocks).toHaveLength(1);
+    expect(editor.content.value.blocks[0]!.type).toBe("paragraph");
+    expect(editor.content.value.blocks.map((b) => b.id)).not.toContain(footer.id);
+  });
+
+  // Read-only: they are rendered outside the draggable list, so none of the
+  // editing affordances the authored blocks carry appear on them.
+  it("gives them no block chrome, so they cannot be selected or dragged", () => {
+    const { wrapper } = mountCanvasWith([footerParagraph()]);
+
+    const footer = wrapper.find('[data-testid="footer-blocks"]');
+    expect(footer.find("[data-block-id]").exists()).toBe(false);
+    expect(footer.find(".tpl-block-actions").exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Applications embedding the editor often append something to every email after it leaves the canvas - for example a readonly branding footer. There is no way to show that to the author today: the canvas renders `content`, and `content` is where it must not go.

`footerBlocks` renders consumer-supplied blocks after the template's own, read-only. They never enter `content`, so **`getContent()` and `toMjml()` need no changes at all** — the exclusion is structural rather than a filter someone has to remember.

**Why not lock a block in the template instead?** `lockedBlocks` already exists in core and looked like the answer at first. But a block in the template is *saved*, which breaks it twice: it freezes whatever was true at edit time instead of tracking what the application appends at send time, and a client-side lock is no guarantee once the same content is writable through the consumer's API. Locking answers "can the author edit this"; the question here is "is this part of the template", and the answer has to be no.

**On the name.** `displayBlocks` was the first choice, matching the "Display-only" wording already used for `resolvePreview` — but it reads as a sibling of the existing `displayConditions` and means something quite different. `footerBlocks` says where it renders, and leaves a symmetric `headerBlocks` as an obvious follow-up. Happy to rename.

## Linked issues

n/a — happy to open a Discussion first if you'd rather talk through the API shape before reviewing. CONTRIBUTING suggests that for substantial features and this does add public API.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [x] Documentation
- [x] Tests / tooling / CI
- [ ] Dependency update

## Affected packages

- [x] `@templatical/editor`
- [ ] `@templatical/core` (or `@templatical/core/cloud`)
- [ ] `@templatical/media-library`
- [ ] `@templatical/types`
- [ ] `@templatical/renderer`
- [ ] `@templatical/import-beefree`
- [ ] `apps/playground`
- [x] `apps/docs`
- [ ] Tooling / CI / repo config

## Checklist

- [x] Tests added or updated (and they fail without my change)
- [x] `pnpm run ci` passes locally (lint + typecheck + build + test)
- [x] `pnpm run test:e2e` passes (only if this PR touches editor UI) — 619 passed, 17 skipped
- [x] Docs updated — both `apps/docs/<page>.md` and `apps/docs/de/<page>.md` if user-facing
- [ ] i18n keys added to both `en.ts` and `de.ts` if I added new strings — n/a, no new strings
- [x] Changeset added (`pnpm exec changeset`) — required for any change to a published package
- [x] PR title is descriptive and follows the existing convention

German docs included. I reused the wording `apps/docs/de/api/editor.md` already uses for the same claim on `resolvePreview` — *"Nur zur Anzeige: nie in `getContent()`, im Versand oder im Export"* — so the two options describe display-only identically rather than in two phrasings.

## Notes for reviewers

**Where I'd most like scrutiny:**

1. **`embedded` on `BlockPreviewCanvas`.** Reusing the component as-is rendered a second card inside the email: it draws its own stage, which is right for the saved-block previews it was built for and wrong where a stage already exists. `embedded` drops it and lets the content column fill the caller. Default `false`, with a test asserting existing callers are untouched. If you'd rather not grow that component's API, the alternative is duplicating its render loop in `Canvas.vue`, which I liked less.

2. **Injection over prop-drilling.** `FOOTER_BLOCKS_KEY` follows `PALETTE_BLOCKS_KEY`; nothing between `useEditorCore` and `Canvas` needs the value.

3. **`TemplaticalCloudEditorConfig` also gets the option.** The forwarding block in `index.ts` is shared, so typecheck required it. Tell me if Cloud should not expose this and I'll split the forward instead.

4. **First preview resolve.** The footer is hidden by the same `isInitialResolve` guard the editable list uses, so the skeleton isn't shown with a footer floating under it.

**Known limitation:** footer only. A `headerBlocks` counterpart is a small follow-up but I left it out to keep this to one concern.

