### PR TITLE
fix (import-mjml): recognise MJML social platforms from pack filenames and alt

### DIFF
--- a/.changeset/import-mjml-social-platforms.md
+++ b/.changeset/import-mjml-social-platforms.md
@@ -1,0 +1,13 @@
+---
+"@templatical/import-mjml": patch
+---
+
+Recognise social platforms from icon-pack filenames and `alt`.
+
+An `mj-social-element` whose `src` was `facebook-round-outlined.png` (or
+`youtube-round-outlined.png`) imported as platform `"website"`, because
+`normalizePlatform` only accepted a bare slug or a `-noshare` variant. Pack
+suffixes (`-round`, `-outlined`, and the same tokens MJML uses for `-noshare`)
+are now stripped until a known platform remains. When `name` and `src` still
+do not match, `alt` is tried. `SocialIcon` is still `{ platform, url }` — `alt`
+is a name signal, not a stored field.

--- a/apps/docs/de/guide/migration-from-mjml.md
+++ b/apps/docs/de/guide/migration-from-mjml.md
@@ -122,7 +122,7 @@ Ein Diff zwischen Original und dem von Templatical erzeugten MJML zeigt struktur
 | `mj-button` | `ButtonBlock` | `href`, `background-color`, `color`, Schrift, Padding. |
 | `mj-divider` | `DividerBlock` | `border-color`, `border-width`, Padding. |
 | `mj-spacer` | `SpacerBlock` | `height`. |
-| `mj-social` (mit `mj-social-element`) | `SocialIconsBlock` | Jedes `mj-social-element` → ein `SocialIcon`-Eintrag. |
+| `mj-social` (mit `mj-social-element`) | `SocialIconsBlock` | Jedes `mj-social-element` → ein `SocialIcon`-Eintrag. Die Plattform kommt aus `name`, dem `src`-Dateinamen (Pack-Suffixe wie `-round-outlined` werden abgetrennt) oder `alt`. |
 | `mj-navbar` (mit `mj-navbar-link`) | `MenuBlock` | Jeder Link → `MenuItemData`. |
 | `mj-table` | `TableBlock` | Bildet `<tr>`/`<td>`/`<th>`-Zeilen und -Zellen auf Templaticals Tabellen-Daten ab; eine führende `<th>`-Zeile setzt `hasHeaderRow`. |
 | `mj-raw` | `HtmlBlock` | Inneres Markup bleibt wortgetreu erhalten. |

--- a/apps/docs/guide/migration-from-mjml.md
+++ b/apps/docs/guide/migration-from-mjml.md
@@ -122,7 +122,7 @@ Run a diff between the original and Templatical-generated MJML to spot structura
 | `mj-button` | `ButtonBlock` | `href`, `background-color`, `color`, font, padding. |
 | `mj-divider` | `DividerBlock` | `border-color`, `border-width`, padding. |
 | `mj-spacer` | `SpacerBlock` | `height`. |
-| `mj-social` (with `mj-social-element`) | `SocialIconsBlock` | Each `mj-social-element` → a `SocialIcon` entry. |
+| `mj-social` (with `mj-social-element`) | `SocialIconsBlock` | Each `mj-social-element` → a `SocialIcon` entry. Platform comes from `name`, the `src` filename (pack suffixes such as `-round-outlined` stripped), or `alt`. |
 | `mj-navbar` (with `mj-navbar-link`) | `MenuBlock` | Each link → `MenuItemData`. |
 | `mj-table` | `TableBlock` | Maps `<tr>`/`<td>`/`<th>` rows and cells to Templatical's table data; a leading `<th>` row sets `hasHeaderRow`. |
 | `mj-raw` | `HtmlBlock` | Inner markup preserved verbatim. |

--- a/packages/import-mjml/src/__tests__/composite-mapper.test.ts
+++ b/packages/import-mjml/src/__tests__/composite-mapper.test.ts
@@ -107,6 +107,41 @@ describe("mj-social", () => {
     ).toEqual(["twitter", "facebook"]);
   });
 
+  it("strips pack suffixes from a src filename (facebook-round-outlined.png)", () => {
+    // Icon packs append style tokens to the platform slug. The stem is not
+    // a SocialPlatform until those tokens are stripped, so the icon used to
+    // fall through to "website" and the platform name vanished.
+    const { result } = convert(
+      `<mj-social>
+         <mj-social-element src="https://cdn.test/icons/facebook-round-outlined.png" href="https://fb.test/autumn" />
+         <mj-social-element src="https://cdn.test/icons/youtube-round-outlined.png" href="https://yt.test/autumn" />
+       </mj-social>`,
+      "mj-social",
+    );
+    const block = result.block as SocialIconsBlock;
+
+    expect(block.icons.map((i) => [i.platform, i.url])).toEqual([
+      ["facebook", "https://fb.test/autumn"],
+      ["youtube", "https://yt.test/autumn"],
+    ]);
+    expect(result.entry.status).toBe("converted");
+    expect("note" in result.entry).toBe(false);
+  });
+
+  it("reads alt as a platform name when src is not a known slug", () => {
+    const { result } = convert(
+      `<mj-social>
+         <mj-social-element src="https://cdn.test/pack/icon-17.png" alt="Instagram" href="https://ig.test/autumn" />
+       </mj-social>`,
+      "mj-social",
+    );
+    const block = result.block as SocialIconsBlock;
+
+    expect(block.icons[0].platform).toBe("instagram");
+    expect(block.icons[0].url).toBe("https://ig.test/autumn");
+    expect(result.entry.status).toBe("converted");
+  });
+
   it("falls back to website for an unknown platform and reports it", () => {
     const { result } = convert(
       '<mj-social><mj-social-element name="mastodon" href="https://m.test/a" /></mj-social>',

--- a/packages/import-mjml/src/composite-mapper.ts
+++ b/packages/import-mjml/src/composite-mapper.ts
@@ -59,15 +59,44 @@ const PLATFORM_ALIASES: Record<string, SocialPlatform> = {
   "x-twitter": "twitter",
 };
 
-function normalizePlatform(raw: string): SocialPlatform | null {
-  // MJML ships `<platform>-noshare` variants that render the same icon.
-  const cleaned = raw
-    .trim()
-    .toLowerCase()
-    .replace(/-noshare$/, "");
-  if (!cleaned) return null;
+/**
+ * Icon packs (and MJML's `-noshare` variants) append tokens to the platform
+ * slug: `facebook-round-outlined.png`, `facebook-noshare`. Those stems are not
+ * `SocialPlatform` values, so a lookup that stops at the raw filename maps
+ * the icon to `"website"` and the platform name is lost.
+ */
+const PLATFORM_PACK_TOKENS = new Set([
+  "noshare",
+  "round",
+  "outlined",
+  "square",
+  "circle",
+  "solid",
+]);
+
+function lookupPlatform(cleaned: string): SocialPlatform | null {
   if (PLATFORM_ALIASES[cleaned]) return PLATFORM_ALIASES[cleaned];
   return cleaned in KNOWN_PLATFORMS ? (cleaned as SocialPlatform) : null;
+}
+
+function normalizePlatform(raw: string): SocialPlatform | null {
+  const cleaned = raw.trim().toLowerCase();
+  if (!cleaned) return null;
+
+  const direct = lookupPlatform(cleaned);
+  if (direct) return direct;
+
+  const parts = cleaned.split("-");
+  while (
+    parts.length > 1 &&
+    PLATFORM_PACK_TOKENS.has(parts[parts.length - 1])
+  ) {
+    parts.pop();
+    const candidate = parts.join("-");
+    const hit = lookupPlatform(candidate);
+    if (hit) return hit;
+  }
+  return null;
 }
 
 /** The `<style>/<platform>.png` tail of the URL `renderers/social.ts:76` builds. */
@@ -136,12 +165,19 @@ export function convertSocial(
     const src = (childAttrs.src ?? "").trim();
     const fromSrc = src ? platformFromSrc(src) : { platform: "", style: "" };
 
-    const rawName = (childAttrs.name ?? "").trim() || fromSrc.platform;
-    const platform = normalizePlatform(rawName);
-    if (!platform && rawName) {
-      notes.push(
-        `Unrecognised social platform "${rawName}" mapped to "website".`,
-      );
+    const name = (childAttrs.name ?? "").trim();
+    const alt = (childAttrs.alt ?? "").trim();
+    const platform =
+      normalizePlatform(name) ??
+      normalizePlatform(fromSrc.platform) ??
+      normalizePlatform(alt);
+    if (!platform) {
+      const rawName = name || fromSrc.platform || alt;
+      if (rawName) {
+        notes.push(
+          `Unrecognised social platform "${rawName}" mapped to "website".`,
+        );
+      }
     }
 
     icons.push({


### PR DESCRIPTION
## Summary

An `mj-social-element` whose `src` was `facebook-round-outlined.png` (or `youtube-round-outlined.png`) imported as platform `"website"`. `normalizePlatform` only accepted a bare slug or a `-noshare` variant, so icon-pack filenames never matched a `SocialPlatform`.

Pack suffixes (`-round`, `-outlined`, `-noshare`, and the other style tokens) are now stripped until a known platform remains. When `name` and `src` still do not match, `alt` is tried. `SocialIcon` is still `{ platform, url }` — `alt` is a name signal, not a stored field.

Unknown platforms (e.g. `mastodon`) still map to `"website"` with an approximated note.

Patch changeset on `@templatical/import-mjml`. Migration guide updated in both locales.

## Linked issues

n/a

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [x] Documentation
- [x] Tests / tooling / CI
- [ ] Dependency update

## Affected packages

- [ ] `@templatical/editor`
- [ ] `@templatical/core` (or `@templatical/core/cloud`)
- [ ] `@templatical/media-library`
- [ ] `@templatical/types`
- [ ] `@templatical/renderer`
- [ ] `@templatical/import-beefree`
- [x] `@templatical/import-mjml`
- [ ] `apps/playground`
- [x] `apps/docs`
- [ ] Tooling / CI / repo config

## Checklist

- [x] Tests added or updated (and they fail without my change)
- [x] Package tests pass locally (`@templatical/import-mjml`)
- [ ] `pnpm run test:e2e` passes (only if this PR touches editor UI)
- [x] Docs updated — both `apps/docs/<page>.md` and `apps/docs/de/<page>.md` if user-facing
- [ ] i18n keys added to both `en.ts` and `de.ts` if I added new strings
- [x] Changeset added (`pnpm exec changeset`) — required for any change to a published package
- [x] PR title is descriptive and follows the existing convention

## Notes for reviewers

The pin is `normalizePlatform` in `packages/import-mjml/src/composite-mapper.ts`. Existing keeps: `name="facebook"`, Templatical `src="…/circle/instagram.png"`, `facebook-noshare`, unknown `mastodon` → `"website"`.
