### PR TITLE
fix: dialogs being clipped to editor's container in Safari

### DIFF
--- a/.changeset/quiet-moons-wonder.md
+++ b/.changeset/quiet-moons-wonder.md
@@ -1,0 +1,27 @@
+---
+"@templatical/editor": patch
+---
+
+Fix two ways the host page could break the editor
+
+**Dialogs were clipped to the container in Safari.** When the container did not
+fill the viewport, every dialog was painted cut off at its edge and the backdrop
+dimmed only the editor's own area. Safari paints a `position: fixed` descendant
+clipped to an ancestor's `overflow: hidden` box while still resolving its layout
+against the viewport, and the editor's root carried that `overflow: hidden`. The
+clip now sits on an inner chrome wrapper that does not enclose the popover root,
+so dialogs cover the viewport again — both tag pickers, the link dialog,
+test-email, save-block, saved-blocks browser, restore-version, and
+`@templatical/media-library`'s modals when opened from the editor.
+
+**Host typography inherited into the editor.** Twelve inheritable properties —
+`letter-spacing`, `text-transform`, `font-style`, `font-weight` and others —
+crossed into the chrome and the canvas, so a host with
+`text-transform: uppercase` showed a preview of an email the recipient would
+never receive. Shadow DOM does not prevent this: it blocks host rules, but
+inheritance follows the flattened tree. The editor's root now neutralizes all
+twelve. `direction` still inherits, so RTL pages keep working.
+
+No API change, and no CSS reset is needed on your container — an aggressive one
+(`all: initial` / `all: revert`) would wipe the `--tpl-user-*` theming
+properties. See the new [Embedding the editor](https://docs.templatical.com/getting-started/embedding) guide.

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -85,6 +85,7 @@ const enSidebar: DefaultTheme.SidebarMulti = {
       items: [
         { text: "Installation", link: "/getting-started/installation" },
         { text: "Quick Start", link: "/getting-started/quick-start" },
+        { text: "Embedding", link: "/getting-started/embedding" },
         {
           text: "How Rendering Works",
           link: "/getting-started/how-rendering-works",
@@ -260,6 +261,7 @@ const deSidebar: DefaultTheme.SidebarMulti = {
       items: [
         { text: "Installation", link: "/de/getting-started/installation" },
         { text: "Schnellstart", link: "/de/getting-started/quick-start" },
+        { text: "Einbetten", link: "/de/getting-started/embedding" },
         {
           text: "So funktioniert das Rendering",
           link: "/de/getting-started/how-rendering-works",

--- a/apps/docs/de/getting-started/embedding.md
+++ b/apps/docs/de/getting-started/embedding.md
@@ -1,0 +1,96 @@
+---
+title: Den Editor einbetten
+description: CSS-Einschränkungen für den Container, in den Sie den Editor mounten, und was bricht, wenn ein Vorfahre sie verletzt.
+---
+
+# Den Editor einbetten
+
+Der Editor ist eine Komponente, die Sie in ein Element Ihrer eigenen Seite mounten. Fast alles, was an dieser Nahtstelle schiefgeht, ist eine CSS-Wechselwirkung zwischen Ihrer Seite und den Overlays des Editors — verursacht von einer kleinen Menge von Eigenschaften.
+
+Nichts davon ist Templatical-spezifisch: Es sind reine CSS-Regeln, die jede Bibliothek betreffen, die Overlays mit `position: fixed` positioniert. Siehe außerdem [Shadow DOM](../guide/shadow-dom) dazu, wie der Editor seine eigenen Styles isoliert, und [Theming](../guide/theming) für die `--tpl-user-*`-Oberfläche.
+
+## Der Container des Editors
+
+Der Editor mountet seine Dialoge in eine Popover-Wurzel mit `z-index: 10000` innerhalb des Containers, den Sie an `init()` übergeben. Ein z-index wirkt nur innerhalb seines eigenen Stacking-Kontexts. Deshalb **darf der Container keinen eigenen Stacking-Kontext erzeugen** — sonst bleiben alle Dialoge des Editors darin eingeschlossen, und jedes Chrome von Ihnen mit höherem z-index im übergeordneten Kontext überdeckt sie.
+
+Diese Eigenschaften erzeugen einen Stacking-Kontext, wenn sie auf dem Container oder einem Vorfahren zwischen Container und dem Stacking-Kontext Ihres Chromes liegen:
+
+| Eigenschaft | Auslösender Wert |
+| ----------- | ---------------- |
+| `isolation` | `isolate` |
+| `transform` / `translate` / `rotate` / `scale` | alles außer `none` |
+| `filter` / `backdrop-filter` | alles außer `none` |
+| `perspective` | alles außer `none` |
+| `opacity` | kleiner als `1` |
+| `will-change` | `transform`, `filter`, `opacity`, `perspective` |
+| `contain` | `paint`, `layout`, `content`, `strict` |
+| `mix-blend-mode` | alles außer `normal` |
+| `position: fixed` / `sticky` | immer |
+| `position: relative` / `absolute` | mit einem `z-index` außer `auto` |
+
+Wenn sich eine davon nicht vermeiden lässt — ein Route-Übergang, der `transform` animiert, oder ein Wrapper, den Sie nicht kontrollieren — geben Sie diesem Element einen `z-index` oberhalb Ihres eigenen Headers, Ihrer Sidebar oder Ihrer Toast-Ebene:
+
+```css
+#your-editor-container {
+  /* Über Ihrem eigenen Chrome, damit die Dialoge des Editors es auch sind. */
+  z-index: 200;
+  position: relative;
+}
+```
+
+::: tip Warum ein höherer z-index auf dem Dialog nicht hilft
+Ein `fixed` positionierter Nachfahre kann einen Stacking-Kontext mit keinem z-index verlassen — verglichen wird zwischen der Wurzel des Kontexts und Ihrem Chrome, der Wert des Nachfahren geht dabei nie ein. Der Wert muss also auf den Container, nicht auf den Dialog. Den Container höher zu legen ist unbedenklich, weil sich dessen eigene Box nicht mit Ihrem Chrome überschneidet; betroffen sind nur die Dialoge, die `fixed` sind und den Viewport ausfüllen.
+:::
+
+### Dieselben Eigenschaften verschieben auch
+
+`transform`, `filter`, `perspective`, `will-change` und `contain` erledigen zwei Aufgaben gleichzeitig: Neben dem Stacking-Kontext oben erzeugt jede auch einen **umgebenden Block für `position: fixed`**. Ein `fixed` positionierter Nachfahre bezieht seine Koordinaten dann auf diesen Vorfahren statt auf den Viewport — und zwar auch dann, wenn der berechnete Wert von `transform` `none` lautet, denn eine laufende oder animierte Transformation befördert das Element trotzdem.
+
+Was das für den Editor bedeutet:
+
+| Overlay | Unter einem transformierten Vorfahren |
+| ------- | ------------------------------------- |
+| Farbwähler, Rich-Text-Toolbars, Merge-Tag-Autovervollständigung | Nicht betroffen. Sie verankern sich `absolute` in der Popover-Wurzel und rechnen Viewport-Koordinaten in wurzel-lokale um, wodurch sich der Versatz des Vorfahren aufhebt. |
+| Dialoghöhe | Nicht betroffen. Jeder Dialog begrenzt seine Höhe gegen seinen eigenen Backdrop statt gegen den Viewport und bleibt damit in der Box, die er bekommt. |
+| Drag-and-drop-Ghost | **Versetzt.** Der Ghost ist `position: fixed` und wird aus Viewport-Koordinaten platziert, driftet also um den Versatz des Vorfahren vom Cursor weg. |
+
+Wenn Sie Drag-and-drop nutzen, halten Sie `transform` daher von allen Vorfahren des Containers fern.
+
+::: warning Ersetzen Sie es nicht durch `opacity`
+`opacity` statt `transform` zu animieren vermeidet das Containing-Block-Problem und führt direkt in das Stacking-Problem — `opacity` unter `1` erzeugt einen Stacking-Kontext, sodass Ihr Chrome anfängt, über die Dialoge des Editors zu zeichnen. Es gibt keine Eigenschaft, die beides umgeht. Legen Sie einen Scroll- oder Einblend-Effekt auf ein Element, das den Container des Editors nicht umschließt.
+:::
+
+### Beschneidende Vorfahren in Safari
+
+`overflow: hidden`, `clip`, `auto` oder `scroll` auf einem Vorfahren des Containers erzeugt weder einen Stacking-Kontext noch einen umgebenden Block und fehlt deshalb in der Tabelle oben — in Safari beschneidet es die Dialoge trotzdem.
+
+Safari zeichnet einen `position: fixed` positionierten Nachfahren auf die Box eines solchen Vorfahren beschnitten, bezieht sein Layout aber weiterhin auf den Viewport. Ein Dialog wird also korrekt platziert und dann an der Kante dieses Vorfahren abgeschnitten, und sein abdunkelnder Backdrop bedeckt nur dessen Fläche. Chrome und Firefox zeichnen ihn über den gesamten Viewport.
+
+Der Editor hält seinen eigenen Clip von der Vorfahrenkette der Dialoge fern, sein Container darf also in einem scrollbaren oder beschnittenen Layout liegen. Ein Vorfahre **des** Containers liegt außerhalb dessen, was der Editor beeinflussen kann:
+
+```css
+.your-app-shell {
+  /* Beschneidet die Dialoge des Editors in Safari. */
+  overflow: hidden;
+}
+```
+
+Wenn das Element nur seine eigenen Kinder umschließen soll, hilft auch `overflow: clip` mit `overflow-clip-margin` nicht — jeder Wert beschneidet. Verschieben Sie die Eigenschaft auf ein Element, das den Container nicht umschließt, oder lassen Sie die Seite normal scrollen.
+
+## Typografie der Host-Seite dringt nicht ein
+
+Der Editor neutralisiert an seiner Wurzel jede vererbbare Typografie-Eigenschaft, sodass die globalen Schriftstile Ihrer Seite weder sein Chrome noch seine Canvas erreichen:
+
+`letter-spacing` · `word-spacing` · `text-transform` · `font-style` · `font-weight` · `text-indent` · `text-align` · `white-space` · `list-style-type` · `cursor` · `font-variant-numeric` · `text-shadow` — dazu `font-family`, `font-size`, `line-height` und `color`.
+
+Am wichtigsten ist das für die Canvas. Ein seitenweites `text-transform: uppercase`, das die Vorschau erreicht, würde Ihnen eine E-Mail zeigen, die der Empfänger nie bekommt. Die Zusage gilt deshalb für E-Mail-Inhalte, nicht nur für das Chrome des Editors.
+
+::: tip Warum Shadow DOM allein nicht genügt
+Shadow DOM blockiert *Regeln* der Host-Seite — ein Selektor aus Ihrem Stylesheet greift innerhalb der Shadow-Wurzel des Editors nie. Es blockiert jedoch keine *Vererbung*, die dem flachgelegten Baum folgt; vererbbare Eigenschaften überschreiten die Grenze also trotzdem. Aufgehalten werden sie vom Reset des Editors, und der wirkt mit `shadowDom: false` genauso.
+:::
+
+**`direction` darf bewusst vererbt werden.** Eine RTL-Seite gibt ihre Schreibrichtung an den Editor weiter, was RTL-Einbettungen genau so wollen. `visibility` bleibt aus demselben Grund unangetastet.
+
+### Sie brauchen kein CSS-Reset auf dem Container
+
+Ein Reset des Containers ist nicht nötig, und ein aggressives Reset schadet: `all: initial` oder `all: revert` löscht dort die `--tpl-user-*`-Custom-Properties, auf denen [Theming](../guide/theming) beruht, und kann die `height: 100%`-Kette zerreißen, an der sich der Editor bemisst. Gestalten Sie die Box des Containers — Größe, Position, Rahmen — und lassen Sie seine vererbten Werte unberührt.

--- a/apps/docs/de/getting-started/installation.md
+++ b/apps/docs/de/getting-started/installation.md
@@ -17,7 +17,7 @@ Feature-Wunsch oder rauer Kante begegnet? [Diskussion eröffnen](https://github.
   - **Standardmodus** (`shadowDom: true`, Shadow DOM) — Chrome 80+, Edge 80+, Firefox 101+, Safari 16.4+. Firefox- und Safari-Mindestversionen sind durch die `adoptedStyleSheets`-API bestimmt, auf die der Shadow-Pfad angewiesen ist.
   - **Opt-out-Modus** (`shadowDom: false`, Light DOM) — Chrome 80+, Edge 80+, Firefox 80+, Safari 14+. Verwenden Sie diesen Modus, wenn Sie ältere Firefox- oder Safari-Versionen unterstützen müssen oder Ihre Integration Light-DOM-Zugriff auf Editor-Interna benötigt. Siehe den [Shadow-DOM-Leitfaden](../guide/shadow-dom) für die Kompromisse.
 - **Container-Element** -- muss eine definierte Höhe haben (der Editor füllt seinen Container aus). Im Standardmodus muss es ein Elementtyp sein, der einen Shadow Root hosten kann (z. B. `<div>`, `<section>`, `<article>`). Siehe [Container-Element-Anforderungen](../api/editor#container-element-requirements).
-- **Kein `transform` und kein Stacking-Kontext auf einem Vorfahren des Containers** -- `transform`, `filter`, `perspective`, `will-change`, `opacity` unter `1`, `isolation`, `contain` und positionierte Elemente mit `z-index` verändern jeweils, wo die Overlays des Editors gezeichnet oder positioniert werden. Das sind reine CSS-Regeln, keine Templatical-spezifischen Einschränkungen; sie betreffen jede Bibliothek, die Overlays mit `position: fixed` positioniert. Was jede Eigenschaft konkret bricht und wie Sie es umgehen, steht unter [Der Container des Editors](#der-container-des-editors).
+- **Kein `transform` und kein Stacking-Kontext auf einem Vorfahren des Containers** -- `transform`, `filter`, `perspective`, `will-change`, `opacity` unter `1`, `isolation`, `contain` und positionierte Elemente mit `z-index` verändern jeweils, wo die Overlays des Editors gezeichnet oder positioniert werden. Das sind reine CSS-Regeln, keine Templatical-spezifischen Einschränkungen; sie betreffen jede Bibliothek, die Overlays mit `position: fixed` positioniert. Was jede Eigenschaft konkret bricht und wie Sie es umgehen, steht unter [Den Editor einbetten](./embedding).
 - **Keine erforderlichen Peer-Dependencies** -- Vue, TipTap und alle internen Bibliotheken sind im Editor gebündelt. Sie müssen weder Vue noch eine andere Framework-Runtime installieren, unabhängig davon, welches Framework Ihre App verwendet. (`@templatical/renderer`, `@templatical/quality`, `@templatical/media-library` und `pusher-js` sind _optionale_ Peers — installieren Sie sie nur, wenn Sie das entsprechende Feature nutzen; siehe [Optionale Peers](#optionale-peers) weiter unten.)
 
 ## Netzwerk-Anfragen
@@ -48,54 +48,9 @@ Der `@import` bleibt dabei im Stylesheet erhalten, die Anfrage wird also weiterh
 
 ## Der Container des Editors
 
-Der Editor mountet seine Dialoge in eine Popover-Wurzel mit `z-index: 10000` innerhalb des Containers, den Sie an `init()` übergeben. Ein z-index wirkt nur innerhalb seines eigenen Stacking-Kontexts. Deshalb **darf der Container keinen eigenen Stacking-Kontext erzeugen** — sonst bleiben alle Dialoge des Editors darin eingeschlossen, und jedes Chrome von Ihnen mit höherem z-index im übergeordneten Kontext überdeckt sie.
+Der Container, den Sie an `init()` übergeben, unterliegt einigen CSS-Einschränkungen. Ein Vorfahre mit `transform`, `overflow: hidden` oder einem eigenen Stacking-Kontext kann die Dialoge des Editors verschieben oder beschneiden.
 
-Diese Eigenschaften erzeugen einen Stacking-Kontext, wenn sie auf dem Container oder einem Vorfahren zwischen Container und dem Stacking-Kontext Ihres Chromes liegen:
-
-| Eigenschaft | Auslösender Wert |
-| ----------- | ---------------- |
-| `isolation` | `isolate` |
-| `transform` / `translate` / `rotate` / `scale` | alles außer `none` |
-| `filter` / `backdrop-filter` | alles außer `none` |
-| `perspective` | alles außer `none` |
-| `opacity` | kleiner als `1` |
-| `will-change` | `transform`, `filter`, `opacity`, `perspective` |
-| `contain` | `paint`, `layout`, `content`, `strict` |
-| `mix-blend-mode` | alles außer `normal` |
-| `position: fixed` / `sticky` | immer |
-| `position: relative` / `absolute` | mit einem `z-index` außer `auto` |
-
-Wenn sich eine davon nicht vermeiden lässt — ein Route-Übergang, der `transform` animiert, oder ein Wrapper, den Sie nicht kontrollieren — geben Sie diesem Element einen `z-index` oberhalb Ihres eigenen Headers, Ihrer Sidebar oder Ihrer Toast-Ebene:
-
-```css
-#your-editor-container {
-  /* Über Ihrem eigenen Chrome, damit die Dialoge des Editors es auch sind. */
-  z-index: 200;
-  position: relative;
-}
-```
-
-::: tip Warum ein höherer z-index auf dem Dialog nicht hilft
-Ein `fixed` positionierter Nachfahre kann einen Stacking-Kontext mit keinem z-index verlassen — verglichen wird zwischen der Wurzel des Kontexts und Ihrem Chrome, der Wert des Nachfahren geht dabei nie ein. Der Wert muss also auf den Container, nicht auf den Dialog. Den Container höher zu legen ist unbedenklich, weil sich dessen eigene Box nicht mit Ihrem Chrome überschneidet; betroffen sind nur die Dialoge, die `fixed` sind und den Viewport ausfüllen.
-:::
-
-### Dieselben Eigenschaften verschieben auch
-
-`transform`, `filter`, `perspective`, `will-change` und `contain` erledigen zwei Aufgaben gleichzeitig: Neben dem Stacking-Kontext oben erzeugt jede auch einen **umgebenden Block für `position: fixed`**. Ein `fixed` positionierter Nachfahre bezieht seine Koordinaten dann auf diesen Vorfahren statt auf den Viewport — und zwar auch dann, wenn der berechnete Wert von `transform` `none` lautet, denn eine laufende oder animierte Transformation befördert das Element trotzdem.
-
-Was das für den Editor bedeutet:
-
-| Overlay | Unter einem transformierten Vorfahren |
-| ------- | ------------------------------------- |
-| Farbwähler, Rich-Text-Toolbars, Merge-Tag-Autovervollständigung | Nicht betroffen. Sie verankern sich `absolute` in der Popover-Wurzel und rechnen Viewport-Koordinaten in wurzel-lokale um, wodurch sich der Versatz des Vorfahren aufhebt. |
-| Dialoghöhe | Nicht betroffen. Jeder Dialog begrenzt seine Höhe gegen seinen eigenen Backdrop statt gegen den Viewport und bleibt damit in der Box, die er bekommt. |
-| Drag-and-drop-Ghost | **Versetzt.** Der Ghost ist `position: fixed` und wird aus Viewport-Koordinaten platziert, driftet also um den Versatz des Vorfahren vom Cursor weg. |
-
-Wenn Sie Drag-and-drop nutzen, halten Sie `transform` daher von allen Vorfahren des Containers fern.
-
-::: warning Ersetzen Sie es nicht durch `opacity`
-`opacity` statt `transform` zu animieren vermeidet das Containing-Block-Problem und führt direkt in das Stacking-Problem — `opacity` unter `1` erzeugt einen Stacking-Kontext, sodass Ihr Chrome anfängt, über die Dialoge des Editors zu zeichnen. Es gibt keine Eigenschaft, die beides umgeht. Legen Sie einen Scroll- oder Einblend-Effekt auf ein Element, das den Container des Editors nicht umschließt.
-:::
+Was jede Eigenschaft bricht und wie Sie es umgehen, steht unter [Den Editor einbetten](./embedding).
 
 ## npm
 

--- a/apps/docs/getting-started/embedding.md
+++ b/apps/docs/getting-started/embedding.md
@@ -1,0 +1,96 @@
+---
+title: Embedding the editor
+description: CSS constraints on the container you mount the editor into, and what breaks when an ancestor violates them.
+---
+
+# Embedding the editor
+
+The editor is a component you mount into an element of your own page. Almost everything that goes wrong at that seam is a CSS interaction between your page and the editor's overlays, and a small set of properties causes all of it.
+
+Nothing here is Templatical-specific — these are plain CSS rules that affect any library positioning overlays with `position: fixed`. See also [Shadow DOM](../guide/shadow-dom) for how the editor isolates its own styles, and [Theming](../guide/theming) for the `--tpl-user-*` surface.
+
+## The editor's container
+
+The editor mounts its dialogs into a popover root at `z-index: 10000`, inside the container you pass to `init()`. A z-index only competes within its own stacking context, so **the container must not establish one** — otherwise every editor dialog is confined to it, and any chrome of yours with a higher z-index in the parent context paints over them.
+
+These properties on the container, or on any ancestor between it and the stacking context your chrome lives in, create one:
+
+| Property | Creating value |
+| -------- | -------------- |
+| `isolation` | `isolate` |
+| `transform` / `translate` / `rotate` / `scale` | anything but `none` |
+| `filter` / `backdrop-filter` | anything but `none` |
+| `perspective` | anything but `none` |
+| `opacity` | less than `1` |
+| `will-change` | `transform`, `filter`, `opacity`, `perspective` |
+| `contain` | `paint`, `layout`, `content`, `strict` |
+| `mix-blend-mode` | anything but `normal` |
+| `position: fixed` / `sticky` | always |
+| `position: relative` / `absolute` | with any `z-index` other than `auto` |
+
+If one of them is unavoidable — a route transition that animates `transform`, a wrapper you do not control — give that element a `z-index` higher than your own header, sidebar, or toast layer:
+
+```css
+#your-editor-container {
+  /* Above your own chrome, so the editor's dialogs are too. */
+  z-index: 200;
+  position: relative;
+}
+```
+
+::: tip Why a higher z-index on the dialog will not help
+A `fixed` descendant cannot escape a stacking context at any z-index — the comparison happens between the context's root and your chrome, and the descendant's own value never enters it. So the value has to go on the container, not on the dialog. Raising the container is safe because its own box does not overlap your chrome; only the dialogs, which are `fixed` and cover the viewport, are affected.
+:::
+
+### The same properties also move things
+
+`transform`, `filter`, `perspective`, `will-change` and `contain` do two jobs at once: alongside the stacking context above, each establishes a **containing block for `position: fixed`**. A fixed descendant then resolves its coordinates against that ancestor instead of the viewport — and this applies even while the computed `transform` reads `none`, because a running or animated transform still promotes the element.
+
+What that means for the editor:
+
+| Overlay | Under a transformed ancestor |
+| ------- | ---------------------------- |
+| Color pickers, rich-text toolbars, merge-tag autocomplete | Unaffected. They anchor `absolute` inside the popover root and convert viewport coordinates to root-local ones, so the ancestor's offset cancels out. |
+| Dialog height | Unaffected. Every dialog caps against its own backdrop rather than the viewport, so it stays inside whatever box it is given. |
+| Drag-and-drop ghost | **Offset.** The ghost is `position: fixed` and placed from viewport coordinates, so it drifts away from the cursor by the ancestor's offset. |
+
+So if you use drag-and-drop, keep `transform` off every ancestor of the container.
+
+::: warning Do not substitute `opacity`
+Animating `opacity` instead of `transform` avoids the containing-block problem and walks straight into the stacking one — `opacity` below `1` creates a stacking context, so your chrome starts painting over the editor's dialogs. There is no property that dodges both. For a scroll or entrance effect, put it on an element that does not wrap the editor's container.
+:::
+
+### Clipping ancestors in Safari
+
+`overflow: hidden`, `clip`, `auto` or `scroll` on an ancestor of the container creates neither a stacking context nor a containing block, so it is absent from the table above — and in Safari it still clips the dialogs.
+
+Safari paints a `position: fixed` descendant clipped to such an ancestor's box while resolving its layout against the viewport. A dialog is placed correctly and then cut off at that ancestor's edge, and its dimming backdrop covers only that ancestor's area. Chrome and Firefox paint it across the viewport.
+
+The editor keeps its own clip off the dialogs' ancestor chain, so its container may sit in a scrollable or clipped layout. An ancestor **of** the container is outside what the editor can reach:
+
+```css
+.your-app-shell {
+  /* Clips the editor's dialogs in Safari. */
+  overflow: hidden;
+}
+```
+
+If the element only needs to contain its own children, `overflow: clip` with `overflow-clip-margin` will not help — every value clips. Move the property to an element that does not wrap the container, or let the page scroll normally.
+
+## Host typography cannot leak in
+
+The editor neutralizes every inheritable typography property at its root, so your page's global type styles do not reach its chrome or its canvas:
+
+`letter-spacing` · `word-spacing` · `text-transform` · `font-style` · `font-weight` · `text-indent` · `text-align` · `white-space` · `list-style-type` · `cursor` · `font-variant-numeric` · `text-shadow` — alongside `font-family`, `font-size`, `line-height` and `color`.
+
+This matters most for the canvas. A page-wide `text-transform: uppercase` reaching the preview would show you an email the recipient never receives, so the guarantee covers email content, not just editor chrome.
+
+::: tip Why shadow DOM alone is not enough
+Shadow DOM blocks host *rules* — a selector in your stylesheet never matches inside the editor's shadow root. It does not block *inheritance*, which follows the flattened tree, so inheritable properties cross the boundary regardless. The editor's own reset is what stops them, and it works identically with `shadowDom: false`.
+:::
+
+**`direction` is deliberately allowed to inherit.** An RTL page propagates its writing direction into the editor, which is what an RTL embedder wants. `visibility` is likewise left alone.
+
+### You do not need a CSS reset on the container
+
+Resetting the container is not necessary, and an aggressive reset is harmful: `all: initial` or `all: revert` there wipes the `--tpl-user-*` custom properties that [Theming](../guide/theming) relies on, and can break the `height: 100%` chain the editor sizes against. Style the container's box — size, position, border — and leave its inherited values alone.

--- a/apps/docs/getting-started/installation.md
+++ b/apps/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ Have a feature request or hit a rough edge? [Open a discussion](https://github.c
   - **Default mode** (`shadowDom: true`, Shadow DOM) — Chrome 80+, Edge 80+, Firefox 101+, Safari 16.4+. Firefox and Safari minimums are driven by the `adoptedStyleSheets` API the shadow path relies on.
   - **Opt-out mode** (`shadowDom: false`, light DOM) — Chrome 80+, Edge 80+, Firefox 80+, Safari 14+. Use this if you need to support older Firefox or Safari, or if your integration requires light-DOM access to editor internals. See the [Shadow DOM guide](../guide/shadow-dom) for trade-offs.
 - **Container element** -- must have a defined height (the editor fills its container). In default mode, must be an element type that can host a shadow root (e.g. `<div>`, `<section>`, `<article>`). See [container element requirements](../api/editor#container-element-requirements).
-- **No `transform`, and no stacking context, on an ancestor of the container** -- `transform`, `filter`, `perspective`, `will-change`, `opacity` below `1`, `isolation`, `contain`, and positioned elements with a `z-index` each change where the editor's overlays are painted or positioned. These are plain CSS rules, not Templatical-specific limitations, and they affect any library that positions overlays with `position: fixed`. See [The editor's container](#the-editor-s-container) for what each one breaks and how to work around it.
+- **No `transform`, and no stacking context, on an ancestor of the container** -- `transform`, `filter`, `perspective`, `will-change`, `opacity` below `1`, `isolation`, `contain`, and positioned elements with a `z-index` each change where the editor's overlays are painted or positioned. These are plain CSS rules, not Templatical-specific limitations, and they affect any library that positions overlays with `position: fixed`. See [Embedding the editor](./embedding) for what each one breaks and how to work around it.
 - **No required peer dependencies** -- Vue, TipTap, and all internal libraries are bundled into the editor. You don't need to install Vue or any framework runtime, regardless of which framework your app uses. (`@templatical/renderer`, `@templatical/quality`, `@templatical/media-library`, and `pusher-js` are _optional_ peers — install them only if you use the corresponding feature; see [Optional peers](#optional-peers) below.)
 
 ## Network requests
@@ -48,54 +48,9 @@ The `@import` is still present in the stylesheet, so the request is still attemp
 
 ## The editor's container
 
-The editor mounts its dialogs into a popover root at `z-index: 10000`, inside the container you pass to `init()`. A z-index only competes within its own stacking context, so **the container must not establish one** — otherwise every editor dialog is confined to it, and any chrome of yours with a higher z-index in the parent context paints over them.
+The container you pass to `init()` has a few CSS constraints, and an ancestor with `transform`, `overflow: hidden`, or its own stacking context can misplace or clip the editor's dialogs.
 
-These properties on the container, or on any ancestor between it and the stacking context your chrome lives in, create one:
-
-| Property | Creating value |
-| -------- | -------------- |
-| `isolation` | `isolate` |
-| `transform` / `translate` / `rotate` / `scale` | anything but `none` |
-| `filter` / `backdrop-filter` | anything but `none` |
-| `perspective` | anything but `none` |
-| `opacity` | less than `1` |
-| `will-change` | `transform`, `filter`, `opacity`, `perspective` |
-| `contain` | `paint`, `layout`, `content`, `strict` |
-| `mix-blend-mode` | anything but `normal` |
-| `position: fixed` / `sticky` | always |
-| `position: relative` / `absolute` | with any `z-index` other than `auto` |
-
-If one of them is unavoidable — a route transition that animates `transform`, a wrapper you do not control — give that element a `z-index` higher than your own header, sidebar, or toast layer:
-
-```css
-#your-editor-container {
-  /* Above your own chrome, so the editor's dialogs are too. */
-  z-index: 200;
-  position: relative;
-}
-```
-
-::: tip Why a higher z-index on the dialog will not help
-A `fixed` descendant cannot escape a stacking context at any z-index — the comparison happens between the context's root and your chrome, and the descendant's own value never enters it. So the value has to go on the container, not on the dialog. Raising the container is safe because its own box does not overlap your chrome; only the dialogs, which are `fixed` and cover the viewport, are affected.
-:::
-
-### The same properties also move things
-
-`transform`, `filter`, `perspective`, `will-change` and `contain` do two jobs at once: alongside the stacking context above, each establishes a **containing block for `position: fixed`**. A fixed descendant then resolves its coordinates against that ancestor instead of the viewport — and this applies even while the computed `transform` reads `none`, because a running or animated transform still promotes the element.
-
-What that means for the editor:
-
-| Overlay | Under a transformed ancestor |
-| ------- | ---------------------------- |
-| Color pickers, rich-text toolbars, merge-tag autocomplete | Unaffected. They anchor `absolute` inside the popover root and convert viewport coordinates to root-local ones, so the ancestor's offset cancels out. |
-| Dialog height | Unaffected. Every dialog caps against its own backdrop rather than the viewport, so it stays inside whatever box it is given. |
-| Drag-and-drop ghost | **Offset.** The ghost is `position: fixed` and placed from viewport coordinates, so it drifts away from the cursor by the ancestor's offset. |
-
-So if you use drag-and-drop, keep `transform` off every ancestor of the container.
-
-::: warning Do not substitute `opacity`
-Animating `opacity` instead of `transform` avoids the containing-block problem and walks straight into the stacking one — `opacity` below `1` creates a stacking context, so your chrome starts painting over the editor's dialogs. There is no property that dodges both. For a scroll or entrance effect, put it on an element that does not wrap the editor's container.
-:::
+See [Embedding the editor](./embedding) for what each property breaks and how to work around it.
 
 ## npm
 

--- a/apps/playground/e2e/tests/host-style-inheritance.spec.ts
+++ b/apps/playground/e2e/tests/host-style-inheritance.spec.ts
@@ -1,0 +1,148 @@
+import { expect } from "@playwright/test";
+import { test } from "../fixtures/editor.fixture";
+import { SELECTORS } from "../helpers/selectors";
+
+/**
+ * Host page typography must not inherit into the editor.
+ *
+ * Shadow DOM blocks host *rules*; it does not block inheritance, which follows
+ * the flattened tree. So every inheritable property set on an ancestor of the
+ * container crosses the boundary unless `.tpl` neutralizes it, and the same is
+ * true in light-DOM mode. Twelve properties were measured leaking before the
+ * reset covered them.
+ *
+ * This runs in both DOM-mode projects on purpose: shadow mode is where the
+ * isolation is *assumed* to hold and therefore where a regression would go
+ * unnoticed, while light mode has no boundary at all.
+ *
+ * The structural counterpart is
+ * `packages/editor/tests/inherited-property-scope.test.ts`; this spec is what
+ * proves the declarations actually win against a real host cascade.
+ */
+
+/** Ordinary design-system typography, of the kind that really ships. */
+const HOSTILE: Record<string, string> = {
+  "letter-spacing": "0.12em",
+  "word-spacing": "0.35em",
+  "text-transform": "uppercase",
+  "font-style": "italic",
+  "font-weight": "800",
+  "text-indent": "14px",
+  "text-align": "right",
+  "white-space": "pre",
+  "list-style-type": "square",
+  "cursor": "crosshair",
+  "font-variant-numeric": "tabular-nums",
+  "text-shadow": "1px 1px red",
+};
+
+/** What each property must still compute to inside the editor. */
+const EXPECTED: Record<string, string> = {
+  letterSpacing: "normal",
+  wordSpacing: "0px",
+  textTransform: "none",
+  fontStyle: "normal",
+  fontWeight: "400",
+  textIndent: "0px",
+  textAlign: "start",
+  whiteSpace: "normal",
+  listStyleType: "disc",
+  cursor: "auto",
+  fontVariantNumeric: "normal",
+  textShadow: "none",
+};
+
+test.describe("host style inheritance", () => {
+  test("editor chrome ignores hostile host typography", async ({
+    page,
+    editorReady,
+  }) => {
+    void editorReady;
+
+    await page.addStyleTag({
+      content: `html, body, ${SELECTORS.editorContainer} {\n${Object.entries(
+        HOSTILE,
+      )
+        .map(([k, v]) => `  ${k}: ${v} !important;`)
+        .join("\n")}\n}`,
+    });
+
+    const computed = await page.evaluate(
+      ({ selector, keys }) => {
+        const host = document.querySelector(selector)!;
+        // Shadow mode puts `.tpl` inside the shadow root; light mode leaves it
+        // in the host's own subtree. Same assertion either way.
+        const root: ParentNode = host.shadowRoot ?? host;
+        const tpl = root.querySelector(".tpl") as HTMLElement;
+        const style = getComputedStyle(tpl);
+        return Object.fromEntries(
+          keys.map((k) => [k, style[k as never] as string]),
+        );
+      },
+      { selector: SELECTORS.editorContainer, keys: Object.keys(EXPECTED) },
+    );
+
+    expect(computed).toEqual(EXPECTED);
+  });
+
+  test("the canvas renders email content unaffected", async ({
+    page,
+    editorReady,
+  }) => {
+    void editorReady;
+
+    await page.addStyleTag({
+      content: `html, body, ${SELECTORS.editorContainer} {\n${Object.entries(
+        HOSTILE,
+      )
+        .map(([k, v]) => `  ${k}: ${v} !important;`)
+        .join("\n")}\n}`,
+    });
+
+    // The canvas is the surface that has to stay honest: a leaked
+    // `text-transform` would show the user an email the recipient never gets.
+    const computed = await page.evaluate(
+      ({ selector, keys }) => {
+        const host = document.querySelector(selector)!;
+        const root: ParentNode = host.shadowRoot ?? host;
+        const canvas = (root.querySelector(".tpl-canvas") ??
+          root.querySelector(".tpl-body")) as HTMLElement;
+        const probe = document.createElement("p");
+        probe.textContent = "email body copy";
+        canvas.appendChild(probe);
+        const style = getComputedStyle(probe);
+        const out = Object.fromEntries(
+          keys.map((k) => [k, style[k as never] as string]),
+        );
+        probe.remove();
+        return out;
+      },
+      { selector: SELECTORS.editorContainer, keys: Object.keys(EXPECTED) },
+    );
+
+    expect(computed).toEqual(EXPECTED);
+  });
+
+  test("an RTL host still propagates its writing direction", async ({
+    page,
+    editorReady,
+  }) => {
+    void editorReady;
+
+    // `direction` is deliberately left inheriting, so this is the one property
+    // the reset must NOT neutralize. Without the carve-out an RTL embedder
+    // would get an LTR editor.
+    await page.addStyleTag({
+      content: `html, body, ${SELECTORS.editorContainer} { direction: rtl !important; }`,
+    });
+
+    const direction = await page.evaluate((selector) => {
+      const host = document.querySelector(selector)!;
+      const root: ParentNode = host.shadowRoot ?? host;
+      const tpl = root.querySelector(".tpl") as HTMLElement;
+      return getComputedStyle(tpl).direction;
+    }, SELECTORS.editorContainer);
+
+    expect(direction).toBe("rtl");
+  });
+});

--- a/packages/editor/src/Editor.vue
+++ b/packages/editor/src/Editor.vue
@@ -490,7 +490,7 @@ defineExpose({
        only neutralizes the default action everywhere else (#229). -->
   <div
     ref="rootEl"
-    class="tpl tpl:relative tpl:h-full tpl:overflow-hidden"
+    class="tpl tpl:relative tpl:h-full"
     :class="{ 'tpl:dark': editor.state.darkMode }"
     :data-tpl-theme="core.resolvedTheme.value"
     :style="core.themeStyles.value"
@@ -500,170 +500,191 @@ defineExpose({
     <!-- Reactive `<style>` tags for custom-block definition stylesheets in
          use. Sits at the top so its rules apply to the canvas below. -->
     <CustomBlockStylesheets />
-    <!-- One header for both entry points. Cloud's own controls arrive through
-         the three slots; everything else here is capability-gated, so the same
-         markup covers "no providers at all" and a fully-wired Cloud session. -->
-    <EditorHeader
-      :editor="editor"
-      :core="core"
-      :templates="templates"
-      :show-template-name="config.templates?.nameField !== false"
-      :test-email="testEmail"
-      :version-history="versionHistory"
-      :comments="comments"
-    >
-      <template v-if="cloudAttachment" #left-extras>
-        <CloudHeaderExtras part="left" :cloud="cloudAttachment" />
-      </template>
-      <template v-if="cloudAttachment" #right-extras>
-        <CloudHeaderExtras part="right" :cloud="cloudAttachment" />
-      </template>
-    </EditorHeader>
+    <!-- Chrome wrapper — the clip belongs here, never on the root and never
+         around `.tpl-popover-root`. Safari paints a `position: fixed`
+         descendant clipped to an ancestor's `overflow: hidden` box while still
+         resolving its layout against the viewport, so a dialog teleported
+         under a clipping ancestor is cut off wherever it extends past the
+         container, and its backdrop dims only the container's own area
+         (#633). Keeping the clip on this element bounds the header, rails,
+         canvas and footer without reaching the popover root, and this box is
+         identical to the root's, so everything anchored `absolute` inside
+         lands exactly where it would against the root. Locked by
+         `tests/popover-root-clip-scope.test.ts`. -->
+    <div class="tpl:absolute tpl:inset-0 tpl:overflow-hidden">
+      <!-- One header for both entry points. Cloud's own controls arrive through
+           the three slots; everything else here is capability-gated, so the same
+           markup covers "no providers at all" and a fully-wired Cloud session. -->
+      <EditorHeader
+        :editor="editor"
+        :core="core"
+        :templates="templates"
+        :show-template-name="config.templates?.nameField !== false"
+        :test-email="testEmail"
+        :version-history="versionHistory"
+        :comments="comments"
+      >
+        <template v-if="cloudAttachment" #left-extras>
+          <CloudHeaderExtras part="left" :cloud="cloudAttachment" />
+        </template>
+        <template v-if="cloudAttachment" #right-extras>
+          <CloudHeaderExtras part="right" :cloud="cloudAttachment" />
+        </template>
+      </EditorHeader>
 
-    <!-- Left sidebar — absolute, below header -->
-    <Sidebar v-show="!editor.state.previewMode" />
+      <!-- Left sidebar — absolute, below header -->
+      <Sidebar v-show="!editor.state.previewMode" />
 
-    <!-- Canvas area — absolute, fills remaining space -->
-    <div
-      class="tpl-body tpl:absolute tpl:bottom-0 tpl:overflow-auto tpl:bg-[var(--tpl-canvas-bg)]"
-      style="transition: all 300ms cubic-bezier(0.34, 1.56, 0.64, 1)"
-      :class="[
-        bodyInsetClass,
-        versionHistory?.isPreviewing.value ? 'tpl:top-[104px]' : 'tpl:top-14',
-      ]"
-    >
-      <!-- Preview chrome, floated over the canvas.
+      <!-- Canvas area — absolute, fills remaining space -->
+      <div
+        class="tpl-body tpl:absolute tpl:bottom-0 tpl:overflow-auto tpl:bg-[var(--tpl-canvas-bg)]"
+        style="transition: all 300ms cubic-bezier(0.34, 1.56, 0.64, 1)"
+        :class="[
+          bodyInsetClass,
+          versionHistory?.isPreviewing.value ? 'tpl:top-[104px]' : 'tpl:top-14',
+        ]"
+      >
+        <!-- Preview chrome, floated over the canvas.
 
-           A zero-height sticky layer holding one absolutely-positioned,
-           canvas-centred **column**. Zero height means the layer contributes no
-           space of its own, so nothing here can push the canvas around — which
-           is what lets the merge-tag toggle live over the preview instead of in
-           the header, whose centre track re-centres on every width change and
-           so dragged the Preview button 114.5px sideways each time the toggle
-           appeared (#574).
+             A zero-height sticky layer holding one absolutely-positioned,
+             canvas-centred **column**. Zero height means the layer contributes no
+             space of its own, so nothing here can push the canvas around — which
+             is what lets the merge-tag toggle live over the preview instead of in
+             the header, whose centre track re-centres on every width change and
+             so dragged the Preview button 114.5px sideways each time the toggle
+             appeared (#574).
 
-           A column rather than two fixed offsets. Both pills are reachable at
-           once — the restore pill needs hidden blocks, the toggle needs preview
-           mode without a `resolvePreview`, and nothing makes those exclusive —
-           so they have to stack. Doing that with a hardcoded second offset put
-           the restore pill 48px down even when it rendered alone, which in
-           editing mode (where the toggle never shows) dropped it onto the first
-           block's content. Flow solves what the offset got wrong: whichever
-           pills render sit tight under the header, in order.
+             A column rather than two fixed offsets. Both pills are reachable at
+             once — the restore pill needs hidden blocks, the toggle needs preview
+             mode without a `resolvePreview`, and nothing makes those exclusive —
+             so they have to stack. Doing that with a hardcoded second offset put
+             the restore pill 48px down even when it rendered alone, which in
+             editing mode (where the toggle never shows) dropped it onto the first
+             block's content. Flow solves what the offset got wrong: whichever
+             pills render sit tight under the header, in order.
 
-           Locked by `tests/headerCenterStability.test.ts`. -->
-      <div class="tpl-preview-overlay tpl:sticky tpl:top-0 tpl:z-40 tpl:h-0">
-        <div
-          class="tpl:absolute tpl:left-1/2 tpl:top-2 tpl:flex tpl:-translate-x-1/2 tpl:flex-col tpl:items-center tpl:gap-2"
-        >
-          <!-- Sample / Label. Preview mode only: merge tags are never
-               substituted on the editing canvas, so the choice would have no
-               effect there. A configured `resolvePreview` supersedes samples
-               entirely.
+             Locked by `tests/headerCenterStability.test.ts`. -->
+        <div class="tpl-preview-overlay tpl:sticky tpl:top-0 tpl:z-40 tpl:h-0">
+          <div
+            class="tpl:absolute tpl:left-1/2 tpl:top-2 tpl:flex tpl:-translate-x-1/2 tpl:flex-col tpl:items-center tpl:gap-2"
+          >
+            <!-- Sample / Label. Preview mode only: merge tags are never
+                 substituted on the editing canvas, so the choice would have no
+                 effect there. A configured `resolvePreview` supersedes samples
+                 entirely.
 
-               The wrapper carries only the shadow that lifts the control off
-               the canvas — no `backdrop-filter`, because the toggle's own
-               `--tpl-bg-hover` fill is opaque and covers this box exactly, so a
-               blur would composite a layer to show nothing. -->
-          <Transition name="tpl-preview-pill">
-            <div
-              v-if="
-                editor.state.previewMode &&
-                !core.previewResolution.supersedesSamples.value
-              "
-              data-testid="merge-tag-mode-toggle-anchor"
-              class="tpl:rounded-[var(--tpl-radius-sm)] tpl:shadow-[var(--tpl-shadow-md)]"
-            >
-              <MergeTagModeToggle
-                :sample-mode="core.mergeTagSampleMode.value"
-                @change="core.mergeTagSampleMode.value = $event"
-              />
-            </div>
-          </Transition>
-          <!-- Show all hidden blocks. The shared warning recipe, not a bespoke
-               string: it has to read as the Sample/Label switch's sibling,
-               since the two stack here, and a hand-rolled pill is how this one
-               came to sit 8px shorter with a different radius and a 1.85:1
-               label. `warningBtnCompactClass` carries why the amber is on the
-               border rather than the text. -->
-          <Transition name="tpl-preview-pill">
-            <button
-              v-if="
-                core.conditionPreview.hasHiddenBlocks.value &&
-                core.appliesConditionFilter.value
-              "
-              type="button"
-              :class="warningBtnCompactClass"
-              class="tpl:shadow-[var(--tpl-shadow-md)]"
-              data-testid="restore-hidden-blocks"
-              @click="core.conditionPreview.reset()"
-            >
-              <RotateCcw :size="16" :stroke-width="2" />
-              {{ core.t.blockSettings.restoreHiddenBlocks }}
-            </button>
-          </Transition>
+                 The wrapper carries only the shadow that lifts the control off
+                 the canvas — no `backdrop-filter`, because the toggle's own
+                 `--tpl-bg-hover` fill is opaque and covers this box exactly, so a
+                 blur would composite a layer to show nothing. -->
+            <Transition name="tpl-preview-pill">
+              <div
+                v-if="
+                  editor.state.previewMode &&
+                  !core.previewResolution.supersedesSamples.value
+                "
+                data-testid="merge-tag-mode-toggle-anchor"
+                class="tpl:rounded-[var(--tpl-radius-sm)] tpl:shadow-[var(--tpl-shadow-md)]"
+              >
+                <MergeTagModeToggle
+                  :sample-mode="core.mergeTagSampleMode.value"
+                  @change="core.mergeTagSampleMode.value = $event"
+                />
+              </div>
+            </Transition>
+            <!-- Show all hidden blocks. The shared warning recipe, not a bespoke
+                 string: it has to read as the Sample/Label switch's sibling,
+                 since the two stack here, and a hand-rolled pill is how this one
+                 came to sit 8px shorter with a different radius and a 1.85:1
+                 label. `warningBtnCompactClass` carries why the amber is on the
+                 border rather than the text. -->
+            <Transition name="tpl-preview-pill">
+              <button
+                v-if="
+                  core.conditionPreview.hasHiddenBlocks.value &&
+                  core.appliesConditionFilter.value
+                "
+                type="button"
+                :class="warningBtnCompactClass"
+                class="tpl:shadow-[var(--tpl-shadow-md)]"
+                data-testid="restore-hidden-blocks"
+                @click="core.conditionPreview.reset()"
+              >
+                <RotateCcw :size="16" :stroke-width="2" />
+                {{ core.t.blockSettings.restoreHiddenBlocks }}
+              </button>
+            </Transition>
+          </div>
         </div>
+        <main class="tpl-main tpl:flex tpl:justify-center tpl:p-8">
+          <Canvas
+            :viewport="editor.state.viewport"
+            :content="core.previewResolution.content.value"
+            :selected-block-id="editor.state.selectedBlockId"
+            :dark-mode="editor.state.darkMode"
+            :preview-mode="editor.state.previewMode"
+            :locked-blocks="cloudAttachment?.collaboration?.lockedBlocks.value"
+            @select-block="editor.selectBlock"
+            @open-ai-chat="openCloudPanel('ai-chat')"
+            @open-design-reference="openCloudPanel('design-reference')"
+          />
+        </main>
       </div>
-      <main class="tpl-main tpl:flex tpl:justify-center tpl:p-8">
-        <Canvas
-          :viewport="editor.state.viewport"
-          :content="core.previewResolution.content.value"
-          :selected-block-id="editor.state.selectedBlockId"
-          :dark-mode="editor.state.darkMode"
-          :preview-mode="editor.state.previewMode"
-          :locked-blocks="cloudAttachment?.collaboration?.lockedBlocks.value"
-          @select-block="editor.selectBlock"
-          @open-ai-chat="openCloudPanel('ai-chat')"
-          @open-design-reference="openCloudPanel('design-reference')"
-        />
-      </main>
+
+      <EditorFooter
+        v-if="config.branding !== false"
+        :position-class="[bodyInsetClass]"
+      />
+
+      <!-- Keyboard reorder announcement region (visually hidden, screen-reader live) -->
+      <div
+        class="tpl-sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        :aria-label="core.t.landmarks.reorderAnnouncements"
+      >
+        {{ core.keyboardReorder.announcement.value }}
+      </div>
+
+      <!-- Right sidebar — persisted with v-show -->
+      <RightSidebar
+        v-show="!editor.state.previewMode"
+        :selected-block="editor.selectedBlock.value"
+        :settings="editor.content.value.settings"
+        :shifted-left="rightPanelOpen"
+        @update-block="
+          (updates) =>
+            editor.updateBlock(editor.state.selectedBlockId!, updates)
+        "
+        @delete-block="
+          () => {
+            if (editor.state.selectedBlockId) {
+              core.blockActions.deleteBlock(editor.state.selectedBlockId);
+            }
+          }
+        "
+        @duplicate-block="
+          () => {
+            if (editor.selectedBlock.value) {
+              core.blockActions.duplicateBlock(editor.selectedBlock.value);
+            }
+          }
+        "
+        @update-settings="(updates) => editor.updateSettings(updates)"
+      />
     </div>
 
-    <EditorFooter
-      v-if="config.branding !== false"
-      :position-class="[bodyInsetClass]"
-    />
-
-    <!-- Keyboard reorder announcement region (visually hidden, screen-reader live) -->
-    <div
-      class="tpl-sr-only"
-      role="status"
-      aria-live="polite"
-      aria-atomic="true"
-      :aria-label="core.t.landmarks.reorderAnnouncements"
-    >
-      {{ core.keyboardReorder.announcement.value }}
-    </div>
-
-    <!-- Right sidebar — persisted with v-show -->
-    <RightSidebar
-      v-show="!editor.state.previewMode"
-      :selected-block="editor.selectedBlock.value"
-      :settings="editor.content.value.settings"
-      :shifted-left="rightPanelOpen"
-      @update-block="
-        (updates) => editor.updateBlock(editor.state.selectedBlockId!, updates)
-      "
-      @delete-block="
-        () => {
-          if (editor.state.selectedBlockId) {
-            core.blockActions.deleteBlock(editor.state.selectedBlockId);
-          }
-        }
-      "
-      @duplicate-block="
-        () => {
-          if (editor.selectedBlock.value) {
-            core.blockActions.duplicateBlock(editor.selectedBlock.value);
-          }
-        }
-      "
-      @update-settings="(updates) => editor.updateSettings(updates)"
-    />
-
-    <!-- Popover mount — Teleport target for toolbars, link dialog, modal.
-         Replaces the historical body-level teleport pattern so popups
-         render inside the editor's effective DOM root (shadow-aware). -->
+    <!-- Popover mount — Teleport target for toolbars, link dialog, modals.
+         Every popup mounts here rather than at the page's `<body>`, so it
+         renders inside the editor's effective DOM root and keeps the shadow
+         root's adopted stylesheet; a body-level teleport leaves the shadow
+         tree and renders unstyled. It also has to stay a child of `.tpl`, which
+         declares `--tpl-base-size` and the colour tokens — `@theme inline`
+         rebases the whole Tailwind length scale onto that variable, so a
+         popup hoisted out would lose the sizing scale as well as the palette.
+         Enforced by the `no-teleport-to-body` ESLint rule and
+         `tests/global-refs-audit.test.ts`. -->
     <div
       :ref="(el) => (core.popoverRoot.value = el as HTMLElement | null)"
       class="tpl-popover-root"

--- a/packages/editor/src/styles/index.css
+++ b/packages/editor/src/styles/index.css
@@ -294,6 +294,40 @@
     background-color: var(--tpl-bg);
     color: var(--tpl-text);
     font-family: var(--tpl-font-family);
+
+    /* Neutralize inheritable typography from the host page. Shadow DOM blocks
+       host *rules* — a consumer selector never matches inside the shadow root
+       — but inheritance follows the flattened tree, so every inheritable
+       property crosses the boundary regardless of mode. This rule is the only
+       defense, and it stops exactly what it declares: the four properties
+       above (font-family, color, plus font-size / line-height via @apply)
+       were already covered, and each one below was measured leaking into the
+       built editor under a host setting ordinary design-system typography.
+
+       The stake is fidelity, not just appearance. These reach `.tpl-canvas`
+       too, so a host `text-transform: uppercase` renders the WYSIWYG preview
+       in uppercase while the delivered email is not — the canvas lies about
+       the output.
+
+       `direction` and `visibility` are deliberately absent: an RTL host should
+       propagate its writing direction, and a hidden host should hide the
+       editor. `text-decoration` propagates rather than inherits and does not
+       cross. Locked by `tests/inherited-property-scope.test.ts` and
+       `apps/playground/e2e/tests/host-style-inheritance.spec.ts`. */
+    letter-spacing: normal;
+    word-spacing: normal;
+    text-transform: none;
+    font-style: normal;
+    font-weight: 400;
+    text-indent: 0;
+    /* `start`, not `left` — `left` would break the RTL host whose `direction`
+       we let inherit. */
+    text-align: start;
+    white-space: normal;
+    list-style-type: disc;
+    cursor: auto;
+    font-variant-numeric: normal;
+    text-shadow: none;
 }
 
 /* Form element reset - Preflight is omitted so form elements use browser

--- a/packages/editor/tests/inherited-property-scope.test.ts
+++ b/packages/editor/tests/inherited-property-scope.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * `.tpl` must neutralize every inheritable typography property the host page
+ * can set.
+ *
+ * Shadow DOM blocks host *rules* — a selector in the consumer's stylesheet
+ * never matches inside the shadow root — but inheritance follows the flattened
+ * tree, so every inheritable property walks straight across the boundary. The
+ * editor's own reset is therefore the only defense, in both DOM modes, and it
+ * stops exactly the properties it declares and nothing else.
+ *
+ * Measured against the built editor under a host setting the kind of global
+ * typography design systems really ship (`letter-spacing: 0.12em`,
+ * `text-transform: uppercase`, …). Twelve properties crossed:
+ *
+ *   letter-spacing · word-spacing · text-transform · font-style · font-weight
+ *   text-indent · text-align · white-space · list-style-type · cursor
+ *   font-variant-numeric · text-shadow
+ *
+ * `text-decoration` did **not** cross (it propagates rather than inherits) and
+ * is deliberately absent below.
+ *
+ * The stake is not just ugly chrome. The leak reaches `.tpl-canvas`, so a host
+ * with `text-transform: uppercase` renders the editor's WYSIWYG preview in
+ * uppercase while the email the recipient receives is not — the canvas
+ * misrepresents the output, which is worse than looking wrong.
+ *
+ * **`direction` is deliberately NOT reset.** An RTL host should propagate its
+ * writing direction into the editor; that is inheritance working as intended.
+ * `visibility` is likewise left alone — a hidden host should hide the editor.
+ *
+ * Do not "fix" this class by telling consumers to reset the container. A reset
+ * would have to sit on the container itself to affect inheritance, which
+ * collides head-on with the documented theming surface (`--tpl-user-*` set on
+ * the container or an ancestor): `all: initial` / `all: revert` there wipes
+ * every custom property and breaks theming outright.
+ *
+ * Behavioural coverage:
+ * `apps/playground/e2e/tests/host-style-inheritance.spec.ts`.
+ */
+
+const STYLES = readFileSync(
+  join(import.meta.dirname, "..", "src", "styles", "index.css"),
+  "utf8",
+);
+
+/** property -> the value that neutralizes it. */
+const NEUTRALIZED: Record<string, string> = {
+  "letter-spacing": "normal",
+  "word-spacing": "normal",
+  "text-transform": "none",
+  "font-style": "normal",
+  "font-weight": "400",
+  "text-indent": "0",
+  // `start`, not `left` — `left` would break an RTL host, whose `direction` we
+  // deliberately let inherit.
+  "text-align": "start",
+  "white-space": "normal",
+  "list-style-type": "disc",
+  "cursor": "auto",
+  "font-variant-numeric": "normal",
+  "text-shadow": "none",
+};
+
+/** The base `.tpl { … }` rule — the one carrying the min-height floor. */
+const tplBlock =
+  (STYLES.match(/\n\.tpl\s*\{[^}]*\}/g) ?? []).find((block) =>
+    block.includes("min-height"),
+  ) ?? "";
+
+describe("host typography cannot inherit into the editor", () => {
+  it("finds the base .tpl rule", () => {
+    expect(tplBlock).not.toBe("");
+  });
+
+  it.each(Object.entries(NEUTRALIZED))(
+    "declares %s: %s",
+    (property, value) => {
+      const declaration = new RegExp(
+        `(^|[;{\\s])${property}\\s*:\\s*${value}\\s*(!important\\s*)?;`,
+        "m",
+      );
+      expect(tplBlock).toMatch(declaration);
+    },
+  );
+
+  it("leaves `direction` and `visibility` to inherit", () => {
+    // RTL hosts must propagate their writing direction, and a hidden host
+    // should hide the editor. Neutralizing either would be a regression.
+    expect(tplBlock).not.toMatch(/(^|[;{\s])direction\s*:/m);
+    expect(tplBlock).not.toMatch(/(^|[;{\s])visibility\s*:/m);
+  });
+});

--- a/packages/editor/tests/popover-root-clip-scope.test.ts
+++ b/packages/editor/tests/popover-root-clip-scope.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "vue/compiler-sfc";
+import type { ElementNode, RootNode, TemplateChildNode } from "vue/compiler-sfc";
+
+/**
+ * Nothing between the editor root and `.tpl-popover-root` may clip.
+ *
+ * Every dialog teleports into `.tpl-popover-root` and renders `position:
+ * fixed; inset: 0`, which is supposed to cover the viewport regardless of how
+ * small the consumer's container is. **Safari does not let a `fixed`
+ * descendant escape an ancestor's `overflow: hidden` when painting**, even
+ * though it correctly resolves the layout against the viewport. So the dialog
+ * is positioned right and then painted clipped to that ancestor's box.
+ *
+ * That ancestor used to be our own editor root, which carried
+ * `tpl:overflow-hidden`. Issue #633: with the editor mounted below a ~105px
+ * host header, the merge-tag picker's dimming backdrop darkened only the
+ * editor's own area and the dialog's title bar was cut off above the
+ * container's top edge. Chrome, Firefox and Playwright's WebKit all paint it
+ * correctly, which is why it survived — see the note on coverage below.
+ *
+ * The fix is to move the clip rather than remove it: an inner chrome wrapper
+ * keeps `overflow: hidden` for the header, rails, canvas and footer, while
+ * `.tpl-popover-root` stays a direct child of the (unclipped) root. That also
+ * keeps the popover root inside `.tpl`, which is load-bearing for a second
+ * reason: `--tpl-base-size` is declared there and `@theme inline` rebases the
+ * whole Tailwind length scale onto it, so a popover hoisted out of `.tpl`
+ * would lose every colour token *and* the sizing scale unless it re-declared
+ * the class itself. `ColorPicker` and the merge-tag suggestion popup do not.
+ *
+ * **This is not reachable from a browser test.** Playwright's WebKit does not
+ * reproduce it at 18.0 or 26.5 (verified against the reporter's own repro), so
+ * adding a WebKit e2e project would not guard it. Real Safari 27 does. That
+ * makes this structural guard the only automated coverage, so keep it strict.
+ */
+
+const EDITOR_VUE = join(import.meta.dirname, "..", "src", "Editor.vue");
+
+/** Class names that clip a `position: fixed` descendant in Safari. */
+const CLIPPING = /(^|:)overflow(-x|-y)?-(hidden|clip|scroll|auto)$/;
+
+function isElement(node: TemplateChildNode | RootNode): node is ElementNode {
+  return node.type === 1;
+}
+
+/** Static `class="…"` tokens. A bound `:class` cannot express a clip here. */
+function staticClasses(node: ElementNode): string[] {
+  const attr = node.props.find(
+    (prop) => prop.type === 6 && prop.name === "class",
+  );
+  if (!attr || attr.type !== 6) return [];
+  return (attr.value?.content ?? "").split(/\s+/).filter(Boolean);
+}
+
+function clips(node: ElementNode): boolean {
+  return staticClasses(node).some((token) => CLIPPING.test(token));
+}
+
+function hasClass(node: ElementNode, name: string): boolean {
+  return staticClasses(node).includes(name);
+}
+
+function parseRoot(): ElementNode {
+  const sfc = parse(readFileSync(EDITOR_VUE, "utf8"));
+  const ast = sfc.descriptor.template?.ast;
+  if (!ast) throw new Error("Editor.vue has no <template>");
+  const root = ast.children.filter(isElement)[0];
+  if (!root) throw new Error("Editor.vue's template has no root element");
+  return root;
+}
+
+/** Path from the root down to the first element matching `match`, inclusive. */
+function pathTo(
+  root: ElementNode,
+  match: (node: ElementNode) => boolean,
+): ElementNode[] | null {
+  if (match(root)) return [root];
+  for (const child of root.children.filter(isElement)) {
+    const found = pathTo(child, match);
+    if (found) return [root, ...found];
+  }
+  return null;
+}
+
+const root = parseRoot();
+const pathToPopoverRoot = pathTo(root, (node) =>
+  hasClass(node, "tpl-popover-root"),
+);
+
+describe("popover root is outside every clip (#633)", () => {
+  it("Editor.vue's template has a .tpl-popover-root", () => {
+    expect(pathToPopoverRoot).not.toBeNull();
+    expect(pathToPopoverRoot!.at(-1)!.tag).toBe("div");
+  });
+
+  it("the editor root itself does not clip", () => {
+    expect(staticClasses(root)).toContain("tpl");
+    expect(clips(root)).toBe(false);
+  });
+
+  it("no ancestor of the popover root clips", () => {
+    const clipping = pathToPopoverRoot!
+      .filter(clips)
+      .map((node) => `<${node.tag} class="${staticClasses(node).join(" ")}">`);
+    expect(clipping).toEqual([]);
+  });
+
+  it("the chrome is still clipped by an inner wrapper", () => {
+    // Removing the clip outright would let the canvas and rails spill out of
+    // the consumer's container. The fix relocates it; it does not delete it.
+    // Asserted via the header specifically: the canvas already carries
+    // `overflow-auto` of its own, so a looser "some child clips" check would
+    // pass off `.tpl-body` even if the wrapper were missing entirely.
+    const pathToHeader = pathTo(root, (node) => node.tag === "EditorHeader");
+    expect(pathToHeader).not.toBeNull();
+    const wrappers = pathToHeader!
+      .slice(1) // strictly below the root — the root must not be the clipper
+      .filter(clips);
+    expect(wrappers.length).toBeGreaterThan(0);
+  });
+
+  it("the small-screen notice still paints over the dialogs (#235)", () => {
+    // The notice is `absolute inset-0` at z-index 10001 and relies on being a
+    // later sibling of the popover root. Moving it inside the clipped chrome
+    // wrapper would put the popover root after it in paint order, so dialogs
+    // would show through the gate.
+    const children = root.children.filter(isElement);
+    const popoverIndex = children.findIndex((node) =>
+      hasClass(node, "tpl-popover-root"),
+    );
+    const noticeIndex = children.findIndex(
+      (node) => node.tag === "SmallScreenNotice",
+    );
+    expect(popoverIndex).toBeGreaterThanOrEqual(0);
+    expect(noticeIndex).toBeGreaterThan(popoverIndex);
+  });
+});


### PR DESCRIPTION
Closes #633.