### PR TITLE
fix(import-html): keep a linked image as an image when importing HTML

### DIFF
--- a/.changeset/import-html-linked-images.md
+++ b/.changeset/import-html-linked-images.md
@@ -1,0 +1,47 @@
+---
+"@templatical/import-html": patch
+---
+
+Keep a linked image as an `image` block with its href.
+
+An `<a>` wrapping an `<img>` imported as a `paragraph` of raw markup, and the
+link target was dropped. A styled linked image — padding or a background on the
+anchor — imported as a button labelled `"Button"`, with the `src` and `alt`
+discarded entirely. That is the cell-as-button path matching `"" === ""` on an
+image-only anchor. Both now import as `image` with `linkUrl` from a non-empty
+href, reported `converted` with no `note`. `target="_blank"` sets
+`linkOpenInNewTab`; otherwise the key is omitted. An empty `href` omits
+`linkUrl`. An `<a>` that wraps both an image and text becomes that `image` plus
+a sibling `paragraph` that keeps the remaining `<a>`.
+
+Measured on the wide corpus, before and after:
+
+| | before | after |
+|---|---|---|
+| converted / approximated / html-fallback | 525 / 49 / 88 | 541 / 31 / 90 |
+| `image` blocks with `linkUrl` | 0 | 16 |
+| buttons labelled `"Button"` | 12 | 0 |
+| sections | 155 | 155 |
+| multi-column sections | 39 | 39 |
+| empty columns inside a multi-column section | 0 | 0 |
+| source words absent from the imported template | 0 | 0 |
+
+The files that moved: `konsav-general`, `konsav-promotional`,
+`swu-goldstar-invoice`, `swu-meow-digest-left`, `swu-meow-two-column`,
+`swu-oxygen-progress`. `swu-oxygen-progress` is twelve `<a href=""><img></a>`
+(empty href, so no `linkUrl`) that stop being approximated paragraphs wrapping
+a raw `<img>`. `swu-meow-digest-left` and `swu-meow-two-column` each pick up one
+extra `center` html-fallback: a `<center>` around a linked image is no longer
+swallowed into a `"Button"`, and `center` is not a mapped tag. The image
+survives as markup inside that fallback.
+
+The ground-truth oracle — block factories, `@templatical/renderer`, `mjml`, then
+import — still recovers columns `1, 2, 3, 2-1, 1-2` with per-slot occupancy
+`[[2], [2, 2], [1, 1, 1], [1, 1], [1, 1]]`.
+
+Merge and flatten report notes now say "columns" rather than "cells", because
+the count is layout cells or sibling column `<div>`s. The note strings changed
+on `ac-receipt-inlined`, `konsav-general`, `mc-gallery-1-4`,
+`mc-simple-leftsidebar`, `swu-goldstar-invoice`, `swu-meow-digest-left`, and
+`swu-oxygen-progress`; content and every other report field did not. Filter
+code that matches the old "cells" wording will miss those entries.

--- a/apps/docs/de/guide/migration-from-html.md
+++ b/apps/docs/de/guide/migration-from-html.md
@@ -69,7 +69,7 @@ HTML-Elemente werden auf ihre Templatical-Entsprechungen abgebildet:
 | `<img>` | `image` | Konvertiert |
 | `<a>` als Button gestaltet (Hintergrund, Padding, Border-Radius oder `display: inline-block`) | `button` | Konvertiert |
 | `<a>` (Text-Link) | geht im umgebenden `paragraph` auf | Konvertiert |
-| `<a>`, das ein Bild umschließt | `paragraph` | Approximiert (Link-Ziel entfällt) |
+| `<a>`, das ein `<img>` umschließt | `image` mit `linkUrl` | Konvertiert |
 | `<hr>` | `divider` | Konvertiert |
 | Leeres `<td>` mit explizit gesetzter Höhe | `spacer` | Konvertiert |
 | `<td>`, dessen gesamter Inhalt ein gestyltes `<a>` ist | `button` | Konvertiert (Cell-as-Button-Muster) |
@@ -79,7 +79,7 @@ HTML-Elemente werden auf ihre Templatical-Entsprechungen abgebildet:
 
 Alles, was sich nicht zuordnen lässt, wird wortgetreu in einem HTML-Block erhalten — sichtbarer Inhalt geht nicht verloren.
 
-Eine Zelle, die Text und einen Link mischt, wird ein einzelner `paragraph`, der beides enthält — das `<a>` samt `href` inline. Eine Zelle gilt als Button, wenn der Anchor ihr gesamter Inhalt ist.
+Eine Zelle, die Text und einen Link mischt, wird ein einzelner `paragraph`, der beides enthält — das `<a>` samt `href` inline. Eine Zelle gilt als Button, wenn ihr gesamter Inhalt ein gestyltes Text-`<a>` ist.
 
 Ein `<div>`, `<center>` oder `<main>`, das eine Tabelle umschließt, erzeugt keinen eigenen Block: Der Importer steigt hinein, unabhängig von der Verschachtelungstiefe, und ordnet die gefundenen Tabellen zu. Ein Wrapper, der nur Text enthält, behält seine `paragraph`-Zuordnung; ein Wrapper, dessen gesamter Inhalt eine Überschrift ist, wird entfernt, sodass die Überschrift selbst zugeordnet wird.
 
@@ -87,7 +87,7 @@ Ein `<div>`, `<center>` oder `<main>`, das eine Tabelle umschließt, erzeugt kei
 
 `<br>`, `<em>`, `<strong>`, `<i>`, `<b>`, `<u>`, `<small>`, `<sub>` und `<sup>` bleiben in dem Text, zu dem sie gehören. Eine Folge davon wird zusammen mit dem umgebenden reinen Text zu einem einzigen `paragraph`, dessen Farbe, Größe und Ausrichtung aus der umgebenden Zelle stammen — `Hello<br>World` in einem `<td>` wird also ein Paragraph mit beiden Wörtern und dem Umbruch.
 
-Ein Text-`<a>` geht in dieser Folge auf und behält sein `href`, sodass ein Satz mit einem Link als ein Paragraph ankommt und der Link nicht aus seinem Text herausgelöst wird. Ein `<a>`, dessen Inhalt kein Text ist — ein verlinktes Bild —, wird ein eigener `paragraph`.
+Ein Text-`<a>` geht in dieser Folge auf und behält sein `href`, sodass ein Satz mit einem Link als ein Paragraph ankommt und der Link nicht aus seinem Text herausgelöst wird. Ein `<a>`, das ein `<img>` umschließt, wird ein `image` mit `linkUrl` aus einem nicht-leeren href. Ein `<a>`, das Bild und Text umschließt, wird zu diesem `image` plus einem benachbarten `paragraph`, der das restliche `<a>` behält.
 
 ::: tip
 Reiner Text zählt hier als Inhalt. Ein Zellendurchlauf, der nur Element-Kinder besuchte, verlor die Wörter zwischen zwei Inline-Tags und ebenso einen freistehenden Satz neben einer Tabelle auf Body- oder Wrapper-Ebene. Beides bleibt jetzt erhalten.
@@ -167,7 +167,6 @@ Globale Template-Einstellungen werden aus dem Dokument gelesen:
 - **Externe Ressourcen** — `<link>`, externe Stylesheets, Web Fonts und Remote-Bilder werden nicht geladen. Bild-`src`-URLs bleiben unverändert.
 - **Outlook-MSO-Conditionals** — bleiben innerhalb des umgebenden Blocks als HTML erhalten (in Nicht-Outlook-Clients ohnehin inert).
 - **Formularelemente (`<form>`/`<input>`/`<button>`)** — bleiben als HTML-Fallback. Die meisten Mail-Clients blockieren Formular-Submits ohnehin; bauen Sie den CTA als Button mit Link auf eine gehostete Seite.
-- **Verlinkte Bilder** — ein `<a>`, das ein `<img>` umschließt, wird ein `paragraph` mit dem Bild; das Link-Ziel entfällt. Ergänzen Sie es im Editor als `linkUrl` eines `image`-Blocks. Genau diese Einträge werden als `approximated` mit `Inline anchor wrapped in a paragraph block.` gemeldet.
 - **Zeilen mit mehr als drei Zellen** — `ColumnLayout` fasst höchstens drei Spalten, eine breitere Zeile wird also auf eine zusammengefasst und gemeldet. Auch Verhältnisse außerhalb von `'2'` / `'2-1'` / `'1-2'` / `'3'` — etwa ein Sidebar-Paar im Verhältnis `1-2-1` — haben keine Entsprechung und werden als gleichmäßige Teilung importiert.
 - **AMP for Email** — wird in Templatical derzeit nicht unterstützt.
 

--- a/apps/docs/de/guide/migration-from-html.md
+++ b/apps/docs/de/guide/migration-from-html.md
@@ -72,7 +72,7 @@ HTML-Elemente werden auf ihre Templatical-Entsprechungen abgebildet:
 | `<a>`, das ein `<img>` umschließt | `image` mit `linkUrl` | Konvertiert |
 | `<hr>` | `divider` | Konvertiert |
 | Leeres `<td>` mit explizit gesetzter Höhe | `spacer` | Konvertiert |
-| `<td>`, dessen gesamter Inhalt ein gestyltes `<a>` ist | `button` | Konvertiert (Cell-as-Button-Muster) |
+| `<td>`, dessen gesamter Inhalt ein gestyltes Text-`<a>` ist | `button` | Konvertiert (Cell-as-Button-Muster) |
 | `<table>` (Layout, mehrere Zeilen/Spalten) | `section` (eine pro `<tr>`) | Konvertiert |
 | `<table>` (Datentabelle — nur Text in Zellen) | `html` | HTML-Fallback |
 | Unbekannte / Custom-Elemente | `html` | HTML-Fallback |

--- a/apps/docs/guide/migration-from-html.md
+++ b/apps/docs/guide/migration-from-html.md
@@ -69,7 +69,7 @@ HTML elements map to Templatical equivalents:
 | `<img>` | `image` | Converted |
 | `<a>` styled as button (background color, padding, border-radius, or `display: inline-block`) | `button` | Converted |
 | `<a>` (text link) | folded into the surrounding `paragraph` | Converted |
-| `<a>` wrapping an image | `paragraph` | Approximated (link target dropped) |
+| `<a>` wrapping an `<img>` | `image` with `linkUrl` | Converted |
 | `<hr>` | `divider` | Converted |
 | Empty `<td>` with explicit height | `spacer` | Converted |
 | `<td>` whose entire content is one styled `<a>` | `button` | Converted (cell-as-button pattern) |
@@ -79,7 +79,7 @@ HTML elements map to Templatical equivalents:
 
 Anything that can't be mapped is preserved verbatim inside an HTML block, so no visible content is lost.
 
-A cell mixing copy with a link becomes one `paragraph` holding both, with the `<a>` and its `href` inline. A cell reads as a button when the anchor is its entire content.
+A cell mixing copy with a link becomes one `paragraph` holding both, with the `<a>` and its `href` inline. A cell whose entire content is one styled text `<a>` reads as a button.
 
 A `<div>`, `<center>` or `<main>` that wraps a table produces no block of its own: the importer descends into it, at any nesting depth, and maps the tables it finds. A wrapper holding only text keeps its `paragraph` mapping, and a wrapper whose whole content is one heading is unwrapped so the heading is what gets mapped.
 
@@ -87,7 +87,7 @@ A `<div>`, `<center>` or `<main>` that wraps a table produces no block of its ow
 
 `<br>`, `<em>`, `<strong>`, `<i>`, `<b>`, `<u>`, `<small>`, `<sub>` and `<sup>` stay inside the text they belong to. A run of them, together with the bare text around it, becomes one `paragraph` whose colour, size and alignment come from the containing cell — so `Hello<br>World` in a `<td>` imports as a single paragraph holding both words and the line break.
 
-A text `<a>` folds into that run, keeping its `href`, so a sentence containing a link arrives as one paragraph rather than as a link torn out of its copy. An `<a>` whose content is not text — a linked image — becomes a `paragraph` of its own.
+A text `<a>` folds into that run, keeping its `href`, so a sentence containing a link arrives as one paragraph rather than as a link torn out of its copy. An `<a>` wrapping an `<img>` becomes an `image` with `linkUrl` from a non-empty href. An `<a>` wrapping both an image and text becomes that `image` plus a sibling `paragraph` that keeps the remaining `<a>`.
 
 ::: tip
 Bare text counts as content here. A cell walk that visited only element children dropped the words between two inline tags, and dropped a loose sentence sitting beside a table at body or wrapper level. Both are now kept.
@@ -167,7 +167,6 @@ Global template settings are extracted from the document:
 - **External resources** — `<link>`, external stylesheets, web fonts, and remote images are not fetched. Image `src` URLs are preserved as-is.
 - **Outlook MSO conditional comments** — preserved as HTML inside their containing block (they're inert in non-Outlook clients anyway).
 - **`<form>` / `<input>` / `<button>` form controls** — preserved as HTML-fallback. Most email clients block form submission; rebuild the call-to-action as a button linking to a hosted form.
-- **Linked images** — an `<a>` wrapping an `<img>` becomes a `paragraph` holding the image, and the link target is dropped. Re-add it as an `image` block's `linkUrl` in the editor. These are the entries reported as `approximated` with `Inline anchor wrapped in a paragraph block.`
 - **Rows of more than three cells** — `ColumnLayout` holds at most three columns, so a wider row is merged into one and reported. Ratios outside `'2'` / `'2-1'` / `'1-2'` / `'3'`, such as a `1-2-1` sidebar pair, have no equivalent either and import as the equal split.
 - **AMP for Email** — not currently supported in Templatical.
 

--- a/apps/docs/guide/migration-from-html.md
+++ b/apps/docs/guide/migration-from-html.md
@@ -72,7 +72,7 @@ HTML elements map to Templatical equivalents:
 | `<a>` wrapping an `<img>` | `image` with `linkUrl` | Converted |
 | `<hr>` | `divider` | Converted |
 | Empty `<td>` with explicit height | `spacer` | Converted |
-| `<td>` whose entire content is one styled `<a>` | `button` | Converted (cell-as-button pattern) |
+| `<td>` whose entire content is one styled text `<a>` | `button` | Converted (cell-as-button pattern) |
 | `<table>` (layout, multi-row/column) | `section` (one per `<tr>`) | Converted |
 | `<table>` (data table — text-only cells) | `html` | HTML fallback |
 | Unknown / custom elements | `html` | HTML fallback |

--- a/packages/import-html/src/__tests__/block-mapper.test.ts
+++ b/packages/import-html/src/__tests__/block-mapper.test.ts
@@ -372,6 +372,65 @@ describe("convertElement — anchors", () => {
     expect(r.entry.templaticalBlockType).toBe("paragraph");
     expect(r.entry.status).toBe("approximated");
   });
+
+  const LINKED_SRC = "https://cdn.test/autumn-hero.jpg";
+  const LINKED_ALT = "Autumn sale banner";
+  const LINKED_HREF = "https://shop.test/autumn";
+
+  it("maps an image-only anchor to an image with linkUrl", () => {
+    const { $, $el } = firstEl(
+      `<a href="${LINKED_HREF}"><img src="${LINKED_SRC}" alt="${LINKED_ALT}"></a>`,
+      "a",
+    );
+    const r = convertElement($el, $)!;
+    expect(r.entry.sourceTag).toBe("a");
+    expect(r.entry.templaticalBlockType).toBe("image");
+    expect(r.entry.status).toBe("converted");
+    expect("note" in r.entry).toBe(false);
+    if (r.block.type !== "image") throw new Error("expected image block");
+    expect(r.block.src).toBe(LINKED_SRC);
+    expect(r.block.alt).toBe(LINKED_ALT);
+    expect(r.block.linkUrl).toBe(LINKED_HREF);
+  });
+
+  it("maps a styled image-only anchor to an image, not a button", () => {
+    // A button built from an image-only anchor is labelled by the factory
+    // default and discards the image. The image case is decided first.
+    const { $, $el } = firstEl(
+      `<a style="background:#f00;padding:8px 16px" href="${LINKED_HREF}">` +
+        `<img src="${LINKED_SRC}" alt="${LINKED_ALT}"></a>`,
+      "a",
+    );
+    const r = convertElement($el, $)!;
+    expect(r.entry.templaticalBlockType).toBe("image");
+    expect(r.entry.status).toBe("converted");
+    if (r.block.type !== "image") throw new Error("expected image block");
+    expect(r.block.src).toBe(LINKED_SRC);
+    expect(r.block.alt).toBe(LINKED_ALT);
+    expect(r.block.linkUrl).toBe(LINKED_HREF);
+    expect(r.block.type).not.toBe("button");
+  });
+
+  it("sets linkOpenInNewTab when the wrapping anchor targets _blank", () => {
+    const { $, $el } = firstEl(
+      `<a href="${LINKED_HREF}" target="_blank">` +
+        `<img src="${LINKED_SRC}" alt="${LINKED_ALT}"></a>`,
+      "a",
+    );
+    const r = convertElement($el, $)!;
+    if (r.block.type !== "image") throw new Error("expected image block");
+    expect(r.block.linkOpenInNewTab).toBe(true);
+  });
+
+  it("omits linkOpenInNewTab when the wrapping anchor has no _blank target", () => {
+    const { $, $el } = firstEl(
+      `<a href="${LINKED_HREF}"><img src="${LINKED_SRC}" alt="${LINKED_ALT}"></a>`,
+      "a",
+    );
+    const r = convertElement($el, $)!;
+    if (r.block.type !== "image") throw new Error("expected image block");
+    expect("linkOpenInNewTab" in r.block).toBe(false);
+  });
 });
 
 describe("convertElement — divider", () => {
@@ -554,6 +613,20 @@ describe("isProseAnchor", () => {
     ).toBe(false);
   });
 
+  it("refuses a link that wraps an image plus text", () => {
+    // Folding would keep the image as raw markup inside a paragraph. The
+    // image is a first-class block with linkUrl; the text is a sibling.
+    expect(
+      isProseAnchor(
+        anchor(
+          '<a href="https://shop.test/autumn">' +
+            '<img src="https://cdn.test/autumn-hero.jpg" alt="Autumn sale banner">' +
+            "Shop now</a>",
+        ),
+      ),
+    ).toBe(false);
+  });
+
   it("refuses a link whose text is only whitespace", () => {
     expect(isProseAnchor(anchor('<a href="https://x.test/go">  </a>'))).toBe(
       false,
@@ -719,6 +792,53 @@ describe("isButtonCell", () => {
     const r = isButtonCell($el, $);
     expect(r.match).toBe(true);
     expect(r.anchor?.attr("href")).toBe("https://shop.test/buy");
+  });
+
+  it("does not match a cell whose entire content is a linked image", () => {
+    // `isWholeCellAnchor` compares normalised text; an `<a><img></a>` is
+    // `"" === ""` and would otherwise pass. A button labelled from that
+    // empty text is the factory default and the image is discarded.
+    const { $, $el } = firstEl(
+      "<table><tr><td>" +
+        '<a href="https://shop.test/autumn">' +
+        '<img src="https://cdn.test/autumn-hero.jpg" alt="Autumn sale banner">' +
+        "</a></td></tr></table>",
+      "td",
+    );
+    expect(isButtonCell($el, $).match).toBe(false);
+  });
+
+  it("does not match a cell whose entire content is a styled linked image", () => {
+    const { $, $el } = firstEl(
+      "<table><tr><td>" +
+        '<a style="background:#f00;padding:8px 16px" href="https://shop.test/autumn">' +
+        '<img src="https://cdn.test/autumn-hero.jpg" alt="Autumn sale banner">' +
+        "</a></td></tr></table>",
+      "td",
+    );
+    expect(isButtonCell($el, $).match).toBe(false);
+  });
+
+  it("does not match a styled cell wrapping a linked image", () => {
+    const { $, $el } = firstEl(
+      '<table><tr><td style="background:#f00;padding:8px 16px">' +
+        '<a href="https://shop.test/autumn">' +
+        '<img src="https://cdn.test/autumn-hero.jpg" alt="Autumn sale banner">' +
+        "</a></td></tr></table>",
+      "td",
+    );
+    expect(isButtonCell($el, $).match).toBe(false);
+  });
+
+  it("does not match a styled anchor wrapping an image plus text", () => {
+    const { $, $el } = firstEl(
+      "<table><tr><td>" +
+        '<a style="background:#f00;padding:8px 16px" href="https://shop.test/autumn">' +
+        '<img src="https://cdn.test/autumn-hero.jpg" alt="Autumn sale banner">' +
+        "Shop now</a></td></tr></table>",
+      "td",
+    );
+    expect(isButtonCell($el, $).match).toBe(false);
   });
 });
 

--- a/packages/import-html/src/__tests__/section-builder.test.ts
+++ b/packages/import-html/src/__tests__/section-builder.test.ts
@@ -1090,7 +1090,7 @@ describe("processTable — the section a row produces is in the report", () => {
       sourceTag: "tr",
       templaticalBlockType: "section",
       status: "approximated",
-      note: "Row of 4 cells was merged into a single column. Templatical sections hold at most 3 columns.",
+      note: "Row of 4 columns was merged into a single column. Templatical sections hold at most 3 columns.",
     });
 
     // The document-level warning is unchanged: a warning is context for the
@@ -1130,7 +1130,7 @@ describe("processTable — the section a row produces is in the report", () => {
       sourceTag: "tr",
       templaticalBlockType: null,
       status: "approximated",
-      note: "Nested row of 2 cells lost its columns. A Templatical section cannot nest inside a column, so its cells were merged into the surrounding column.",
+      note: "Nested row of 2 columns lost its columns. A Templatical section cannot nest inside a column, so its columns were merged into the surrounding column.",
     });
   });
 
@@ -1268,7 +1268,7 @@ describe("extractCellBlocks — a container in a cell is descended to its table"
     expect(flattened[0].sourceTag).toBe("tr");
     expect(flattened[0].status).toBe("approximated");
     expect(flattened[0].note).toBe(
-      "Nested row of 2 cells lost its columns. A Templatical section cannot nest inside a column, so its cells were merged into the surrounding column.",
+      "Nested row of 2 columns lost its columns. A Templatical section cannot nest inside a column, so its columns were merged into the surrounding column.",
     );
   });
 
@@ -2165,7 +2165,7 @@ describe("processTable — declared widths choose between same-count layouts", (
     const entry = sectionEntriesOf(entries)[0];
     expect(entry.status).toBe("approximated");
     expect(entry.note).toBe(
-      "Row of 4 cells was merged into a single column. Templatical sections hold at most 3 columns.",
+      "Row of 4 columns was merged into a single column. Templatical sections hold at most 3 columns.",
     );
     expect(warnings).toHaveLength(1);
   });

--- a/packages/import-html/src/__tests__/section-builder.test.ts
+++ b/packages/import-html/src/__tests__/section-builder.test.ts
@@ -530,6 +530,141 @@ describe("extractCellBlocks — a button cell is one whose whole content is the 
   });
 });
 
+describe("extractCellBlocks — a linked image is an image, not a button or a paragraph", () => {
+  const SRC = "https://cdn.test/autumn-hero.jpg";
+  const ALT = "Autumn sale banner";
+  const HREF = "https://shop.test/autumn";
+  const IMG = `<img src="${SRC}" alt="${ALT}">`;
+
+  function imageEntryOf(entries: ImportReportEntry[]) {
+    const entry = entries.find((e) => e.templaticalBlockType === "image");
+    if (!entry) throw new Error("expected an image report entry");
+    return entry;
+  }
+
+  it("maps a plain linked image in a cell to an image with linkUrl", () => {
+    const { blocks, entries } = runCell(`<a href="${HREF}">${IMG}</a>`);
+
+    expect(blocks.map((b) => b.type)).toEqual(["image"]);
+    const image = blocks[0];
+    if (image.type !== "image") throw new Error("expected image block");
+    expect(image.src).toBe(SRC);
+    expect(image.alt).toBe(ALT);
+    expect(image.linkUrl).toBe(HREF);
+    const entry = imageEntryOf(entries);
+    expect(entry.status).toBe("converted");
+    expect("note" in entry).toBe(false);
+  });
+
+  it("maps a styled linked image in a cell to an image, not a button", () => {
+    // The content-loss case: padding/background on the `<a>` is a button
+    // signal, and without this pin `isButtonCell` swallows the cell and
+    // labels a button from empty text.
+    const { blocks, entries } = runCell(
+      `<a style="background:#f00;padding:8px 16px" href="${HREF}">${IMG}</a>`,
+    );
+
+    expect(blocks.some((b) => b.type === "button")).toBe(false);
+    expect(blocks.map((b) => b.type)).toEqual(["image"]);
+    const image = blocks[0];
+    if (image.type !== "image") throw new Error("expected image block");
+    expect(image.src).toBe(SRC);
+    expect(image.alt).toBe(ALT);
+    expect(image.linkUrl).toBe(HREF);
+    const entry = imageEntryOf(entries);
+    expect(entry.status).toBe("converted");
+    expect("note" in entry).toBe(false);
+  });
+
+  it("sets linkOpenInNewTab only when the wrapping anchor targets _blank", () => {
+    const blank = runCell(`<a href="${HREF}" target="_blank">${IMG}</a>`);
+    const imageBlank = blank.blocks[0];
+    if (imageBlank.type !== "image") throw new Error("expected image block");
+    expect(imageBlank.linkOpenInNewTab).toBe(true);
+
+    const sameTab = runCell(`<a href="${HREF}">${IMG}</a>`);
+    const imageSame = sameTab.blocks[0];
+    if (imageSame.type !== "image") throw new Error("expected image block");
+    expect("linkOpenInNewTab" in imageSame).toBe(false);
+  });
+
+  it("still converts a styled text anchor to a button with its label and url", () => {
+    const { blocks } = runCell(
+      '<a style="background:#c41e3a;padding:8px 16px" ' +
+        'href="https://shop.test/buy-now">Grab the deal</a>',
+    );
+
+    expect(blocks.map((b) => b.type)).toEqual(["button"]);
+    const button = blocks[0];
+    if (button.type !== "button") throw new Error("expected button block");
+    expect(button.text).toBe("Grab the deal");
+    expect(button.url).toBe("https://shop.test/buy-now");
+  });
+
+  it("still converts a cell whose entire content is one styled text anchor to a button", () => {
+    const { blocks } = runCell(
+      '<a href="https://events.test/rsvp">Save my seat</a>',
+      'style="background:#c41e3a;padding:14px"',
+    );
+
+    expect(blocks.map((b) => b.type)).toEqual(["button"]);
+    const button = blocks[0];
+    if (button.type !== "button") throw new Error("expected button block");
+    expect(button.text).toBe("Save my seat");
+    expect(button.url).toBe("https://events.test/rsvp");
+  });
+
+  it("still converts a bare img to an image", () => {
+    const { blocks, entries } = runCell(
+      '<img src="https://cdn.test/ceramic-vase.jpg" alt="Ceramic vase">',
+    );
+
+    expect(blocks.map((b) => b.type)).toEqual(["image"]);
+    const image = blocks[0];
+    if (image.type !== "image") throw new Error("expected image block");
+    expect(image.src).toBe("https://cdn.test/ceramic-vase.jpg");
+    expect(image.alt).toBe("Ceramic vase");
+    expect("linkUrl" in image).toBe(false);
+    const entry = imageEntryOf(entries);
+    expect(entry.sourceTag).toBe("img");
+    expect(entry.status).toBe("converted");
+    expect("note" in entry).toBe(false);
+  });
+
+  it("still folds a plain text anchor into the surrounding run", () => {
+    const { blocks } = runCell(
+      'See the <a href="https://docs.test/guide">full guide</a> today',
+    );
+
+    expect(blocks).toHaveLength(1);
+    const sentence = blocks[0];
+    if (sentence.type !== "paragraph")
+      throw new Error("expected paragraph block");
+    expect(sentence.content).toBe(
+      '<p>See the <a href="https://docs.test/guide">full guide</a> today</p>',
+    );
+  });
+
+  it("splits an anchor wrapping an image plus text into an image and a sibling paragraph", () => {
+    const { blocks } = runCell(`<a href="${HREF}">${IMG}Shop now</a>`);
+
+    expect(blocks.some((b) => b.type === "button")).toBe(false);
+    expect(blocks.some((b) => b.type === "html")).toBe(false);
+    expect(blocks.map((b) => b.type)).toEqual(["image", "paragraph"]);
+    const image = blocks[0];
+    if (image.type !== "image") throw new Error("expected image block");
+    expect(image.src).toBe(SRC);
+    expect(image.alt).toBe(ALT);
+    expect(image.linkUrl).toBe(HREF);
+    const paragraph = blocks[1];
+    if (paragraph.type !== "paragraph")
+      throw new Error("expected paragraph block");
+    expect(paragraph.content).toContain("Shop now");
+    expect(paragraph.content).toContain("<a");
+    expect(paragraph.content).toContain(HREF);
+  });
+});
+
 describe("extractCellBlocks — a plain anchor folds, a styled one does not", () => {
   /**
    * One cell's blocks and entries, in a table an image row makes a layout
@@ -602,20 +737,20 @@ describe("extractCellBlocks — a plain anchor folds, a styled one does not", ()
   });
 
   it("leaves an anchor carrying no text as a block of its own", () => {
-    // The hazard behind the fold's text requirement: `convertInlineRun` reads
-    // a run with no text as empty and emits nothing, so an image-only link
-    // folded into one would disappear. It keeps its own block instead.
+    // `convertInlineRun` reads a run with no text as empty and emits
+    // nothing, so an image-only link folded into one would disappear. It is
+    // an image with the wrapping href, not a paragraph of raw markup.
     const { blocks } = runCell(
       '<a href="https://x.test/go">' +
         '<img src="https://x.test/promo.png" alt="Promo"></a>',
     );
 
     expect(blocks).toHaveLength(1);
-    const link = blocks[0];
-    if (link.type !== "paragraph") throw new Error("expected paragraph block");
-    expect(link.content).toBe(
-      '<p><img src="https://x.test/promo.png" alt="Promo"></p>',
-    );
+    const image = blocks[0];
+    if (image.type !== "image") throw new Error("expected image block");
+    expect(image.src).toBe("https://x.test/promo.png");
+    expect(image.alt).toBe("Promo");
+    expect(image.linkUrl).toBe("https://x.test/go");
   });
 
   it("still emits a spacer for an empty cell that states a height", () => {

--- a/packages/import-html/src/block-mapper.ts
+++ b/packages/import-html/src/block-mapper.ts
@@ -499,7 +499,10 @@ export function convertInlineRun(
 /**
  * <img> → Image block.
  */
-function convertImage($el: Cheerio<Element>): Block {
+function convertImage(
+  $el: Cheerio<Element>,
+  link?: { url: string; openInNewTab: boolean },
+): Block {
   const styles = getStyles($el);
   const src = $el.attr("src") ?? "";
   const alt = $el.attr("alt") ?? "";
@@ -516,6 +519,7 @@ function convertImage($el: Cheerio<Element>): Block {
     parsePxValue($el.attr("height")) ||
     parsePxValue(styles.height) ||
     undefined;
+  const href = (link?.url ?? "").trim();
 
   return createImageBlock({
     src,
@@ -531,7 +535,75 @@ function convertImage($el: Cheerio<Element>): Block {
     styles: {
       padding: readPaddingFromStyles(styles),
     },
+    ...(href ? { linkUrl: href } : {}),
+    ...(href && link?.openInNewTab ? { linkOpenInNewTab: true } : {}),
   });
+}
+
+/**
+ * Whether an `<a>` wraps an image. An anchor wrapping only an image carries
+ * no text, so a button built from it is labelled by the factory default and
+ * discards the image entirely. Asked before both button paths — `convertElement`
+ * and `isButtonCell` — and before a mixed image-plus-text anchor can fold
+ * into a prose run.
+ */
+export function isImageAnchor($el: Cheerio<Element>): boolean {
+  return $el.find("img").length > 0;
+}
+
+function isImageOnlyAnchor($el: Cheerio<Element>): boolean {
+  return isImageAnchor($el) && ($el.text() ?? "").trim() === "";
+}
+
+function convertLinkedImage(
+  $anchor: Cheerio<Element>,
+  $img: Cheerio<Element>,
+): { block: Block; entry: ImportReportEntry } {
+  return {
+    block: convertImage($img, {
+      url: $anchor.attr("href") ?? "",
+      openInNewTab: $anchor.attr("target") === "_blank",
+    }),
+    entry: {
+      sourceTag: "a",
+      templaticalBlockType: "image",
+      status: "converted",
+    },
+  };
+}
+
+/**
+ * An `<a>` that wraps both an image and text cannot become one block without
+ * dropping one of them: `convertElement` returns a single block. The walker
+ * emits the image with `linkUrl` and a sibling paragraph that keeps the
+ * remaining `<a>`, so neither is lost.
+ */
+function splitMixedImageAnchor(
+  $anchor: Cheerio<Element>,
+  $host: Cheerio<Element>,
+  $: CheerioAPI,
+): { block: Block; entry: ImportReportEntry }[] {
+  const results: { block: Block; entry: ImportReportEntry }[] = [];
+
+  for (const img of $anchor.find("img").toArray()) {
+    results.push(
+      convertLinkedImage($anchor, $(img) as unknown as Cheerio<Element>),
+    );
+  }
+
+  const $clone = $anchor.clone();
+  $clone.find("img").remove();
+  if (($clone.text() ?? "").trim() === "") return results;
+
+  results.push({
+    block: buildParagraph($.html($clone) ?? "", getStyles($host)),
+    entry: {
+      sourceTag: tagOf($host[0]),
+      templaticalBlockType: "paragraph",
+      status: "converted",
+    },
+  });
+  return results;
 }
 
 /**
@@ -567,7 +639,7 @@ export function looksLikeButton(styles: Record<string, string>): boolean {
  * per-element path drops (`convertParagraph` reads inner HTML, so the element
  * itself never reaches the block).
  *
- * Two constraints, both hazards a relaxed version would reintroduce:
+ * Three constraints, each a hazard a relaxed version would reintroduce:
  *
  * - `looksLikeButton` is the same predicate `convertElement` and
  *   `isButtonCell` use to tell a call to action from a link, so a styled
@@ -575,9 +647,13 @@ export function looksLikeButton(styles: Record<string, string>): boolean {
  * - The anchor must carry text. `convertInlineRun` reads a run with no text
  *   as empty and emits nothing, so an anchor whose content is an image has to
  *   keep the block it already gets; folding it would delete the image.
+ * - The anchor must not wrap an image. An image-plus-text `<a>` folded into
+ *   the run would keep the image as raw markup; it is a first-class image
+ *   with `linkUrl` and a sibling paragraph instead.
  */
 export function isProseAnchor($el: Cheerio<Element>): boolean {
   if (looksLikeButton(getStyles($el))) return false;
+  if (isImageAnchor($el)) return false;
   return ($el.text() ?? "").trim() !== "";
 }
 
@@ -645,6 +721,18 @@ export function walkContentNodes(
     // Asked before the run is flushed and before the caller sees the element,
     // which is what keeps a call to action out of a sentence — a styled anchor
     // is not a prose anchor, so it reaches `onElement` and becomes its button.
+    //
+    // An image-plus-text `<a>` is not one block: `convertElement` would drop
+    // either the image or the text. Split it here so every walk — cell, body,
+    // container — keeps both.
+    if (tag === "a" && isImageAnchor($child) && ($child.text() ?? "").trim()) {
+      flushInlineRun();
+      for (const converted of splitMixedImageAnchor($child, $host, $)) {
+        onRun(converted);
+      }
+      continue;
+    }
+
     if (tag === "a" && isProseAnchor($child)) {
       inlineRun.push(node);
       continue;
@@ -825,6 +913,10 @@ export function isButtonCell(
   const anchors = $el.find("a");
   if (anchors.length !== 1) return { match: false };
   const anchor = $(anchors[0]);
+  // An image-only `<a>` is `"" === ""` on the whole-cell text test, and a
+  // button labelled from that empty text is the factory default — the image
+  // is discarded. Mixed image-plus-text is the same loss of the image.
+  if (isImageAnchor(anchor)) return { match: false };
   if (!isWholeCellAnchor($el, anchor)) return { match: false };
 
   if (looksLikeButton(getStyles(anchor))) return { match: true, anchor };
@@ -887,6 +979,15 @@ export function convertElement(
   }
 
   if (tag === "a") {
+    // Image-only is decided before looksLikeButton: an image-only anchor
+    // carries no text, so a button built from it is labelled by the factory
+    // default and discards the image entirely.
+    if (isImageOnlyAnchor($target)) {
+      return convertLinkedImage(
+        $target,
+        $($target.find("img")[0]) as unknown as Cheerio<Element>,
+      );
+    }
     if (looksLikeButton(styles)) {
       return {
         block: convertButton($target),

--- a/packages/import-html/src/section-builder.ts
+++ b/packages/import-html/src/section-builder.ts
@@ -16,7 +16,6 @@ import {
   isInlineContent,
   isSpacerCell,
   isTableContainer,
-  looksLikeButton,
   walkContentNodes,
 } from "./block-mapper";
 import { readColumnWidth, resolveColumnRatio } from "./column-ratio";
@@ -326,32 +325,34 @@ function packagingRowTables(
  * The report entry for the section a layout row produces.
  *
  * Whether the row was downgraded is read off the slots that were actually
- * built: one slot per cell means every cell kept its own column, while fewer
- * slots than cells means `resolveColumnLayout` merged them. Deciding it by
- * comparing the cell count against the column ceiling instead would be a
- * second source of truth for that ceiling and would start lying the moment
- * the resolver changed. The ceiling appears only in the note's wording, where
- * it explains the merge to a reader rather than driving the branch.
+ * built: one slot per column means every column kept its own slot, while
+ * fewer slots than columns means `resolveColumnLayout` merged them. Deciding
+ * it by comparing the column count against the column ceiling instead would
+ * be a second source of truth for that ceiling and would start lying the
+ * moment the resolver changed. The ceiling appears only in the note's
+ * wording, where it explains the merge to a reader rather than driving the
+ * branch.
  *
  * A faithful row gets no `note` at all. Attaching one unconditionally makes
  * "nothing was lost" indistinguishable from a downgrade for a caller that
  * filters on `note`, which is the whole reason the field is optional.
  *
- * `cellCount` is the row's column-bearing cells, not every cell it has: a
+ * `columnCount` is the row's column hosts — layout cells, or the sibling
+ * column `<div>`s a single cell holds — not every cell the row has: a
  * centring row's gutters were never columns, so counting them would report a
  * three-into-one merge for a row that always stated one column.
  */
 function sectionEntry(
-  cellCount: number,
+  columnCount: number,
   slotCount: number,
   ratioNote: string | undefined,
 ): ImportReportEntry {
-  if (slotCount !== cellCount) {
+  if (slotCount !== columnCount) {
     return {
       sourceTag: "tr",
       templaticalBlockType: "section",
       status: "approximated",
-      note: `Row of ${cellCount} cells was merged into a single column. Templatical sections hold at most 3 columns.`,
+      note: `Row of ${columnCount} columns was merged into a single column. Templatical sections hold at most 3 columns.`,
     };
   }
   if (ratioNote) {
@@ -379,17 +380,17 @@ function sectionEntry(
  * and reporting that as a downgrade would fill the report with entries for a
  * non-event.
  *
- * The count is the row's column-bearing cells, for the same reason
- * `sectionEntry`'s is: a centring row flattened into a parent column lost
- * nothing, so it must report nothing.
+ * The count is the row's column hosts, for the same reason `sectionEntry`'s
+ * is: a centring row flattened into a parent column lost nothing, so it must
+ * report nothing.
  */
-function flattenedRowEntry(cellCount: number): ImportReportEntry | null {
-  if (cellCount <= 1) return null;
+function flattenedRowEntry(columnCount: number): ImportReportEntry | null {
+  if (columnCount <= 1) return null;
   return {
     sourceTag: "tr",
     templaticalBlockType: null,
     status: "approximated",
-    note: `Nested row of ${cellCount} cells lost its columns. A Templatical section cannot nest inside a column, so its cells were merged into the surrounding column.`,
+    note: `Nested row of ${columnCount} columns lost its columns. A Templatical section cannot nest inside a column, so its columns were merged into the surrounding column.`,
   };
 }
 
@@ -540,15 +541,6 @@ function extractContentBlocks(
       // only when it holds a table, and each step moves to a child.
       if (isTableContainer($child, tag)) {
         blocks.push(...extractContentBlocks($child, $, entries, warnings));
-        return;
-      }
-
-      if (tag === "a" && looksLikeButton(getStyles($child))) {
-        const r = convertElement($child, $);
-        if (r) {
-          entries.push(r.entry);
-          blocks.push(r.block);
-        }
         return;
       }
 


### PR DESCRIPTION
## Summary

HTML import treated a linked image as a paragraph of raw markup and dropped the href. A styled linked image — padding or a background on the `<a>` — became a button labelled `"Button"`, with the `src` and `alt` discarded. `ImageBlock` already has `linkUrl`; the renderer already honours it.

Both shapes now import as `image` with `linkUrl` from a non-empty href (`converted`, no `note`). `target="_blank"` sets `linkOpenInNewTab`; otherwise the key is omitted. An `<a>` wrapping an image and text becomes that `image` plus a sibling `paragraph` that keeps the remaining `<a>`.

Also: drop a dead `looksLikeButton` arm in `extractContentBlocks`, and retarget merge/flatten report notes from "cells" to "columns" (the count is layout cells or sibling column `<div>`s). Filter code that matches the old "cells" wording will miss those entries.

Measured on the wide corpus: 16 `image` blocks with `linkUrl` (was 0); 12 `"Button"` defaults gone; phantoms 0; multi-column 39; word preservation exact; oracle still recovers `1, 2, 3, 2-1, 1-2`. Two extra `center` html-fallbacks on the sendwithus meow files — the image survives as markup inside the fallback.

Patch changeset on `@templatical/import-html`. Migration guide updated in both locales.

## Linked issues

n/a

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [x] Documentation
- [x] Tests / tooling / CI
- [ ] Dependency update

## Affected packages

- [ ] `@templatical/editor`
- [ ] `@templatical/core` (or `@templatical/core/cloud`)
- [ ] `@templatical/media-library`
- [ ] `@templatical/types`
- [ ] `@templatical/renderer`
- [ ] `@templatical/import-beefree`
- [x] `@templatical/import-html`
- [ ] `apps/playground`
- [x] `apps/docs`
- [ ] Tooling / CI / repo config

## Checklist

- [x] Tests added or updated (and they fail without my change)
- [x] `pnpm run ci` passes locally (lint + typecheck + build + test)
- [ ] `pnpm run test:e2e` passes (only if this PR touches editor UI)
- [x] Docs updated — both `apps/docs/<page>.md` and `apps/docs/de/<page>.md` if user-facing
- [ ] i18n keys added to both `en.ts` and `de.ts` if I added new strings
- [x] Changeset added (`pnpm exec changeset`) — required for any change to a published package
- [x] PR title is descriptive and follows the existing convention

## Notes for reviewers

The image case is decided before both button paths (`convertElement`'s `looksLikeButton` arm and `isButtonCell`). `isWholeCellAnchor` is `"" === ""` for an `<a><img></a>`, which is why the styled row was total content loss.

`convertElement` still returns a single block. Mixed image-plus-text is split in `walkContentNodes`.

Out of scope: `<strong><img></strong>` (media-only run); MJML real-world corpus (separate follow-up).
