### PR TITLE
fix (import-mjml): keep MJML prose around inline links as a paragraph

### DIFF
--- a/.changeset/import-mjml-menu-prose.md
+++ b/.changeset/import-mjml-menu-prose.md
@@ -1,0 +1,18 @@
+---
+"@templatical/import-mjml": patch
+---
+
+Keep prose around inline links as a paragraph.
+
+An `mj-text` of copy plus a trailing `<a>` imported as a `menu` labelled from
+the links, and the surrounding words were discarded. `looksLikeMenu` walked
+element children only, so text-node siblings never vetoed. It now refuses when
+a non-whitespace text node sits next to the anchors, and the block imports as
+a `paragraph` that keeps both the prose and the `<a>`. Whitespace-only text
+nodes (newlines between `<a>`/`<span>`) still do not veto, so a span-separated
+menu stays a menu. Anchors separated by a text-node `|` become a paragraph —
+same veto, not a second rule.
+
+The dropped footer and body words now survive: `receive`, `message`,
+`unsubscribe`, `smilesdavis`, and the Dropbox copy (`important`, `available`,
+`exclusively`, `accidentally`, `targeted`, `ransomware`).

--- a/apps/docs/de/guide/migration-from-mjml.md
+++ b/apps/docs/de/guide/migration-from-mjml.md
@@ -117,7 +117,7 @@ Ein Diff zwischen Original und dem von Templatical erzeugten MJML zeigt struktur
 | `mj-section` (mit `mj-column`s) | `SectionBlock` mit `columns` | Mehrspaltige Layouts funktionieren gleich; Spaltenbreiten kommen aus MJMLs `width`-Attribut oder werden gleichmäßig verteilt. |
 | `mj-column` | Section-Spalte | Eine Spalte hält eine Liste verschachtelter Blöcke. |
 | `mj-group` | `SectionBlock.stackOnMobile: false` | Kein eigener Block — markiert, dass die Spalten der Section auf Mobilgeräten nebeneinander bleiben, statt zu stapeln. |
-| `mj-text` | `TitleBlock` / `TableBlock` / `MenuBlock` / `ParagraphBlock` | Strukturell aufgelöst: Eine einzelne Überschrift als Wurzelelement wird zu `TitleBlock`, eine einzelne `<table>` zu `TableBlock`, ausschließlich Top-Level-Links ohne Paragraph-Wrapper zu `MenuBlock`, alles andere zu `ParagraphBlock`. |
+| `mj-text` | `TitleBlock` / `TableBlock` / `MenuBlock` / `ParagraphBlock` | Strukturell aufgelöst: Eine einzelne Überschrift als Wurzelelement wird zu `TitleBlock`, eine einzelne `<table>` zu `TableBlock`, durch `<span>` getrennte Top-Level-Anker ohne Paragraph-Wrapper und ohne Nicht-Whitespace-Textknoten als Geschwister zu `MenuBlock`, ein Satz Fließtext plus ein abschließendes `<a>` zu `ParagraphBlock`, alles andere zu `ParagraphBlock`. |
 | `mj-image` | `ImageBlock` | `src`, `alt`, `href`, `width`, Padding. |
 | `mj-button` | `ButtonBlock` | `href`, `background-color`, `color`, Schrift, Padding. |
 | `mj-divider` | `DividerBlock` | `border-color`, `border-width`, Padding. |

--- a/apps/docs/guide/migration-from-mjml.md
+++ b/apps/docs/guide/migration-from-mjml.md
@@ -117,7 +117,7 @@ Run a diff between the original and Templatical-generated MJML to spot structura
 | `mj-section` (containing `mj-column`s) | `SectionBlock` with `columns` | Multi-column layouts work the same way; column widths come from MJML's `width` attribute or are equally distributed. |
 | `mj-column` | Section column | A column holds a list of nested blocks. |
 | `mj-group` | `SectionBlock.stackOnMobile: false` | Not a block at all — marks the section's columns to stay side by side on mobile instead of stacking. |
-| `mj-text` | `TitleBlock` / `TableBlock` / `MenuBlock` / `ParagraphBlock` | Resolved structurally: a single heading root becomes `TitleBlock`, a single `<table>` becomes `TableBlock`, top-level links with no paragraph wrapper become `MenuBlock`, anything else becomes `ParagraphBlock`. |
+| `mj-text` | `TitleBlock` / `TableBlock` / `MenuBlock` / `ParagraphBlock` | Resolved structurally: a single heading root becomes `TitleBlock`, a single `<table>` becomes `TableBlock`, span-separated top-level anchors with no paragraph wrapper and no non-whitespace text-node siblings become `MenuBlock`, a sentence of copy plus a trailing `<a>` becomes `ParagraphBlock`, anything else becomes `ParagraphBlock`. |
 | `mj-image` | `ImageBlock` | `src`, `alt`, `href`, `width`, padding. |
 | `mj-button` | `ButtonBlock` | `href`, `background-color`, `color`, font, padding. |
 | `mj-divider` | `DividerBlock` | `border-color`, `border-width`, padding. |

--- a/packages/import-mjml/src/__tests__/text-inference.test.ts
+++ b/packages/import-mjml/src/__tests__/text-inference.test.ts
@@ -168,6 +168,57 @@ describe("menu inference", () => {
     expect(result.block!.type).toBe("paragraph");
   });
 
+  it("still reads anchors separated by newlines and a span as a menu", () => {
+    const { result } = convert(
+      '<a href="/a">Alpha</a>\n<span style="color: #cccccc; padding: 0 12px;">|</span>\n<a href="/b">Beta</a>',
+    );
+    const block = result.block as MenuBlock;
+
+    expect(block.type).toBe("menu");
+    expect(block.items.map((i) => [i.text, i.url])).toEqual([
+      ["Alpha", "/a"],
+      ["Beta", "/b"],
+    ]);
+    expect(block.separator).toBe("|");
+    expect(result.entry.templaticalBlockType).toBe("menu");
+  });
+
+  it("does not read prose plus a trailing anchor as a menu", () => {
+    // An mj-text of copy plus a trailing <a> is a paragraph. Classifying it
+    // as a menu keeps only the link labels and discards the prose.
+    const { result } = convert(
+      'No longer want to receive these emails? You can <a href="https://example.com/unsub">unsubscribe here</a>.',
+    );
+    const block = result.block as ParagraphBlock;
+
+    expect(block.type).toBe("paragraph");
+    expect(block.content).toBe(
+      '<p>No longer want to receive these emails? You can <a href="https://example.com/unsub">unsubscribe here</a>.</p>',
+    );
+    expect(result.entry).toEqual({
+      sourceTag: "mj-text",
+      templaticalBlockType: "paragraph",
+      status: "converted",
+    });
+  });
+
+  it("does not read anchors separated by a text-node pipe as a menu", () => {
+    const { result } = convert(
+      "<a>View in browser</a> &nbsp;|&nbsp; <a>Unsubscribe</a>",
+    );
+    const block = result.block as ParagraphBlock;
+
+    expect(block.type).toBe("paragraph");
+    expect(block.content).toBe(
+      "<p><a>View in browser</a> &#xa0;|&#xa0; <a>Unsubscribe</a></p>",
+    );
+    expect(result.entry).toEqual({
+      sourceTag: "mj-text",
+      templaticalBlockType: "paragraph",
+      status: "converted",
+    });
+  });
+
   it("marks an anchor with target=_blank as opening in a new tab", () => {
     const { result } = convert('<a href="/a" target="_blank">Alpha</a>');
     expect((result.block as MenuBlock).items[0].openInNewTab).toBe(true);

--- a/packages/import-mjml/src/text-inference.ts
+++ b/packages/import-mjml/src/text-inference.ts
@@ -1,5 +1,6 @@
 import { load } from "cheerio";
 import type { Cheerio } from "cheerio";
+import { isTag, isText } from "domhandler";
 import type { Element } from "domhandler";
 import {
   createMenuBlock,
@@ -162,15 +163,25 @@ function convertTable(
  * A menu is top-level anchors with optional `<span>` separators between them —
  * exactly what `renderers/menu.ts` emits, and deliberately not matched when a
  * `<p>` wrapper is present (that is a paragraph containing links).
+ *
+ * `.children()` is elements only. A non-whitespace text-node sibling must
+ * veto: an `mj-text` of prose plus a trailing `<a>` becomes a menu labelled
+ * from the links and the prose is discarded. Whitespace-only nodes (newlines
+ * between `<a>`/`<span>`) must not.
  */
 function looksLikeMenu(html: string): boolean {
   const $inner = parseInner(html);
-  const kids = $inner("body").children().toArray();
+  const kids = $inner("body").contents().toArray();
   if (kids.length === 0) return false;
 
   let anchors = 0;
   for (const kid of kids) {
-    const tag = kid.tagName?.toLowerCase() ?? "";
+    if (isText(kid)) {
+      if (kid.data.trim() !== "") return false;
+      continue;
+    }
+    if (!isTag(kid)) continue;
+    const tag = kid.tagName.toLowerCase();
     if (tag === "a") anchors += 1;
     else if (tag !== "span") return false;
   }


### PR DESCRIPTION
## Summary

`mj-text` of copy plus a trailing `<a>` imported as a `menu` labelled from the links. The surrounding words were discarded. `looksLikeMenu` walked element children only, so text-node siblings never vetoed.

It now refuses when a non-whitespace text node sits next to the anchors. The block imports as a `paragraph` that keeps both the prose and the `<a>`. Whitespace-only text nodes (newlines between `<a>`/`<span>`) still do not veto, so a span-separated menu stays a menu. Anchors separated by a text-node `|` become a paragraph — same veto, not a second rule.

Measured on the 18-file MJML corpus: the ten files that dropped footer/body words (`receive`, `message`, `unsubscribe`, Dropbox copy) now keep them. Column-count and ratio recovery are unchanged.

Patch changeset on `@templatical/import-mjml`. Migration guide updated in both locales.

## Linked issues

n/a

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [x] Documentation
- [x] Tests / tooling / CI
- [ ] Dependency update

## Affected packages

- [ ] `@templatical/editor`
- [ ] `@templatical/core` (or `@templatical/core/cloud`)
- [ ] `@templatical/media-library`
- [ ] `@templatical/types`
- [ ] `@templatical/renderer`
- [ ] `@templatical/import-beefree`
- [x] `@templatical/import-mjml`
- [ ] `apps/playground`
- [x] `apps/docs`
- [ ] Tooling / CI / repo config

## Checklist

- [x] Tests added or updated (and they fail without my change)
- [x] Package tests, format:check, and docs build pass locally (`@templatical/import-mjml` + both migration-guide locales)
- [ ] `pnpm run test:e2e` passes (only if this PR touches editor UI)
- [x] Docs updated — both `apps/docs/<page>.md` and `apps/docs/de/<page>.md` if user-facing
- [ ] i18n keys added to both `en.ts` and `de.ts` if I added new strings
- [x] Changeset added (`pnpm exec changeset`) — required for any change to a published package
- [x] PR title is descriptive and follows the existing convention

## Notes for reviewers

The pin is the text-node veto in `looksLikeMenu` (`packages/import-mjml/src/text-inference.ts`). Existing keeps: span-separated Alpha/Beta menu; `<p><a>` paragraph.

Out of scope: 4+ column layouts, `mj-hero`, nested `mj-section`, social `alt` / `-round-outlined` platform names.
